### PR TITLE
Correct GitHub repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "name": "tslint-to-eslint-config",
     "repository": {
         "type": "git",
-        "url": "github:typescript-eslint/tslint-to-eslint"
+        "url": "github:typescript-eslint/tslint-to-eslint-config"
     },
     "scripts": {
         "eslint": "eslint \"./src/*.ts\" \"./src/**/*.ts\" --report-unused-disable-directives",


### PR DESCRIPTION
## Overview

npm uses this for the repo link, and following it led to a 404.
