### PR TITLE
added a converter for use-default-type-parameter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -107,6 +107,7 @@ import { convertTypeofCompare } from "./converters/typeof-compare";
 import { convertUnifiedSignatures } from "./converters/unified-signatures";
 import { convertUnnecessaryBind } from "./converters/unnecessary-bind";
 import { convertUnnecessaryConstructor } from "./converters/unnecessary-constructor";
+import { convertUseDefaultTypeParameter } from "./converters/use-default-type-parameter";
 import { convertUseIsnan } from "./converters/use-isnan";
 import { convertQuotemark } from "./converters/quotemark";
 import { convertTripleEquals } from "./converters/triple-equals";
@@ -226,6 +227,7 @@ export const converters = new Map([
     ["unified-signatures", convertUnifiedSignatures],
     ["unnecessary-bind", convertUnnecessaryBind],
     ["unnecessary-constructor", convertUnnecessaryConstructor],
+    ["use-default-type-parameter", convertUseDefaultTypeParameter],
     ["use-isnan", convertUseIsnan],
 
     // These converters are all for rules that need more complex option conversions.

--- a/src/rules/converters/tests/use-default-type-parameter.test.ts
+++ b/src/rules/converters/tests/use-default-type-parameter.test.ts
@@ -1,0 +1,17 @@
+import { convertUseDefaultTypeParameter } from "../use-default-type-parameter";
+
+describe(convertUseDefaultTypeParameter, () => {
+    test("conversion without arguments", () => {
+        const result = convertUseDefaultTypeParameter({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/no-unnecessary-type-arguments",
+                },
+            ],
+        });
+    });
+});

--- a/src/rules/converters/use-default-type-parameter.ts
+++ b/src/rules/converters/use-default-type-parameter.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../converter";
+
+// See here for reference
+// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
+export const convertUseDefaultTypeParameter: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@typescript-eslint/no-unnecessary-type-arguments",
+            },
+        ],
+    };
+};

--- a/src/rules/converters/use-default-type-parameter.ts
+++ b/src/rules/converters/use-default-type-parameter.ts
@@ -1,7 +1,5 @@
 import { RuleConverter } from "../converter";
 
-// See here for reference
-// https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unnecessary-type-arguments.md
 export const convertUseDefaultTypeParameter: RuleConverter = () => {
     return {
         rules: [


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #188
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

- added a converter for `use-default-type-parameter` from the TSLint ruleset
