### PR TITLE
Output optimizing for unsupported rules

### DIFF
--- a/src/reporting/reportConversionResults.test.ts
+++ b/src/reporting/reportConversionResults.test.ts
@@ -167,7 +167,7 @@ describe("reportConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            "👀 1 rule does not yet have an ESLint equivalent; defaulting to eslint-plugin-tslint. 👀",
+            "👀 1 rule does not yet have an ESLint equivalent (see generated log file); defaulting to eslint-plugin-tslint for these rules. 👀",
         );
         expectEqualWrites(
             logger.info.write,

--- a/src/reporting/reportConversionResults.test.ts
+++ b/src/reporting/reportConversionResults.test.ts
@@ -200,7 +200,7 @@ describe("reportConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            "👀 2 rules do not yet have ESLint equivalents; defaulting to eslint-plugin-tslint. 👀",
+            "👀 2 rules do not yet have ESLint equivalents (see generated log file); defaulting to eslint-plugin-tslint for these rules. 👀",
         );
         expectEqualWrites(
             logger.info.write,

--- a/src/reporting/reportConversionResults.ts
+++ b/src/reporting/reportConversionResults.ts
@@ -62,7 +62,7 @@ const logMissingRules = (missing: TSLintRuleOptions[], logger: Logger) => {
                 : " rules do not yet have ESLint equivalents",
         ),
     );
-    logger.stdout.write(chalk.yellow("; defaulting to eslint-plugin-tslint."));
+    logger.stdout.write(chalk.yellow(" (see generated log file); defaulting to eslint-plugin-tslint for these rules."));
     logger.stdout.write(chalk.yellowBright(` 👀${EOL}`));
 
     logger.info.write(


### PR DESCRIPTION
## PR Checklist
-   [x] Addresses an existing issue: ref #233
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Mention the logfile and that tslint is now used for some rules, not all.