### PR TITLE
Added missing quotemark converter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -99,6 +99,7 @@ import { convertUnifiedSignatures } from "./converters/unified-signatures";
 import { convertUnnecessaryBind } from "./converters/unnecessary-bind";
 import { convertUnnecessaryConstructor } from "./converters/unnecessary-constructor";
 import { convertUseIsnan } from "./converters/use-isnan";
+import { convertQuotemark } from "./converters/quotemark";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -205,6 +206,7 @@ export const converters = new Map([
     ["no-octal-literal", convertNoOctalLiteral],
     ["no-regex-spaces", convertNoRegexSpaces],
     ["no-unnecessary-semicolons", convertNoUnnecessarySemicolons],
+    ["quotemark", convertQuotemark],
 
     // These converters are all for rules that need more complex option conversions.
     // Some of them will likely need to have notices about changed lint behaviors...
@@ -221,7 +223,6 @@ export const converters = new Map([
     // ["no-trailing-whitespace", convertNoTrailingWhitespace], //  no-trailing-spaces
     // ["no-unused-expression", convertNoUnusedExpression], // no-unused-expressions
     // ["no-void-expression", convertNoVoidExpression], // (no exact equivalent)
-    // ["quotemark", convertQuotemark], // quotes
     // ["space-within-parens", convertSpaceWithinParens], // space-in-parens
     // ["triple-equals", convertTripleEquals], // eqeqeq
     // ["variable-name", convertVariableName], // a bunch of rules...

--- a/src/rules/converters/quotemark.ts
+++ b/src/rules/converters/quotemark.ts
@@ -1,0 +1,32 @@
+import { RuleConverter } from "../converter";
+
+export const convertQuotemark: RuleConverter = tslintRule => {
+    const notices: string[] = [];
+    const ruleArguments: any[] = [];
+
+    ["jsx-single", "jsx-double", "avoid-template"].forEach(rule => {
+        if (tslintRule.ruleArguments.includes(rule)) {
+            notices.push(`Option "${rule}" is not supported by ESLint.`);
+        }
+    });
+
+    ["single", "double", "backtick"].forEach(rule => {
+        if (tslintRule.ruleArguments.includes(rule)) {
+            ruleArguments.push(rule);
+        }
+    });
+
+    if (tslintRule.ruleArguments.includes("avoid-escape")) {
+        ruleArguments.push({ avoidEscape: true });
+    }
+
+    return {
+        rules: [
+            {
+                notices,
+                ruleArguments,
+                ruleName: "@typescript-eslint/quotes",
+            },
+        ],
+    };
+};

--- a/src/rules/converters/quotemark.ts
+++ b/src/rules/converters/quotemark.ts
@@ -2,17 +2,17 @@ import { RuleConverter } from "../converter";
 
 export const convertQuotemark: RuleConverter = tslintRule => {
     const notices: string[] = [];
-    const ruleArguments: any[] = [];
+    const ruleArguments: Array<string | { avoidEscape: true }> = [];
 
-    ["jsx-single", "jsx-double", "avoid-template"].forEach(rule => {
-        if (tslintRule.ruleArguments.includes(rule)) {
-            notices.push(`Option "${rule}" is not supported by ESLint.`);
+    ["jsx-single", "jsx-double", "avoid-template"].forEach(option => {
+        if (tslintRule.ruleArguments.includes(option)) {
+            notices.push(`Option "${option}" is not supported by ESLint.`);
         }
     });
 
-    ["single", "double", "backtick"].forEach(rule => {
-        if (tslintRule.ruleArguments.includes(rule)) {
-            ruleArguments.push(rule);
+    ["single", "double", "backtick"].forEach(option => {
+        if (tslintRule.ruleArguments.includes(option)) {
+            ruleArguments.push(option);
         }
     });
 

--- a/src/rules/converters/quotemark.ts
+++ b/src/rules/converters/quotemark.ts
@@ -1,8 +1,9 @@
 import { RuleConverter } from "../converter";
 
+type QuotemarkRule = string | { avoidEscape: true };
 export const convertQuotemark: RuleConverter = tslintRule => {
     const notices: string[] = [];
-    const ruleArguments: Array<string | { avoidEscape: true }> = [];
+    const ruleArguments: QuotemarkRule[] = [];
 
     ["jsx-single", "jsx-double", "avoid-template"].forEach(option => {
         if (tslintRule.ruleArguments.includes(option)) {

--- a/src/rules/converters/tests/quotemark.test.ts
+++ b/src/rules/converters/tests/quotemark.test.ts
@@ -17,7 +17,7 @@ describe(convertQuotemark, () => {
         });
     });
 
-    test("conversion with an arguments", () => {
+    test("conversion with an argument", () => {
         const result = convertQuotemark({
             ruleArguments: ["double"],
         });
@@ -49,7 +49,7 @@ describe(convertQuotemark, () => {
         });
     });
 
-    test("conversion with multiple arguments", () => {
+    test("conversion with arguments", () => {
         const result = convertQuotemark({
             ruleArguments: ["single", "avoid-template"],
         });

--- a/src/rules/converters/tests/quotemark.test.ts
+++ b/src/rules/converters/tests/quotemark.test.ts
@@ -1,0 +1,87 @@
+import { convertQuotemark } from "../quotemark";
+
+describe(convertQuotemark, () => {
+    test("conversion without arguments", () => {
+        const result = convertQuotemark({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/quotes",
+                    ruleArguments: [],
+                    notices: [],
+                },
+            ],
+        });
+    });
+
+    test("conversion with an arguments", () => {
+        const result = convertQuotemark({
+            ruleArguments: ["double"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/quotes",
+                    ruleArguments: ["double"],
+                    notices: [],
+                },
+            ],
+        });
+    });
+
+    test("conversion with an avoid-escape argument", () => {
+        const result = convertQuotemark({
+            ruleArguments: ["avoid-escape"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/quotes",
+                    ruleArguments: [{ avoidEscape: true }],
+                    notices: [],
+                },
+            ],
+        });
+    });
+
+    test("conversion with multiple arguments", () => {
+        const result = convertQuotemark({
+            ruleArguments: ["single", "avoid-template"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/quotes",
+                    ruleArguments: ["single"],
+                    notices: ['Option "avoid-template" is not supported by ESLint.'],
+                },
+            ],
+        });
+    });
+
+    test("conversion with unsupported arguments", () => {
+        const result = convertQuotemark({
+            ruleArguments: ["jsx-single", "jsx-double", "avoid-template"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/quotes",
+                    ruleArguments: [],
+                    notices: [
+                        'Option "jsx-single" is not supported by ESLint.',
+                        'Option "jsx-double" is not supported by ESLint.',
+                        'Option "avoid-template" is not supported by ESLint.',
+                    ],
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #182
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
Adds a missing rule converter for the `quotemark` rule.