### PR TITLE
Removed unnecessary type info from fancy configuratino filter typings

### DIFF
--- a/src/input/findOriginalConfigurations.ts
+++ b/src/input/findOriginalConfigurations.ts
@@ -69,7 +69,7 @@ export const findOriginalConfigurations = async (
 };
 
 const configurationResultIsError = (
-    result: readonly [{} | Error | undefined, string | undefined],
+    result: readonly [unknown, unknown],
 ): result is [Error, string] => {
     return result[0] instanceof Error && typeof result[1] === "string";
 };


### PR DESCRIPTION
This fun thread! https://twitter.com/karoljmajewski/status/1155625124185419776

Realized a little while later that the fancy typings are unnecessary; the function really only needs `unknown` as the type