### PR TITLE
Added missing no-floating-promises converter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -43,6 +43,7 @@ import { convertNoEmpty } from "./converters/no-empty";
 import { convertNoEmptyInterface } from "./converters/no-empty-interface";
 import { convertNoEval } from "./converters/no-eval";
 import { convertNoExplicitAny } from "./converters/no-explicit-any";
+import { convertNoFloatingPromises } from "./converters/no-floating-promises";
 import { convertNoForInArray } from "./converters/no-for-in-array";
 import { convertNoInferrableTypes } from "./converters/no-inferrable-types";
 import { convertNoInternalModule } from "./converters/no-internal-module";
@@ -135,6 +136,7 @@ export const converters = new Map([
     ["no-duplicate-switch-case", convertNoDuplicateSwitchCase],
     ["no-empty-interface", convertNoEmptyInterface],
     ["no-eval", convertNoEval],
+    ["no-floating-promises", convertNoFloatingPromises],
     ["no-for-in-array", convertNoForInArray],
     ["no-inferrable-types", convertNoInferrableTypes],
     ["no-internal-module", convertNoInternalModule],

--- a/src/rules/converters/no-floating-promises.ts
+++ b/src/rules/converters/no-floating-promises.ts
@@ -1,0 +1,11 @@
+import { RuleConverter } from "../converter";
+
+export const convertNoFloatingPromises: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@typescript-eslint/no-floating-promises",
+            },
+        ],
+    };
+};

--- a/src/rules/converters/tests/no-floating-promises.test.ts
+++ b/src/rules/converters/tests/no-floating-promises.test.ts
@@ -1,0 +1,17 @@
+import { convertNoFloatingPromises } from "../no-floating-promises";
+
+describe(convertNoFloatingPromises, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoFloatingPromises({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/no-floating-promises",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #169
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Adds a missing rule converter for the `no-floating-promises` rule.