### PR TITLE
Added missing prefer-readonly converter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -86,6 +86,7 @@ import { convertPreferConst } from "./converters/prefer-const";
 import { convertPreferForOf } from "./converters/prefer-for-of";
 import { convertPreferFunctionOverMethod } from "./converters/prefer-function-over-method";
 import { convertPreferObjectSpread } from "./converters/prefer-object-spread";
+import { convertPreferReadonly } from "./converters/prefer-readonly";
 import { convertPreferTemplate } from "./converters/prefer-template";
 import { convertPromiseFunctionAsync } from "./converters/promise-function-async";
 import { convertRadix } from "./converters/radix";
@@ -194,6 +195,7 @@ export const converters = new Map([
     ["one-variable-per-declaration", convertOneVariablePerDeclaration],
     ["prefer-const", convertPreferConst],
     ["prefer-function-over-method", convertPreferFunctionOverMethod],
+    ["prefer-readonly", convertPreferReadonly],
     ["prefer-template", convertPreferTemplate],
     ["space-before-function-paren", convertSpaceBeforeFunctionParen],
     ["switch-default", convertSwitchDefault],

--- a/src/rules/converters/prefer-readonly.ts
+++ b/src/rules/converters/prefer-readonly.ts
@@ -1,0 +1,15 @@
+import { RuleConverter } from "../converter";
+
+export const convertPreferReadonly: RuleConverter = tslintRule => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 &&
+                    tslintRule.ruleArguments[0] === "only-inline-lambdas" && {
+                        ruleArguments: [{ onlyInlineLambdas: true }],
+                    }),
+                ruleName: "prefer-readonly",
+            },
+        ],
+    };
+};

--- a/src/rules/converters/tests/prefer-readonly.test.ts
+++ b/src/rules/converters/tests/prefer-readonly.test.ts
@@ -1,0 +1,32 @@
+import { convertPreferReadonly } from "../prefer-readonly";
+
+describe(convertPreferReadonly, () => {
+    test("conversion without arguments", () => {
+        const result = convertPreferReadonly({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "prefer-readonly",
+                },
+            ],
+        });
+    });
+
+    test("conversion with an argument", () => {
+        const result = convertPreferReadonly({
+            ruleArguments: ["only-inline-lambdas"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ onlyInlineLambdas: true }],
+                    ruleName: "prefer-readonly",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #181
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Adds a missing rule converter for the `prefer-readonly` rule.
