### PR TITLE
added only-arrow-functions converter and unit tests

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -82,6 +82,7 @@ import { convertNoVarRequires } from "./converters/no-var-requires";
 import { convertObjectLiteralKeyQuotes } from "./converters/object-literal-key-quotes";
 import { convertObjectLiteralShorthand } from "./converters/object-literal-shorthand";
 import { convertOneVariablePerDeclaration } from "./converters/one-variable-per-declaration";
+import { convertOnlyArrowFunctions } from "./converters/only-arrow-functions";
 import { convertPreferConst } from "./converters/prefer-const";
 import { convertPreferForOf } from "./converters/prefer-for-of";
 import { convertPreferFunctionOverMethod } from "./converters/prefer-function-over-method";
@@ -193,6 +194,7 @@ export const converters = new Map([
     ["object-literal-key-quotes", convertObjectLiteralKeyQuotes],
     ["object-literal-shorthand", convertObjectLiteralShorthand],
     ["one-variable-per-declaration", convertOneVariablePerDeclaration],
+    ["only-arrow-functions", convertOnlyArrowFunctions],
     ["prefer-const", convertPreferConst],
     ["prefer-function-over-method", convertPreferFunctionOverMethod],
     ["prefer-readonly", convertPreferReadonly],

--- a/src/rules/converters/only-arrow-functions.ts
+++ b/src/rules/converters/only-arrow-functions.ts
@@ -1,0 +1,25 @@
+import { RuleConverter } from "../converter";
+
+export const convertOnlyArrowFunctions: RuleConverter = tslintRule => {
+    const notices: string[] = [];
+
+    if (tslintRule.ruleArguments.includes("allow-declarations")) {
+        notices.push("ESLint does not support allowing standalone function declarations.");
+    }
+
+    if (tslintRule.ruleArguments.includes("allow-named-functions")) {
+        notices.push(
+            "ESLint does not support allowing named functions defined with the function keyword.",
+        );
+    }
+
+    return {
+        rules: [
+            {
+                ...(notices.length > 0 && { notices }),
+                ruleName: "prefer-arrow/prefer-arrow-functions",
+            },
+        ],
+        plugins: ["prefer-arrow"],
+    };
+};

--- a/src/rules/converters/tests/only-arrow-functions.test.ts
+++ b/src/rules/converters/tests/only-arrow-functions.test.ts
@@ -1,0 +1,71 @@
+import { convertOnlyArrowFunctions } from "../only-arrow-functions";
+
+describe(convertOnlyArrowFunctions, () => {
+    test("conversion without arguments", () => {
+        const result = convertOnlyArrowFunctions({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "prefer-arrow/prefer-arrow-functions",
+                },
+            ],
+            plugins: ["prefer-arrow"],
+        });
+    });
+
+    test("conversion with allow-declarations argument", () => {
+        const result = convertOnlyArrowFunctions({
+            ruleArguments: ["allow-declarations"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: ["ESLint does not support allowing standalone function declarations."],
+                    ruleName: "prefer-arrow/prefer-arrow-functions",
+                },
+            ],
+            plugins: ["prefer-arrow"],
+        });
+    });
+
+    test("conversion with allow-named-functions argument", () => {
+        const result = convertOnlyArrowFunctions({
+            ruleArguments: ["allow-named-functions"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [
+                        "ESLint does not support allowing named functions defined with the function keyword.",
+                    ],
+                    ruleName: "prefer-arrow/prefer-arrow-functions",
+                },
+            ],
+            plugins: ["prefer-arrow"],
+        });
+    });
+
+    test("conversion with all arguments", () => {
+        const result = convertOnlyArrowFunctions({
+            ruleArguments: ["allow-declarations", "allow-named-functions"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [
+                        "ESLint does not support allowing standalone function declarations.",
+                        "ESLint does not support allowing named functions defined with the function keyword.",
+                    ],
+                    ruleName: "prefer-arrow/prefer-arrow-functions",
+                },
+            ],
+            plugins: ["prefer-arrow"],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #179
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
Added the converter and the unit tests for the only-arrow-functions TSLint rule.

<!-- Brief description of what is changed and how the code change does that. -->
