### PR TITLE
fix: corrected convert arguments for max-line-length converter

### DIFF
--- a/src/rules/converters/max-line-length.ts
+++ b/src/rules/converters/max-line-length.ts
@@ -12,21 +12,21 @@ export const convertMaxLineLength: RuleConverter = tslintRule => {
 };
 
 const collectArguments = (ruleArguments: any[]) => {
-    if (ruleArguments.length === 0 || ruleArguments[0] === false || ruleArguments.length < 2) {
+    if (ruleArguments.length === 0) {
         return undefined;
     }
 
-    if (ruleArguments.length === 2 && typeof ruleArguments[1] === "number") {
+    const argument = ruleArguments[0];
+
+    if (typeof argument === "number") {
         return {
             ruleArguments: [
                 {
-                    code: ruleArguments[1],
+                    code: argument,
                 },
             ],
         };
     }
-
-    const argument = ruleArguments[1];
 
     return {
         ruleArguments: [

--- a/src/rules/converters/tests/max-line-length.test.ts
+++ b/src/rules/converters/tests/max-line-length.test.ts
@@ -15,37 +15,9 @@ describe(convertMaxLineLength, () => {
         });
     });
 
-    test("conversion with one argument true value", () => {
+    test("conversion with one argument number", () => {
         const result = convertMaxLineLength({
-            ruleArguments: [true],
-        });
-
-        expect(result).toEqual({
-            rules: [
-                {
-                    ruleName: "max-len",
-                },
-            ],
-        });
-    });
-
-    test("conversion with two arguments and first is false", () => {
-        const result = convertMaxLineLength({
-            ruleArguments: [false, 123],
-        });
-
-        expect(result).toEqual({
-            rules: [
-                {
-                    ruleName: "max-len",
-                },
-            ],
-        });
-    });
-
-    test("conversion with two arguments and second is number", () => {
-        const result = convertMaxLineLength({
-            ruleArguments: [true, 123],
+            ruleArguments: [123],
         });
 
         expect(result).toEqual({
@@ -58,10 +30,9 @@ describe(convertMaxLineLength, () => {
         });
     });
 
-    test("conversion with two arguments and second is object", () => {
+    test("conversion with one object argument", () => {
         const result = convertMaxLineLength({
             ruleArguments: [
-                true,
                 {
                     limit: 123,
                     "ignore-pattern": "^import |^export {(.*?)}",
@@ -91,7 +62,6 @@ describe(convertMaxLineLength, () => {
     test("conversion with check-strings inverting value true to false", () => {
         const result = convertMaxLineLength({
             ruleArguments: [
-                true,
                 {
                     limit: 123,
                     "check-strings": true,
@@ -117,7 +87,6 @@ describe(convertMaxLineLength, () => {
     test("conversion with check-strings inverting value false to true", () => {
         const result = convertMaxLineLength({
             ruleArguments: [
-                true,
                 {
                     limit: 123,
                     "check-strings": false,
@@ -143,7 +112,6 @@ describe(convertMaxLineLength, () => {
     test("conversion with check-regex inverting value true to false", () => {
         const result = convertMaxLineLength({
             ruleArguments: [
-                true,
                 {
                     limit: 123,
                     "check-regex": true,
@@ -169,7 +137,6 @@ describe(convertMaxLineLength, () => {
     test("conversion with check-regex inverting value false to true", () => {
         const result = convertMaxLineLength({
             ruleArguments: [
-                true,
                 {
                     limit: 123,
                     "check-regex": false,


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [X] Addresses an existing issue: fixes #200 
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
Fixing arguments converting for max-line-length rule.
