### PR TITLE
added semicolon rule converter plus tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,11 +2,8 @@
     "files.exclude": {
         "**/*.d.ts": true,
         "**/*.js.map": true,
-        "**/*.js": {
-            "when": "$(basename).ts"
-        }
+        "**/*.js": { "when": "$(basename).ts" }
     },
     "prettier.ignorePath": ".prettierignore",
-    "typescript.tsdk": "node_modules/typescript/lib",
-    "editor.tabSize": 4
+    "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,11 @@
     "files.exclude": {
         "**/*.d.ts": true,
         "**/*.js.map": true,
-        "**/*.js": { "when": "$(basename).ts" }
+        "**/*.js": {
+            "when": "$(basename).ts"
+        }
     },
     "prettier.ignorePath": ".prettierignore",
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "editor.tabSize": 4
 }

--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -99,7 +99,7 @@ import { convertPreferTemplate } from "./converters/prefer-template";
 import { convertPromiseFunctionAsync } from "./converters/promise-function-async";
 import { convertRadix } from "./converters/radix";
 import { convertRestrictPlusOperands } from "./converters/restrict-plus-operands";
-import { semicolon } from "./converters/semicolon";
+import { convertSemicolon } from "./converters/semicolon";
 import { convertSpaceBeforeFunctionParen } from "./converters/space-before-function-paren";
 import { convertSwitchDefault } from "./converters/switch-default";
 import { convertTypedefWhitespace } from "./converters/typedef-whitespace";
