### PR TITLE
Add missing converter: newline-before-return

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -25,6 +25,7 @@ import { convertMaxClassesPerFile } from "./converters/max-classes-per-file";
 import { convertMaxFileLineCount } from "./converters/max-file-line-count";
 import { convertMaxLineLength } from "./converters/max-line-length";
 import { convertMemberOrdering } from "./converters/member-ordering";
+import { convertNewlineBeforeReturn } from "./converters/newline-before-return";
 import { convertNewlinePerChainedCall } from "./converters/newline-per-chained-call";
 import { convertNewParens } from "./converters/new-parens";
 import { convertNoAngleBracketTypeAssertion } from "./converters/no-angle-bracket-type-assertion";
@@ -132,6 +133,7 @@ export const converters = new Map([
     ["member-access", convertMemberAccess],
     ["member-ordering", convertMemberOrdering],
     ["new-parens", convertNewParens],
+    ["newline-before-return", convertNewlineBeforeReturn],
     ["newline-per-chained-call", convertNewlinePerChainedCall],
     ["no-angle-bracket-type-assertion", convertNoAngleBracketTypeAssertion],
     ["no-any", convertNoExplicitAny],
@@ -230,7 +232,6 @@ export const converters = new Map([
     // TSLint core rules:
     // ["ban", convertBan], // no-restricted-properties
     // ["import-blacklist", convertImportBlacklist], // no-restricted-imports
-    // ["newline-before-return", convertNewlineBeforeReturn],
     // ["no-duplicate-variable", convertNoDuplicateVariable], // no-redeclare
     // ["no-shadowed-variable", convertNoShadowedVariable], // no-shadow
     // ["no-trailing-whitespace", convertNoTrailingWhitespace], //  no-trailing-spaces

--- a/src/rules/converters/newline-before-return.ts
+++ b/src/rules/converters/newline-before-return.ts
@@ -1,0 +1,19 @@
+import { RuleConverter } from "../converter";
+
+export const convertNewlineBeforeReturn: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "padding-line-between-statements",
+                ruleArguments: [
+                    "error",
+                    {
+                        blankLine: "always",
+                        prev: "*",
+                        next: "return",
+                    },
+                ],
+            },
+        ],
+    };
+};

--- a/src/rules/converters/tests/newline-before-return.test.ts
+++ b/src/rules/converters/tests/newline-before-return.test.ts
@@ -1,0 +1,25 @@
+import { convertNewlineBeforeReturn } from "../newline-before-return";
+
+describe(convertNewlineBeforeReturn, () => {
+    test("conversion without arguments", () => {
+        const result = convertNewlineBeforeReturn({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "padding-line-between-statements",
+                    ruleArguments: [
+                        "error",
+                        {
+                            blankLine: "always",
+                            next: "return",
+                            prev: "*",
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
To #164

## PR Checklist

-   [x] Addresses an existing issue: fixes #164 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Add converter for `newline-before-return` with suggested configuration for new `padding-line-between-statements` rule