### PR TITLE
Added the file extension for a VS Code workspace file to .gitignore. …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ test/*.js
 ~test/jest.config.js
 !test/tests/**/.eslintrc*
 !test/tests/**/*.log
+#VS Code workspace file
+*.code-workspace

--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -108,6 +108,7 @@ import { convertUnifiedSignatures } from "./converters/unified-signatures";
 import { convertUnnecessaryBind } from "./converters/unnecessary-bind";
 import { convertUnnecessaryConstructor } from "./converters/unnecessary-constructor";
 import { convertUseIsnan } from "./converters/use-isnan";
+import { convertUseDefaultTypeParameter } from "./converters/use-default-type-parameter";
 import { convertQuotemark } from "./converters/quotemark";
 import { convertTripleEquals } from "./converters/triple-equals";
 
@@ -227,6 +228,7 @@ export const converters = new Map([
     ["unnecessary-bind", convertUnnecessaryBind],
     ["unnecessary-constructor", convertUnnecessaryConstructor],
     ["use-isnan", convertUseIsnan],
+    ["use-default-type-parameter", convertUseDefaultTypeParameter],
 
     // These converters are all for rules that need more complex option conversions.
     // Some of them will likely need to have notices about changed lint behaviors...

--- a/src/rules/converters/tests/use-default-type-parameter.test.ts
+++ b/src/rules/converters/tests/use-default-type-parameter.test.ts
@@ -1,0 +1,17 @@
+import { convertUseDefaultTypeParameter } from "../use-default-type-parameter";
+
+describe(convertUseDefaultTypeParameter, () => {
+    test("conversion without arguments", () => {
+        const result = convertUseDefaultTypeParameter({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/use-default-type-parameter",
+                },
+            ],
+        });
+    });
+});

--- a/src/rules/converters/use-default-type-parameter.ts
+++ b/src/rules/converters/use-default-type-parameter.ts
@@ -1,0 +1,11 @@
+import { RuleConverter } from "../converter";
+
+export const convertUseDefaultTypeParameter: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@typescript-eslint/use-default-type-parameter",
+            },
+        ],
+    };
+};


### PR DESCRIPTION
…Created a test for use-default-type-parameter, add the rule to rules/converters.ts, and created it it's own converter file.

<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ x] Addresses an existing issue: fixes #188
-   [ x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
It was pretty straightforward as its one of the few rule tslint rules that doesn't have an eslint equivalent which ban-ts-ignore is pretty much the same so I just followed the way it was laid out to a t. Um, tangent, there appears to be something wrong with your e2e and I briefly looked at it but don't have much e2e testing experience. I can create and issue if you'd like.
<!-- Brief description of what is changed and how the code change does that. -->