@@ -218,7 +218,7 @@ export const converters = new Map([
     ["quotemark", convertQuotemark],
     ["radix", convertRadix],
     ["restrict-plus-operands", convertRestrictPlusOperands],
-    ["semicolon", semicolon],
+    ["semicolon", convertSemicolon],
     ["space-before-function-paren", convertSpaceBeforeFunctionParen],
     ["switch-default", convertSwitchDefault],
     ["triple-equals", convertTripleEquals],

--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -99,6 +99,7 @@ import { convertPreferTemplate } from "./converters/prefer-template";
 import { convertPromiseFunctionAsync } from "./converters/promise-function-async";
 import { convertRadix } from "./converters/radix";
 import { convertRestrictPlusOperands } from "./converters/restrict-plus-operands";
+import { semicolon } from "./converters/semicolon";
 import { convertSpaceBeforeFunctionParen } from "./converters/space-before-function-paren";
 import { convertSwitchDefault } from "./converters/switch-default";
 import { convertTypedefWhitespace } from "./converters/typedef-whitespace";
@@ -217,6 +218,7 @@ export const converters = new Map([
     ["quotemark", convertQuotemark],
     ["radix", convertRadix],
     ["restrict-plus-operands", convertRestrictPlusOperands],
+    ["semicolon", semicolon],
     ["space-before-function-paren", convertSpaceBeforeFunctionParen],
     ["switch-default", convertSwitchDefault],
     ["triple-equals", convertTripleEquals],

--- a/src/rules/converters/semicolon.ts
+++ b/src/rules/converters/semicolon.ts
@@ -1,0 +1,53 @@
+import { RuleConverter } from "../converter";
+
+// for reference, see here
+// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/semi.md
+export const semicolon: RuleConverter = tslintRule => {
+    const getMultilineDelimiter = (strategy: "always" | "never") => {
+        if (strategy === "always") {
+            return "semi";
+        } else {
+            return "none";
+        }
+    };
+
+    const ignoreInterfaces = tslintRule.ruleArguments.includes("ignore-interfaces");
+    const strictBoundClassMethods = tslintRule.ruleArguments.includes("strict-bound-class-methods");
+
+    return {
+        rules: [
+            {
+                ruleName: "@typescript-eslint/semi",
+                ruleArguments: [tslintRule.ruleArguments[0]],
+            },
+            ...(ignoreInterfaces
+                ? []
+                : [
+                      {
+                          ruleName: "@typescript-estlint/member-delimiter-style",
+                          ruleArguments: [
+                              "error",
+                              {
+                                  multiline: {
+                                      delimiter: getMultilineDelimiter(tslintRule.ruleArguments[0]),
+                                      requireLast: true,
+                                  },
+                                  singleline: {
+                                      delimiter: "semi",
+                                      requireLast: false,
+                                  },
+                              },
+                          ],
+                      },
+                  ]),
+        ],
+        notices: [
+            "You must disable the base rule (semi) as it can report incorrect errors.",
+            ...(strictBoundClassMethods
+                ? [
+                      "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
+                  ]
+                : []),
+        ],
+    };
+};

--- a/src/rules/converters/semicolon.ts
+++ b/src/rules/converters/semicolon.ts
@@ -6,9 +6,8 @@ export const semicolon: RuleConverter = tslintRule => {
     const getMultilineDelimiter = (strategy: "always" | "never") => {
         if (strategy === "always") {
             return "semi";
-        } else {
-            return "none";
         }
+        return "none";
     };
 
     const ignoreInterfaces = tslintRule.ruleArguments.includes("ignore-interfaces");

--- a/src/rules/converters/semicolon.ts
+++ b/src/rules/converters/semicolon.ts
@@ -2,7 +2,7 @@ import { RuleConverter } from "../converter";
 
 // for reference, see here
 // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/semi.md
-export const semicolon: RuleConverter = tslintRule => {
+export const convertSemicolon: RuleConverter = tslintRule => {
     const getMultilineDelimiter = (strategy: "always" | "never") => {
         if (strategy === "always") {
             return "semi";

--- a/src/rules/converters/semicolon.ts
+++ b/src/rules/converters/semicolon.ts
@@ -1,7 +1,5 @@
 import { RuleConverter } from "../converter";
 
-// for reference, see here
-// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/semi.md
 export const convertSemicolon: RuleConverter = tslintRule => {
     const getMultilineDelimiter = (strategy: "always" | "never") => {
         if (strategy === "always") {
@@ -23,7 +21,7 @@ export const convertSemicolon: RuleConverter = tslintRule => {
                 ? []
                 : [
                       {
-                          ruleName: "@typescript-estlint/member-delimiter-style",
+                          ruleName: "@typescript-eslint/member-delimiter-style",
                           ruleArguments: [
                               "error",
                               {
@@ -40,13 +38,11 @@ export const convertSemicolon: RuleConverter = tslintRule => {
                       },
                   ]),
         ],
-        notices: [
-            "You must disable the base rule (semi) as it can report incorrect errors.",
-            ...(strictBoundClassMethods
-                ? [
-                      "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
-                  ]
-                : []),
-        ],
+
+        notices: strictBoundClassMethods
+            ? [
+                  "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
+              ]
+            : undefined,
     };
 };

--- a/src/rules/converters/tests/semicolon.test.ts
+++ b/src/rules/converters/tests/semicolon.test.ts
@@ -1,0 +1,207 @@
+import { semicolon } from "../semicolon";
+
+describe("semicolon", () => {
+    test("conversion with always", () => {
+        const result = semicolon({
+            ruleArguments: ["always"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/semi",
+                    ruleArguments: ["always"],
+                },
+                {
+                    ruleName: "@typescript-estlint/member-delimiter-style",
+                    ruleArguments: [
+                        "error",
+                        {
+                            multiline: {
+                                delimiter: "semi",
+                                requireLast: true,
+                            },
+                            singleline: {
+                                delimiter: "semi",
+                                requireLast: false,
+                            },
+                        },
+                    ],
+                },
+            ],
+            notices: ["You must disable the base rule (semi) as it can report incorrect errors."],
+        });
+    });
+
+    test("conversion with never", () => {
+        const result = semicolon({
+            ruleArguments: ["never"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/semi",
+                    ruleArguments: ["never"],
+                },
+                {
+                    ruleName: "@typescript-estlint/member-delimiter-style",
+                    ruleArguments: [
+                        "error",
+                        {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: true,
+                            },
+                            singleline: {
+                                delimiter: "semi",
+                                requireLast: false,
+                            },
+                        },
+                    ],
+                },
+            ],
+            notices: ["You must disable the base rule (semi) as it can report incorrect errors."],
+        });
+    });
+
+    test("conversion with always and strict bound class methods", () => {
+        const result = semicolon({
+            ruleArguments: ["always", "strict-bound-class-methods"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/semi",
+                    ruleArguments: ["always"],
+                },
+                {
+                    ruleName: "@typescript-estlint/member-delimiter-style",
+                    ruleArguments: [
+                        "error",
+                        {
+                            multiline: {
+                                delimiter: "semi",
+                                requireLast: true,
+                            },
+                            singleline: {
+                                delimiter: "semi",
+                                requireLast: false,
+                            },
+                        },
+                    ],
+                },
+            ],
+            notices: [
+                "You must disable the base rule (semi) as it can report incorrect errors.",
+                "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
+            ],
+        });
+    });
+
+    test("conversion with never and strict bound class methods", () => {
+        const result = semicolon({
+            ruleArguments: ["never", "strict-bound-class-methods"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/semi",
+                    ruleArguments: ["never"],
+                },
+                {
+                    ruleName: "@typescript-estlint/member-delimiter-style",
+                    ruleArguments: [
+                        "error",
+                        {
+                            multiline: {
+                                delimiter: "none",
+                                requireLast: true,
+                            },
+                            singleline: {
+                                delimiter: "semi",
+                                requireLast: false,
+                            },
+                        },
+                    ],
+                },
+            ],
+            notices: [
+                "You must disable the base rule (semi) as it can report incorrect errors.",
+                "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
+            ],
+        });
+    });
+
+    test("conversion with always and ignore interfaces", () => {
+        const result = semicolon({
+            ruleArguments: ["always", "ignore-interfaces"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/semi",
+                    ruleArguments: ["always"],
+                },
+            ],
+            notices: ["You must disable the base rule (semi) as it can report incorrect errors."],
+        });
+    });
+
+    test("conversion with never and ignore interfaces", () => {
+        const result = semicolon({
+            ruleArguments: ["never", "ignore-interfaces"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/semi",
+                    ruleArguments: ["never"],
+                },
+            ],
+            notices: ["You must disable the base rule (semi) as it can report incorrect errors."],
+        });
+    });
+
+    test("conversion with always, strict bound class methods and ignore interfaces", () => {
+        const result = semicolon({
+            ruleArguments: ["always", "ignore-interfaces", "strict-bound-class-methods"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/semi",
+                    ruleArguments: ["always"],
+                },
+            ],
+            notices: [
+                "You must disable the base rule (semi) as it can report incorrect errors.",
+                "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
+            ],
+        });
+    });
+
+    test("conversion with always, strict bound class methods and ignore interfaces", () => {
+        const result = semicolon({
+            ruleArguments: ["never", "ignore-interfaces", "strict-bound-class-methods"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/semi",
+                    ruleArguments: ["never"],
+                },
+            ],
+            notices: [
+                "You must disable the base rule (semi) as it can report incorrect errors.",
+                "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
+            ],
+        });
+    });
+});

--- a/src/rules/converters/tests/semicolon.test.ts
+++ b/src/rules/converters/tests/semicolon.test.ts
@@ -13,7 +13,7 @@ describe(convertSemicolon, () => {
                     ruleArguments: ["always"],
                 },
                 {
-                    ruleName: "@typescript-estlint/member-delimiter-style",
+                    ruleName: "@typescript-eslint/member-delimiter-style",
                     ruleArguments: [
                         "error",
                         {
@@ -29,7 +29,6 @@ describe(convertSemicolon, () => {
                     ],
                 },
             ],
-            notices: ["You must disable the base rule (semi) as it can report incorrect errors."],
         });
     });
 
@@ -45,7 +44,7 @@ describe(convertSemicolon, () => {
                     ruleArguments: ["never"],
                 },
                 {
-                    ruleName: "@typescript-estlint/member-delimiter-style",
+                    ruleName: "@typescript-eslint/member-delimiter-style",
                     ruleArguments: [
                         "error",
                         {
@@ -61,7 +60,6 @@ describe(convertSemicolon, () => {
                     ],
                 },
             ],
-            notices: ["You must disable the base rule (semi) as it can report incorrect errors."],
         });
     });
 
@@ -77,7 +75,7 @@ describe(convertSemicolon, () => {
                     ruleArguments: ["always"],
                 },
                 {
-                    ruleName: "@typescript-estlint/member-delimiter-style",
+                    ruleName: "@typescript-eslint/member-delimiter-style",
                     ruleArguments: [
                         "error",
                         {
@@ -94,7 +92,6 @@ describe(convertSemicolon, () => {
                 },
             ],
             notices: [
-                "You must disable the base rule (semi) as it can report incorrect errors.",
                 "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
             ],
         });
@@ -112,7 +109,7 @@ describe(convertSemicolon, () => {
                     ruleArguments: ["never"],
                 },
                 {
-                    ruleName: "@typescript-estlint/member-delimiter-style",
+                    ruleName: "@typescript-eslint/member-delimiter-style",
                     ruleArguments: [
                         "error",
                         {
@@ -129,7 +126,6 @@ describe(convertSemicolon, () => {
                 },
             ],
             notices: [
-                "You must disable the base rule (semi) as it can report incorrect errors.",
                 "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
             ],
         });
@@ -147,7 +143,6 @@ describe(convertSemicolon, () => {
                     ruleArguments: ["always"],
                 },
             ],
-            notices: ["You must disable the base rule (semi) as it can report incorrect errors."],
         });
     });
 
@@ -163,7 +158,6 @@ describe(convertSemicolon, () => {
                     ruleArguments: ["never"],
                 },
             ],
-            notices: ["You must disable the base rule (semi) as it can report incorrect errors."],
         });
     });
 
