### PR TITLE
[Fixes #174] implement no-shadowed-variable converter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -69,6 +69,7 @@ import { convertNoReference } from "./converters/no-reference";
 import { convertNoRegexSpaces } from "./converters/no-regex-spaces";
 import { convertNoRequireImports } from "./converters/no-require-imports";
 import { convertNoReturnAwait } from "./converters/no-return-await";
+import { convertNoShadowedVariable } from "./converters/no-shadowed-variable";
 import { convertNoSparseArrays } from "./converters/no-sparse-arrays";
 import { convertNoStringLiteral } from "./converters/no-string-literal";
 import { convertNoStringThrow } from "./converters/no-string-throw";
@@ -186,6 +187,7 @@ export const converters = new Map([
     ["no-regex-spaces", convertNoRegexSpaces],
     ["no-require-imports", convertNoRequireImports],
     ["no-return-await", convertNoReturnAwait],
+    ["no-shadowed-variable", convertNoShadowedVariable],
     ["no-sparse-arrays", convertNoSparseArrays],
     ["no-string-literal", convertNoStringLiteral],
     ["no-string-throw", convertNoStringThrow],
@@ -237,7 +239,6 @@ export const converters = new Map([
     // ["ban", convertBan], // no-restricted-properties
     // ["import-blacklist", convertImportBlacklist], // no-restricted-imports
     // ["no-duplicate-variable", convertNoDuplicateVariable], // no-redeclare
-    // ["no-shadowed-variable", convertNoShadowedVariable], // no-shadow
     // ["no-unused-expression", convertNoUnusedExpression], // no-unused-expressions
     // ["space-within-parens", convertSpaceWithinParens], // space-in-parens
     // ["variable-name", convertVariableName], // a bunch of rules...

--- a/src/rules/converters/no-shadowed-variable.ts
+++ b/src/rules/converters/no-shadowed-variable.ts
@@ -1,0 +1,49 @@
+import { RuleConverter } from "../converter";
+
+const SELECTIVE_DISABLE_NOTICE =
+    "ESLint does not support selectively disabling shadowed declaration checks " +
+    "depending on the type of declaration, so all kinds of declarations are checked.";
+
+const UNDERSCORE_DISABLE_NOTICE =
+    "ESLint does not support disabling shadowed variable checks based on " +
+    "whether their names start with underscore or not, please use 'allow' in eslint configuration to " +
+    "provide specific variable names you want to disable the rule for.";
+
+export const convertNoShadowedVariable: RuleConverter = tslintRule => {
+    const ruleArguments: { hoist: "all" | "never" }[] = [];
+    const notices: string[] = [];
+
+    if (tslintRule.ruleArguments.length === 0 || !(tslintRule.ruleArguments[0] instanceof Object)) {
+        ruleArguments.push({ hoist: "all" });
+    } else {
+        const config: Record<string, boolean> = tslintRule.ruleArguments[0];
+
+        if (config.underscore === false) {
+            notices.push(UNDERSCORE_DISABLE_NOTICE);
+        }
+
+        if (config.temporalDeadZone === false) {
+            ruleArguments.push({ hoist: "never" });
+        } else {
+            ruleArguments.push({ hoist: "all" });
+        }
+
+        const hasUnsupportedDisables = Object.entries(config).some(
+            ([key, value]) => value === false && key !== "underscore" && key !== "temporalDeadZone",
+        );
+
+        if (hasUnsupportedDisables) {
+            notices.push(SELECTIVE_DISABLE_NOTICE);
+        }
+    }
+
+    return {
+        rules: [
+            {
+                ...(notices.length > 0 && { notices }),
+                ...(ruleArguments.length > 0 && { ruleArguments }),
+                ruleName: "no-shadow",
+            },
+        ],
+    };
+};

--- a/src/rules/converters/tests/no-shadowed-variable.test.ts
+++ b/src/rules/converters/tests/no-shadowed-variable.test.ts
@@ -1,0 +1,85 @@
+import { convertNoShadowedVariable } from "../no-shadowed-variable";
+
+describe(convertNoShadowedVariable, () => {
+    test("conversion without parameter", () => {
+        const result = convertNoShadowedVariable({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ hoist: "all" }],
+                    ruleName: "no-shadow",
+                },
+            ],
+        });
+    });
+
+    test("conversion with non-object parameter", () => {
+        const result = convertNoShadowedVariable({
+            ruleArguments: ["will-be-ignored"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ hoist: "all" }],
+                    ruleName: "no-shadow",
+                },
+            ],
+        });
+    });
+
+    test("conversion with empty parameter object", () => {
+        const result = convertNoShadowedVariable({
+            ruleArguments: [{}],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ hoist: "all" }],
+                    ruleName: "no-shadow",
+                },
+            ],
+        });
+    });
+
+    test("conversion with disabled 'temporalDeadZone'", () => {
+        const result = convertNoShadowedVariable({
+            ruleArguments: [{ temporalDeadZone: false }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ hoist: "never" }],
+                    ruleName: "no-shadow",
+                },
+            ],
+        });
+    });
+
+    test("conversion with disabled declaration types", () => {
+        const result = convertNoShadowedVariable({
+            ruleArguments: [{ class: false, underscore: false }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [
+                        "ESLint does not support disabling shadowed variable checks based on " +
+                            "whether their names start with underscore or not, please use 'allow' in eslint configuration to " +
+                            "provide specific variable names you want to disable the rule for.",
+                        "ESLint does not support selectively disabling shadowed declaration checks " +
+                            "depending on the type of declaration, so all kinds of declarations are checked.",
+                    ],
+                    ruleArguments: [{ hoist: "all" }],
+                    ruleName: "no-shadow",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #174 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

I added a converter between tslint's `no-shadowed-variable` rule and eslint's `no-shadow` rule. Tslint's `no-shadowed-variable`'s default behavior corresponds to eslint's `no-shadow` with the `hoist` option set to `all`. `no-shadow`'s `host` option can be switched to `never` when tslint's `no-shadowed-variable` has a configuration object with `temporalDeadZone` set to `false`.
If `no-shadowed-variable` is configured to disable checking for `underscore`, a notice is shown explaining that eslint does not support disabling checking on whether a variable name starts with underscore or not and asking users to use `no-shadow`'s `allow` config instead, if they want to disable checking for specific variables.
Finally, if `no-shadowed-variable` is set to disable checks for anything other than `temporalDeadZone` and `underscore` (e.g. `class`, `function`, etc.), a notice saying that eslint doesn't support disabling checks based on declaration type is shown.

Reference:

- [no-shadowed-variable](https://palantir.github.io/tslint/rules/no-shadowed-variable/)
- [no-shadow](https://eslint.org/docs/rules/no-shadow)

