### PR TITLE
set vscode editor tab width to be 4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,11 @@
     "files.exclude": {
         "**/*.d.ts": true,
         "**/*.js.map": true,
-        "**/*.js": { "when": "$(basename).ts" }
+        "**/*.js": {
+            "when": "$(basename).ts"
+        }
     },
     "prettier.ignorePath": ".prettierignore",
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "editor.tabSize": 4
 }


### PR DESCRIPTION

<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

I don't really have an issue that this solves but I saw this as someone who's editor wants to indent everything using 2 spaces. 

### Quality of life changes

- added `editor.tabSize` to the workspace config for VSCode to account for contributors who are using 2 spaces. Prettier will fix the end result on save but it's nice to have when actually editing a file 😄 