### PR TITLE
Add missing converter: file-name-casing

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -13,6 +13,7 @@ import { convertCurly } from "./converters/curly";
 import { convertCyclomaticComplexity } from "./converters/cyclomatic-complexity";
 import { convertEofline } from "./converters/eofline";
 import { convertMemberAccess } from "./converters/member-access";
+import { convertFileNameCasing } from "./converters/file-name-casing";
 import { convertForin } from "./converters/forin";
 import { convertFunctionConstructor } from "./converters/function-constructor";
 import { convertIncrementDecrement } from "./converters/increment-decrement";
@@ -123,6 +124,7 @@ export const converters = new Map([
     ["callable-types", convertCallableTypes],
     ["class-name", convertClassName],
     ["eofline", convertEofline],
+    ["file-name-casing", convertFileNameCasing],
     ["forin", convertForin],
     ["function-constructor", convertFunctionConstructor],
     ["indent", convertIndent],

--- a/src/rules/converters/file-name-casing.ts
+++ b/src/rules/converters/file-name-casing.ts
@@ -1,6 +1,15 @@
 import { RuleConverter } from "../converter";
 
-const IGNORE_CASE_NOTICE = "ESLint (Unicorn plugin) does not support ignore as case";
+const IGNORE_CASE_NOTICE = "ESLint (Unicorn plugin) does not support the 'ignore' case.";
+const CASING_BY_FILETYPE_CHANGE =
+    "ESLint (Unicorn Plugin) does not support file name casing by file type, so all previously configured casings are now allowed.";
+const CASES_MAP: { [s: string]: string } = {
+    "camel-case": "camelCase",
+    "pascal-case": "pascalCase",
+    "kebab-case": "kebabCase",
+    "snake-case": "snakeCase",
+};
+
 export const convertFileNameCasing: RuleConverter = tslintRule => {
     return {
         rules: [
@@ -15,12 +24,7 @@ export const convertFileNameCasing: RuleConverter = tslintRule => {
 
 const collectArguments = (ruleArguments: any[]) => {
     const notices: string[] = [];
-    const casesMap = new Map();
-    casesMap.set("camel-case", "camelCase");
-    casesMap.set("pascal-case", "pascalCase");
-    casesMap.set("kebab-case", "kebabCase");
-    casesMap.set("snake-case", "snakeCase");
-    const foundCases: { [k: string]: any } = {};
+    const foundCases: { [k: string]: boolean } = {};
 
     if (ruleArguments.length === 0 || ruleArguments[0] === false || ruleArguments.length < 2) {
         return undefined;
@@ -31,16 +35,17 @@ const collectArguments = (ruleArguments: any[]) => {
         if (casings === "ignore") {
             notices.push(IGNORE_CASE_NOTICE);
         } else {
-            foundCases[casesMap.get(casings)] = true;
+            foundCases[CASES_MAP[casings]] = true;
         }
     }
 
     if (ruleArguments[1] instanceof Object) {
+        notices.push(CASING_BY_FILETYPE_CHANGE);
         for (const casing in casings) {
             if (casings[casing] === "ignore") {
                 notices.push(IGNORE_CASE_NOTICE);
             } else {
-                foundCases[casesMap.get(casings[casing])] = true;
+                foundCases[CASES_MAP[casings[casing]]] = true;
             }
         }
     }

--- a/src/rules/converters/file-name-casing.ts
+++ b/src/rules/converters/file-name-casing.ts
@@ -1,0 +1,56 @@
+import { RuleConverter } from "../converter";
+
+const IGNORE_CASE_NOTICE = "ESLint (Unicorn plugin) does not support ignore as case";
+export const convertFileNameCasing: RuleConverter = tslintRule => {
+    return {
+        rules: [
+            {
+                ruleName: "unicorn/filename-case",
+                ...collectArguments(tslintRule.ruleArguments),
+            },
+        ],
+        plugins: ["unicorn"],
+    };
+};
+
+const collectArguments = (ruleArguments: any[]) => {
+    const notices: string[] = [];
+    let casesMap = new Map();
+    casesMap.set("camel-case", "camelCase");
+    casesMap.set("pascal-case", "pascalCase");
+    casesMap.set("kebab-case", "kebabCase");
+    casesMap.set("snake-case", "snakeCase");
+    let foundCases: { [k: string]: any } = {};
+
+    if (ruleArguments.length === 0 || ruleArguments[0] === false || ruleArguments.length < 2) {
+        return undefined;
+    }
+
+    let casings = ruleArguments[1];
+    if (typeof casings === "string") {
+        if (casings === "ignore") {
+            notices.push(IGNORE_CASE_NOTICE);
+        } else {
+            foundCases[casesMap.get(casings)] = true;
+        }
+    }
+
+    if (ruleArguments[1] instanceof Object) {
+        for (let casing in casings) {
+            if (casings[casing] === "ignore") {
+                notices.push(IGNORE_CASE_NOTICE);
+            } else {
+                foundCases[casesMap.get(casings[casing])] = true;
+            }
+        }
+    }
+
+    return {
+        ...(notices.length > 0 && { notices }),
+        ruleArguments: [
+            {
+                cases: foundCases,
+            },
+        ],
+    };
+};

--- a/src/rules/converters/file-name-casing.ts
+++ b/src/rules/converters/file-name-casing.ts
@@ -15,18 +15,18 @@ export const convertFileNameCasing: RuleConverter = tslintRule => {
 
 const collectArguments = (ruleArguments: any[]) => {
     const notices: string[] = [];
-    let casesMap = new Map();
+    const casesMap = new Map();
     casesMap.set("camel-case", "camelCase");
     casesMap.set("pascal-case", "pascalCase");
     casesMap.set("kebab-case", "kebabCase");
     casesMap.set("snake-case", "snakeCase");
-    let foundCases: { [k: string]: any } = {};
+    const foundCases: { [k: string]: any } = {};
 
     if (ruleArguments.length === 0 || ruleArguments[0] === false || ruleArguments.length < 2) {
         return undefined;
     }
 
-    let casings = ruleArguments[1];
+    const casings = ruleArguments[1];
     if (typeof casings === "string") {
         if (casings === "ignore") {
             notices.push(IGNORE_CASE_NOTICE);
@@ -36,7 +36,7 @@ const collectArguments = (ruleArguments: any[]) => {
     }
 
     if (ruleArguments[1] instanceof Object) {
-        for (let casing in casings) {
+        for (const casing in casings) {
             if (casings[casing] === "ignore") {
                 notices.push(IGNORE_CASE_NOTICE);
             } else {

--- a/src/rules/converters/tests/file-name-casing.test.ts
+++ b/src/rules/converters/tests/file-name-casing.test.ts
@@ -46,7 +46,10 @@ describe(convertFileNameCasing, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: ["ESLint (Unicorn plugin) does not support ignore as case"],
+                    notices: [
+                        "ESLint (Unicorn Plugin) does not support file name casing by file type, so all previously configured casings are now allowed.",
+                        "ESLint (Unicorn plugin) does not support the 'ignore' case.",
+                    ],
                     ruleName: "unicorn/filename-case",
                     ruleArguments: [
                         {
@@ -70,7 +73,7 @@ describe(convertFileNameCasing, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: ["ESLint (Unicorn plugin) does not support ignore as case"],
+                    notices: ["ESLint (Unicorn plugin) does not support the 'ignore' case."],
                     ruleName: "unicorn/filename-case",
                     ruleArguments: [
                         {
@@ -91,7 +94,10 @@ describe(convertFileNameCasing, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: ["ESLint (Unicorn plugin) does not support ignore as case"],
+                    notices: [
+                        "ESLint (Unicorn Plugin) does not support file name casing by file type, so all previously configured casings are now allowed.",
+                        "ESLint (Unicorn plugin) does not support the 'ignore' case.",
+                    ],
                     ruleName: "unicorn/filename-case",
                     ruleArguments: [
                         {

--- a/src/rules/converters/tests/file-name-casing.test.ts
+++ b/src/rules/converters/tests/file-name-casing.test.ts
@@ -1,0 +1,91 @@
+import { convertFileNameCasing } from "../file-name-casing";
+
+describe(convertFileNameCasing, () => {
+    test("conversion without string value", () => {
+        const result = convertFileNameCasing({
+            ruleArguments: [true, "camel-case"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "unicorn/filename-case",
+                    ruleArguments: [
+                        {
+                            cases: {
+                                camelCase: true,
+                            },
+                        },
+                    ],
+                },
+            ],
+            plugins: ["unicorn"],
+        });
+    });
+
+    test("conversion with object for filetypes", () => {
+        const result = convertFileNameCasing({
+            ruleArguments: [true, { ".ts": "ignore", ".tsx": "pascal-case", ".js": "snake-case" }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: ["ESLint (Unicorn plugin) does not support ignore as case"],
+                    ruleName: "unicorn/filename-case",
+                    ruleArguments: [
+                        {
+                            cases: {
+                                snakeCase: true,
+                                pascalCase: true,
+                            },
+                        },
+                    ],
+                },
+            ],
+            plugins: ["unicorn"],
+        });
+    });
+
+    test("conversion with ignore as case", () => {
+        const result = convertFileNameCasing({
+            ruleArguments: [true, "ignore"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: ["ESLint (Unicorn plugin) does not support ignore as case"],
+                    ruleName: "unicorn/filename-case",
+                    ruleArguments: [
+                        {
+                            cases: {},
+                        },
+                    ],
+                },
+            ],
+            plugins: ["unicorn"],
+        });
+    });
+
+    test("conversion with ignore in object", () => {
+        const result = convertFileNameCasing({
+            ruleArguments: [true, { ".ts": "ignore" }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: ["ESLint (Unicorn plugin) does not support ignore as case"],
+                    ruleName: "unicorn/filename-case",
+                    ruleArguments: [
+                        {
+                            cases: {},
+                        },
+                    ],
+                },
+            ],
+            plugins: ["unicorn"],
+        });
+    });
+});

--- a/src/rules/converters/tests/file-name-casing.test.ts
+++ b/src/rules/converters/tests/file-name-casing.test.ts
@@ -1,6 +1,21 @@
 import { convertFileNameCasing } from "../file-name-casing";
 
 describe(convertFileNameCasing, () => {
+    test("conversion without parameter", () => {
+        const result = convertFileNameCasing({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "unicorn/filename-case",
+                },
+            ],
+            plugins: ["unicorn"],
+        });
+    });
+
     test("conversion without string value", () => {
         const result = convertFileNameCasing({
             ruleArguments: [true, "camel-case"],


### PR DESCRIPTION
Linked to issue: #161


## PR Checklist

-   [x] Addresses an existing issue: fixes #161
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Add converter for file-name-casing. Map casings to new rule in the unicorn plugin.