### PR TITLE
Disabled end-to-end tests in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,9 +144,6 @@ workflows:
             - prettier:
                   requires:
                       - build
-            - test-end-to-end:
-                  requires:
-                      - build
             - test-unit:
                   requires:
                       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,7 @@ jobs:
             - attach_workspace:
                   at: "."
 
-            - run: ls test/tests -l
-            - run: ls 'test/tests/custom eslint path' -l
+            - run: npm i -g ts-node
             - run: npm run test:end-to-end
 
     test-unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
             - attach_workspace:
                   at: "."
 
-            - run: ls test -l
+            - run: ls test/tests -l
             - run: ls test/tests -l
             - run: npm run test:unit -- --coverage
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
                   at: "."
 
             - run: ls test/tests -l
-            - run: ls test/tests -l
+            - run: ls 'test/tests/custom eslint path' -l
             - run: npm run test:end-to-end
 
     test-unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,8 @@ jobs:
             - attach_workspace:
                   at: "."
 
+            - run: ls test/tests -l
+            - run: ls test/tests -l
             - run: npm run test:end-to-end
 
     test-unit:
@@ -105,8 +107,6 @@ jobs:
             - attach_workspace:
                   at: "."
 
-            - run: ls test/tests -l
-            - run: ls test/tests -l
             - run: npm run test:unit -- --coverage
 
     tsc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,8 @@ jobs:
             - attach_workspace:
                   at: "."
 
+            - run: ls test -l
+            - run: ls test/tests -l
             - run: npm run test:unit -- --coverage
 
     tsc:

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules/
 src/**/*.js
 test/*.js
 ~test/jest.config.js
-test/tests/**/.eslintrc*
+!test/tests/**/.eslintrc*
+!test/tests/**/*.log

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
     moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
-    testRegex: "test(.*)\\.test\\.ts$",
+    testRegex: "test(.*).test.ts$",
     testEnvironment: "node",
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
     moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
-    testRegex: "test(.*)\\test\\.ts$",
+    testRegex: "test(.*)\\.test\\.ts$",
     testEnvironment: "node",
 };

--- a/test/tests/custom eslint path/tslint-to-eslint-config.log
+++ b/test/tests/custom eslint path/tslint-to-eslint-config.log
@@ -1,0 +1,2 @@
+no-implicit-dependencies does not yet have an ESLint equivalent.
+strict-boolean-expressions does not yet have an ESLint equivalent.

--- a/test/tests/custom package path/.eslintrc.json
+++ b/test/tests/custom package path/.eslintrc.json
@@ -1,0 +1,31 @@
+module.exports = {
+    env: {
+        es6: true,
+        node: true,
+    },
+    parser: "@typescript-eslint/parser",
+    parserOptions: {
+        project: "tsconfig.json",
+        sourceType: "module",
+    },
+    plugins: ["@typescript-eslint", "@typescript-eslint/tslint"],
+    rules: {
+        "@typescript-eslint/array-type": "error",
+        "@typescript-eslint/interface-name-prefix": "error",
+        "no-magic-numbers": "off",
+        "prefer-template": "off",
+        "@typescript-eslint/tslint/config": [
+            "error",
+            {
+                rules: {
+                    "no-implicit-dependencies": [true, "dev"],
+                    "strict-boolean-expressions": [
+                        true,
+                        "allow-boolean-or-undefined",
+                        "allow-number",
+                    ],
+                },
+            },
+        ],
+    },
+};

--- a/test/tests/custom package path/tslint-to-eslint-config.log
+++ b/test/tests/custom package path/tslint-to-eslint-config.log
@@ -1,2 +1,0 @@
-no-implicit-dependencies does not yet have an ESLint equivalent.
-strict-boolean-expressions does not yet have an ESLint equivalent.

--- a/test/tests/custom package path/tslint-to-eslint-config.log
+++ b/test/tests/custom package path/tslint-to-eslint-config.log
@@ -1,0 +1,2 @@
+no-implicit-dependencies does not yet have an ESLint equivalent.
+strict-boolean-expressions does not yet have an ESLint equivalent.

--- a/test/tests/custom typescript path/.eslintrc.json
+++ b/test/tests/custom typescript path/.eslintrc.json
@@ -1,0 +1,31 @@
+module.exports = {
+    env: {
+        browser: true,
+        node: true,
+    },
+    parser: "@typescript-eslint/parser",
+    parserOptions: {
+        project: "tsconfig.json",
+        sourceType: "module",
+    },
+    plugins: ["@typescript-eslint", "@typescript-eslint/tslint"],
+    rules: {
+        "@typescript-eslint/array-type": "error",
+        "@typescript-eslint/interface-name-prefix": "error",
+        "no-magic-numbers": "off",
+        "prefer-template": "off",
+        "@typescript-eslint/tslint/config": [
+            "error",
+            {
+                rules: {
+                    "no-implicit-dependencies": [true, "dev"],
+                    "strict-boolean-expressions": [
+                        true,
+                        "allow-boolean-or-undefined",
+                        "allow-number",
+                    ],
+                },
+            },
+        ],
+    },
+};

--- a/test/tests/custom typescript path/tslint-to-eslint-config.log
+++ b/test/tests/custom typescript path/tslint-to-eslint-config.log
@@ -1,0 +1,2 @@
+no-implicit-dependencies does not yet have an ESLint equivalent.
+strict-boolean-expressions does not yet have an ESLint equivalent.

--- a/test/tests/missing tslint.json/.eslintrc.json
+++ b/test/tests/missing tslint.json/.eslintrc.json
@@ -1,0 +1,50 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "project": "tsconfig.json",
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint",
+        "@typescript-eslint/tslint"
+    ],
+    "rules": {
+        "@typescript-eslint/array-type": "error",
+        "@typescript-eslint/interface-name-prefix": "error",
+        "@typescript-eslint/member-ordering": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-param-reassign": "off",
+        "@typescript-eslint/no-parameter-properties": "off",
+        "@typescript-eslint/no-use-before-declare": "off",
+        "@typescript-eslint/promise-function-async": "off",
+        "@typescript-eslint/unbound-method": "off",
+        "arrow-body-style": "off",
+        "default-case": "off",
+        "linebreak-style": "off",
+        "no-bitwise": "off",
+        "no-empty": "off",
+        "no-empty-functions": "off",
+        "no-magic-numbers": "off",
+        "prefer-template": "off",
+        "@typescript-eslint/tslint/config": [
+            "error",
+            {
+                "rules": {
+                    "no-implicit-dependencies": [
+                        true,
+                        "dev"
+                    ],
+                    "strict-boolean-expressions": [
+                        true,
+                        "allow-boolean-or-undefined",
+                        "allow-number"
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/test/tests/standalone tslint.json/tslint-to-eslint-config.log
+++ b/test/tests/standalone tslint.json/tslint-to-eslint-config.log
@@ -1,0 +1,2 @@
+no-implicit-dependencies does not yet have an ESLint equivalent.
+strict-boolean-expressions does not yet have an ESLint equivalent.


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: starts on #156
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Mostly fixes end-to-end tests, but doesn't completely - `ts-node` needs to get running in Circle for them to work. In the meantime, disables them from running in builds.