### PR TITLE
Added missing no-implicit-dependencies converter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -53,6 +53,7 @@ import { convertNoExplicitAny } from "./converters/no-explicit-any";
 import { convertNoFloatingPromises } from "./converters/no-floating-promises";
 import { convertNoForIn } from "./converters/no-for-in";
 import { convertNoForInArray } from "./converters/no-for-in-array";
+import { convertNoImplicitDependencies } from "./converters/no-implicit-dependencies";
 import { convertNoInferrableTypes } from "./converters/no-inferrable-types";
 import { convertNoInternalModule } from "./converters/no-internal-module";
 import { convertNoInvalidRegexp } from "./converters/no-invalid-regexp";
@@ -180,6 +181,7 @@ export const converters = new Map([
     ["no-eval", convertNoEval],
     ["no-floating-promises", convertNoFloatingPromises],
     ["no-for-in-array", convertNoForInArray],
+    ["no-implicit-dependencies", convertNoImplicitDependencies],
     ["no-for-in", convertNoForIn],
     ["no-inferrable-types", convertNoInferrableTypes],
     ["no-internal-module", convertNoInternalModule],

--- a/src/rules/converters/no-implicit-dependencies.ts
+++ b/src/rules/converters/no-implicit-dependencies.ts
@@ -8,6 +8,8 @@ export const convertNoImplicitDependencies: RuleConverter = tslintRule => {
             ruleArgs.push({ devDependencies: false });
         } else if (element === "optional") {
             ruleArgs.push({ optionalDependencies: false });
+        } else {
+            ruleArgs.push({ devDependencies: element });
         }
     });
     return {

--- a/src/rules/converters/no-implicit-dependencies.ts
+++ b/src/rules/converters/no-implicit-dependencies.ts
@@ -1,7 +1,10 @@
 import { RuleConverter } from "../converter";
 
 export const convertNoImplicitDependencies: RuleConverter = tslintRule => {
-    const ruleArgs = [];
+    const ruleArgs: {
+        [eslintOption in "devDependencies" | "optionalDependencies"]?: boolean
+    }[] = [];
+    const notices: string[] = [];
 
     tslintRule.ruleArguments.forEach(element => {
         if (element === "dev") {
@@ -9,15 +12,19 @@ export const convertNoImplicitDependencies: RuleConverter = tslintRule => {
         } else if (element === "optional") {
             ruleArgs.push({ optionalDependencies: false });
         } else {
-            ruleArgs.push({ devDependencies: element });
+            notices.push("ESLint does not support whitelisting modules");
         }
     });
+
     return {
         rules: [
             {
                 ruleName: "import/no-extraneous-dependencies",
                 ...(ruleArgs.length > 0 && { ruleArguments: ruleArgs }),
+                ...(notices.length > 0 && { notices }),
             },
         ],
+
+        plugins: ["import"],
     };
 };

--- a/src/rules/converters/no-implicit-dependencies.ts
+++ b/src/rules/converters/no-implicit-dependencies.ts
@@ -1,0 +1,21 @@
+import { RuleConverter } from "../converter";
+
+export const convertNoImplicitDependencies: RuleConverter = tslintRule => {
+    const ruleArgs = [];
+
+    tslintRule.ruleArguments.forEach(element => {
+        if (element === "dev") {
+            ruleArgs.push({ devDependencies: false });
+        } else if (element === "optional") {
+            ruleArgs.push({ optionalDependencies: false });
+        }
+    });
+    return {
+        rules: [
+            {
+                ruleName: "import/no-extraneous-dependencies",
+                ...(ruleArgs.length > 0 && { ruleArguments: ruleArgs }),
+            },
+        ],
+    };
+};

--- a/src/rules/converters/tests/no-implicit-dependencies.test.ts
+++ b/src/rules/converters/tests/no-implicit-dependencies.test.ts
@@ -12,6 +12,7 @@ describe(convertNoImplicitDependencies, () => {
                     ruleName: "import/no-extraneous-dependencies",
                 },
             ],
+            plugins: ["import"],
         });
     });
 
@@ -27,6 +28,7 @@ describe(convertNoImplicitDependencies, () => {
                     ruleName: "import/no-extraneous-dependencies",
                 },
             ],
+            plugins: ["import"],
         });
     });
 
@@ -42,6 +44,7 @@ describe(convertNoImplicitDependencies, () => {
                     ruleName: "import/no-extraneous-dependencies",
                 },
             ],
+            plugins: ["import"],
         });
     });
 
@@ -57,6 +60,7 @@ describe(convertNoImplicitDependencies, () => {
                     ruleName: "import/no-extraneous-dependencies",
                 },
             ],
+            plugins: ["import"],
         });
     });
 
@@ -68,10 +72,11 @@ describe(convertNoImplicitDependencies, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: [{ devDependencies: ["src", "app"] }],
+                    notices: ["ESLint does not support whitelisting modules"],
                     ruleName: "import/no-extraneous-dependencies",
                 },
             ],
+            plugins: ["import"],
         });
     });
 });

--- a/src/rules/converters/tests/no-implicit-dependencies.test.ts
+++ b/src/rules/converters/tests/no-implicit-dependencies.test.ts
@@ -59,4 +59,19 @@ describe(convertNoImplicitDependencies, () => {
             ],
         });
     });
+
+    test("conversion with whitelisted folders argument", () => {
+        const result = convertNoImplicitDependencies({
+            ruleArguments: [["src", "app"]],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ devDependencies: ["src", "app"] }],
+                    ruleName: "import/no-extraneous-dependencies",
+                },
+            ],
+        });
+    });
 });

--- a/src/rules/converters/tests/no-implicit-dependencies.test.ts
+++ b/src/rules/converters/tests/no-implicit-dependencies.test.ts
@@ -1,0 +1,62 @@
+import { convertNoImplicitDependencies } from "../no-implicit-dependencies";
+
+describe(convertNoImplicitDependencies, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoImplicitDependencies({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "import/no-extraneous-dependencies",
+                },
+            ],
+        });
+    });
+
+    test("conversion with dev argument", () => {
+        const result = convertNoImplicitDependencies({
+            ruleArguments: ["dev"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ devDependencies: false }],
+                    ruleName: "import/no-extraneous-dependencies",
+                },
+            ],
+        });
+    });
+
+    test("conversion with optional argument", () => {
+        const result = convertNoImplicitDependencies({
+            ruleArguments: ["optional"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ optionalDependencies: false }],
+                    ruleName: "import/no-extraneous-dependencies",
+                },
+            ],
+        });
+    });
+
+    test("conversion with both dev and optional argument", () => {
+        const result = convertNoImplicitDependencies({
+            ruleArguments: ["dev", "optional"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ devDependencies: false }, { optionalDependencies: false }],
+                    ruleName: "import/no-extraneous-dependencies",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #171 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
Adds a missing rule converter for the no-implicit-dependencies rule.

Still not sure how to handle correctly the case when whitelist modules are given :
I saw [here](https://github.com/benmosher/eslint-plugin-import/blob/master/src/rules/no-extraneous-dependencies.js) that all (dev dep, peer dep, opt dep ...) accepts the whitelist array, but I added them only on devDep for the moment, as they are not mapped to specific category of deps on Tslint side.

Any thoughts on this @JoshuaKGoldberg 👋 
<!-- Brief description of what is changed and how the code change does that. -->