@@ -180,7 +174,6 @@ describe(convertSemicolon, () => {
                 },
             ],
             notices: [
-                "You must disable the base rule (semi) as it can report incorrect errors.",
                 "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
             ],
         });
@@ -199,7 +192,6 @@ describe(convertSemicolon, () => {
                 },
             ],
             notices: [
-                "You must disable the base rule (semi) as it can report incorrect errors.",
                 "Option `strict-bound-class-methods` was found, there is no exact equivalent yet supported.",
             ],
         });

--- a/src/rules/converters/tests/semicolon.test.ts
+++ b/src/rules/converters/tests/semicolon.test.ts
@@ -1,8 +1,8 @@
-import { semicolon } from "../semicolon";
+import { convertSemicolon } from "../semicolon";
 
-describe("semicolon", () => {
+describe(convertSemicolon, () => {
     test("conversion with always", () => {
-        const result = semicolon({
+        const result = convertSemicolon({
             ruleArguments: ["always"],
         });
 
@@ -34,7 +34,7 @@ describe("semicolon", () => {
     });
 
     test("conversion with never", () => {
-        const result = semicolon({
+        const result = convertSemicolon({
             ruleArguments: ["never"],
         });
 
@@ -66,7 +66,7 @@ describe("semicolon", () => {
     });
 
     test("conversion with always and strict bound class methods", () => {
-        const result = semicolon({
+        const result = convertSemicolon({
             ruleArguments: ["always", "strict-bound-class-methods"],
         });
 
@@ -101,7 +101,7 @@ describe("semicolon", () => {
     });
 
     test("conversion with never and strict bound class methods", () => {
-        const result = semicolon({
+        const result = convertSemicolon({
             ruleArguments: ["never", "strict-bound-class-methods"],
         });
 
@@ -136,7 +136,7 @@ describe("semicolon", () => {
     });
 
     test("conversion with always and ignore interfaces", () => {
-        const result = semicolon({
+        const result = convertSemicolon({
             ruleArguments: ["always", "ignore-interfaces"],
         });
 
@@ -152,7 +152,7 @@ describe("semicolon", () => {
     });
 
     test("conversion with never and ignore interfaces", () => {
-        const result = semicolon({
+        const result = convertSemicolon({
             ruleArguments: ["never", "ignore-interfaces"],
         });
 
@@ -168,7 +168,7 @@ describe("semicolon", () => {
     });
 
     test("conversion with always, strict bound class methods and ignore interfaces", () => {
-        const result = semicolon({
+        const result = convertSemicolon({
             ruleArguments: ["always", "ignore-interfaces", "strict-bound-class-methods"],
         });
 
@@ -187,7 +187,7 @@ describe("semicolon", () => {
     });
 
     test("conversion with always, strict bound class methods and ignore interfaces", () => {
-        const result = semicolon({
+        const result = convertSemicolon({
             ruleArguments: ["never", "ignore-interfaces", "strict-bound-class-methods"],
         });
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #183
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

### Issue related changes

- added a rule converter for `semicolon` in the TSLint ruleset
- added proper handling for the options that come with the rule itself
- added tests to make sure that the right comparative rules are being output
- added a couple of notices so that the user is informed of things not automatically converted
