### PR TITLE
Switched no-console output from blacklist to whitelist

### DIFF
--- a/src/rules/converters/no-console.ts
+++ b/src/rules/converters/no-console.ts
@@ -5,7 +5,14 @@ export const convertNoConsole: RuleConverter = tslintRule => {
         rules: [
             {
                 ...(tslintRule.ruleArguments.length !== 0 && {
-                    ruleArguments: [{ allow: tslintRule.ruleArguments }],
+                    notices: ["Custom console methods, if they exist, will no longer be allowed."],
+                    ruleArguments: [
+                        {
+                            allow: Object.keys(console).filter(
+                                method => !tslintRule.ruleArguments.includes(method),
+                            ),
+                        },
+                    ],
                 }),
                 ruleName: "no-console",
             },

--- a/src/rules/converters/tests/no-console.test.ts
+++ b/src/rules/converters/tests/no-console.test.ts
@@ -1,5 +1,15 @@
 import { convertNoConsole } from "../no-console";
 
+const consoleKeysExcluding = (...keys: string[]) => {
+    const knownConsoleKeys = new Set(Object.keys(console));
+
+    for (const key of keys) {
+        knownConsoleKeys.delete(key);
+    }
+
+    return Array.from(knownConsoleKeys);
+};
+
 describe(convertNoConsole, () => {
     test("conversion without arguments", () => {
         const result = convertNoConsole({
@@ -23,7 +33,8 @@ describe(convertNoConsole, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: [{ allow: ["info", "log"] }],
+                    notices: ["Custom console methods, if they exist, will no longer be allowed."],
+                    ruleArguments: [{ allow: consoleKeysExcluding("info", "log") }],
                     ruleName: "no-console",
                 },
             ],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #234
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Uses `Object.keys(console)` to figure out the previously allowed console methods.