### PR TITLE
Add no-caller and no-eval mergers

### DIFF
--- a/src/rules/mergers.ts
+++ b/src/rules/mergers.ts
@@ -1,7 +1,11 @@
 import { mergeBanTypes } from "./mergers/ban-types";
+import { mergeNoCaller } from "./mergers/no-caller";
+import { mergeNoEval } from "./mergers/no-eval";
 import { mergeNoUnnecessaryTypeAssertion } from "./mergers/no-unnecessary-type-assertion";
 
 export const mergers = new Map([
     ["@typescript-eslint/ban-types", mergeBanTypes],
     ["@typescript-eslint/no-unnecessary-type-assertion", mergeNoUnnecessaryTypeAssertion],
+    ["no-caller", mergeNoCaller],
+    ["no-eval", mergeNoEval],
 ]);

--- a/src/rules/mergers/no-caller.ts
+++ b/src/rules/mergers/no-caller.ts
@@ -1,0 +1,6 @@
+import { RuleMerger } from "../merger";
+
+export const mergeNoCaller: RuleMerger = () => {
+    // no-caller rule does not accept any options
+    return [];
+};

--- a/src/rules/mergers/no-eval.ts
+++ b/src/rules/mergers/no-eval.ts
@@ -1,0 +1,28 @@
+import { RuleMerger } from "../merger";
+
+export const mergeNoEval: RuleMerger = (existingOptions, newOptions) => {
+    if (existingOptions === undefined && newOptions === undefined) {
+        return [];
+    }
+
+    let allowIndirect = true;
+
+    for (const options of [existingOptions, newOptions]) {
+        if (
+            options === undefined ||
+            options.length === 0 ||
+            options[0].allowIndirect === undefined
+        ) {
+            allowIndirect = false;
+            break;
+        }
+
+        allowIndirect = allowIndirect && options[0].allowIndirect;
+    }
+
+    return [
+        {
+            ...(allowIndirect && { allowIndirect }),
+        },
+    ];
+};

--- a/src/rules/mergers/tests/no-caller.test.ts
+++ b/src/rules/mergers/tests/no-caller.test.ts
@@ -1,0 +1,9 @@
+import { mergeNoCaller } from "../no-caller";
+
+describe(mergeNoCaller, () => {
+    test("neither options existing", () => {
+        const result = mergeNoCaller(undefined, undefined);
+
+        expect(result).toEqual([]);
+    });
+});

--- a/src/rules/mergers/tests/no-eval.test.ts
+++ b/src/rules/mergers/tests/no-eval.test.ts
@@ -1,0 +1,45 @@
+import { mergeNoEval } from "../no-eval";
+
+describe(mergeNoEval, () => {
+    test("neither options existing", () => {
+        const result = mergeNoEval(undefined, undefined);
+
+        expect(result).toEqual([]);
+    });
+
+    test("neither allowIndirect existing", () => {
+        const result = mergeNoEval([{}], [{}]);
+
+        expect(result).toEqual([{}]);
+    });
+
+    test("original allowIndirect existing", () => {
+        const result = mergeNoEval([{ allowIndirect: true }], [{}]);
+
+        expect(result).toEqual([{}]);
+    });
+
+    test("new allowIndirect existing", () => {
+        const result = mergeNoEval([{}], [{ allowIndirect: true }]);
+
+        expect(result).toEqual([{}]);
+    });
+
+    test("original allowIndirect is false but new allowIndirect is true", () => {
+        const result = mergeNoEval([{ allowIndirect: false }], [{ allowIndirect: true }]);
+
+        expect(result).toEqual([{}]);
+    });
+
+    test("original allowIndirect is true but new allowIndirect is false", () => {
+        const result = mergeNoEval([{ allowIndirect: true }], [{ allowIndirect: false }]);
+
+        expect(result).toEqual([{}]);
+    });
+
+    test("both allowIndirect are true", () => {
+        const result = mergeNoEval([{ allowIndirect: true }], [{ allowIndirect: true }]);
+
+        expect(result).toEqual([{ allowIndirect: true }]);
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #135
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
- `no-caller` is quite straightforward as it has no options.
- For `no-eval` I only set `allowIndirect: true` if both original and new options have it set to true, because otherwise at least one of the original TSLint rules would have flagged indirect `eval` calls out.

ESLint Docs
- [`no-caller`](https://eslint.org/docs/rules/no-caller)
- [`no-eval`](https://eslint.org/docs/rules/no-eval)