### PR TITLE
Add missing converter: no-null-keyword

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -107,6 +107,7 @@ import { convertUnnecessaryConstructor } from "./converters/unnecessary-construc
 import { convertUseIsnan } from "./converters/use-isnan";
 import { convertQuotemark } from "./converters/quotemark";
 import { convertTripleEquals } from "./converters/triple-equals";
+import { convertNoNullKeyword } from "./converters/no-null-keyword";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -215,6 +216,7 @@ export const converters = new Map([
     ["no-constant-condition", convertNoConstantCondition],
     ["no-control-regex", convertNoControlRegex],
     ["no-multiline-string", convertNoMultilineString],
+    ["no-null-keyword", convertNoNullKeyword],
     ["no-invalid-regexp", convertNoInvalidRegexp],
     ["no-octal-literal", convertNoOctalLiteral],
     ["no-regex-spaces", convertNoRegexSpaces],

--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -112,7 +112,9 @@ import { convertQuotemark } from "./converters/quotemark";
 import { convertTripleEquals } from "./converters/triple-equals";
 
 /**
- * Keys TSLint rule names to their ESLint rule converters. */ export const converters = new Map([
+ * Keys TSLint rule names to their ESLint rule converters.
+ */
+export const converters = new Map([
     ["adjacent-overload-signatures", convertAdjacentOverloadSignatures],
     ["array-type", convertArrayType],
     ["arrow-parens", convertArrowParens],

--- a/src/rules/converters/no-null-keyword.ts
+++ b/src/rules/converters/no-null-keyword.ts
@@ -2,6 +2,7 @@ import { RuleConverter } from "../converter";
 
 export const convertNoNullKeyword: RuleConverter = () => {
     return {
+        notices: ["Null types will no longer be handled."],
         rules: [
             {
                 ruleName: "no-null/no-null",

--- a/src/rules/converters/no-null-keyword.ts
+++ b/src/rules/converters/no-null-keyword.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../converter";
+
+export const convertNoNullKeyword: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "no-null/no-null",
+            },
+        ],
+        plugins: ["no-null"],
+    };
+};

--- a/src/rules/converters/tests/no-null-keyword.test.ts
+++ b/src/rules/converters/tests/no-null-keyword.test.ts
@@ -7,6 +7,7 @@ describe(convertNoNullKeyword, () => {
         });
 
         expect(result).toEqual({
+            notices: ["Null types will no longer be handled."],
             rules: [
                 {
                     ruleName: "no-null/no-null",

--- a/src/rules/converters/tests/no-null-keyword.test.ts
+++ b/src/rules/converters/tests/no-null-keyword.test.ts
@@ -1,0 +1,18 @@
+import { convertNoNullKeyword } from "../no-null-keyword";
+
+describe(convertNoNullKeyword, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoNullKeyword({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "no-null/no-null",
+                },
+            ],
+            plugins: ["no-null"],
+        });
+    });
+});


### PR DESCRIPTION
Add converter for #173

## PR Checklist

-   [x] Addresses an existing issue: fixes #173 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Add converter to convert `no-null-keyword` rule. Will add plugin eslint-plugin-no-null to settings.
