### PR TITLE
Added ordered-imports converter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -90,6 +90,7 @@ import { convertObjectLiteralKeyQuotes } from "./converters/object-literal-key-q
 import { convertObjectLiteralShorthand } from "./converters/object-literal-shorthand";
 import { convertOneVariablePerDeclaration } from "./converters/one-variable-per-declaration";
 import { convertOnlyArrowFunctions } from "./converters/only-arrow-functions";
+import { convertOrderedImports } from "./converters/ordered-imports";
 import { convertPreferConst } from "./converters/prefer-const";
 import { convertPreferForOf } from "./converters/prefer-for-of";
 import { convertPreferFunctionOverMethod } from "./converters/prefer-function-over-method";
@@ -207,6 +208,7 @@ export const converters = new Map([
     ["object-literal-shorthand", convertObjectLiteralShorthand],
     ["one-variable-per-declaration", convertOneVariablePerDeclaration],
     ["only-arrow-functions", convertOnlyArrowFunctions],
+    ["ordered-imports", convertOrderedImports],
     ["prefer-const", convertPreferConst],
     ["prefer-for-of", convertPreferForOf],
     ["prefer-function-over-method", convertPreferFunctionOverMethod],

--- a/src/rules/converters/ordered-imports.ts
+++ b/src/rules/converters/ordered-imports.ts
@@ -1,0 +1,26 @@
+import { RuleConverter } from "../converter";
+
+export const convertOrderedImports: RuleConverter = tslintRule => {
+    const notices: string[] = [];
+    const unsupportedtslintOptions = [
+        "import-sources-order",
+        "named-imports-order",
+        "module-source-path",
+    ];
+
+    unsupportedtslintOptions.forEach(option => {
+        if (tslintRule.ruleArguments.includes(option)) {
+            notices.push(`Option "${option}" is not supported by ESLint.`);
+        }
+    });
+
+    return {
+        rules: [
+            {
+                ...(notices.length > 0 && { notices }),
+                ruleName: "import/order",
+            },
+        ],
+        plugins: ["import"],
+    };
+};

--- a/src/rules/converters/tests/ordered-imports.test.ts
+++ b/src/rules/converters/tests/ordered-imports.test.ts
@@ -1,0 +1,70 @@
+import { convertOrderedImports } from "../ordered-imports";
+
+describe(convertOrderedImports, () => {
+    test("conversion without arguments", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "import/order",
+                },
+            ],
+            plugins: ["import"],
+        });
+    });
+
+    test("conversion with allow-declarations argument", () => {
+        const result = convertOrderedImports({
+            ruleArguments: ["import-sources-order"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: ['Option "import-sources-order" is not supported by ESLint.'],
+                    ruleName: "import/order",
+                },
+            ],
+            plugins: ["import"],
+        });
+    });
+
+    test("conversion with allow-declarations argument", () => {
+        const result = convertOrderedImports({
+            ruleArguments: ["named-imports-order"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: ['Option "named-imports-order" is not supported by ESLint.'],
+                    ruleName: "import/order",
+                },
+            ],
+            plugins: ["import"],
+        });
+    });
+
+    test("conversion with unsupported arguments", () => {
+        const result = convertOrderedImports({
+            ruleArguments: ["import-sources-order", "named-imports-order", "module-source-path"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [
+                        'Option "import-sources-order" is not supported by ESLint.',
+                        'Option "named-imports-order" is not supported by ESLint.',
+                        'Option "module-source-path" is not supported by ESLint.',
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+            plugins: ["import"],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #180 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Added the converter and the unit tests for the ordered-imports TSLint rule.
