### PR TITLE
Corrected convert names: member-ordering, no-eval

### DIFF
--- a/src/rules/converters/member-ordering.ts
+++ b/src/rules/converters/member-ordering.ts
@@ -4,7 +4,7 @@ export const convertMemberOrdering: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "some-rule",
+                ruleName: "member-ordering",
             },
         ],
     };

--- a/src/rules/converters/no-eval.ts
+++ b/src/rules/converters/no-eval.ts
@@ -4,7 +4,7 @@ export const convertNoEval: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "some-rule",
+                ruleName: "no-eval",
             },
         ],
     };


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: starts on #150
-   ~[ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)~

## Overview
They were saying 'some-name' as the rule name before. Not ideal.
