### PR TITLE
Add strict-boolean-expression converter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -112,6 +112,7 @@ import { convertRestrictPlusOperands } from "./converters/restrict-plus-operands
 import { convertSemicolon } from "./converters/semicolon";
 import { convertSpaceBeforeFunctionParen } from "./converters/space-before-function-paren";
 import { convertSpaceWithinParens } from "./converters/space-within-parens";
+import { convertStrictBooleanExpressions } from "./converters/strict-boolean-expressions";
 import { convertSwitchDefault } from "./converters/switch-default";
 import { convertTripleEquals } from "./converters/triple-equals";
 import { convertTypedefWhitespace } from "./converters/typedef-whitespace";
@@ -242,6 +243,7 @@ export const converters = new Map([
     ["semicolon", convertSemicolon],
     ["space-before-function-paren", convertSpaceBeforeFunctionParen],
     ["space-within-parens", convertSpaceWithinParens],
+    ["strict-boolean-expressions", convertStrictBooleanExpressions],
     ["switch-default", convertSwitchDefault],
     ["triple-equals", convertTripleEquals],
     ["type-literal-delimiter", convertTypeLiteralDelimiter],
@@ -262,10 +264,6 @@ export const converters = new Map([
     // TSLint core rules:
     // ["ban", convertBan], // no-restricted-properties
     // ["import-blacklist", convertImportBlacklist], // no-restricted-imports
-    // ["no-duplicate-variable", convertNoDuplicateVariable], // no-redeclare
-    // ["no-void-expression", convertNoVoidExpression], // (no exact equivalent)
-    // ["quotemark", convertQuotemark], // quotes
-    // ["triple-equals", convertTripleEquals], // eqeqeq
 
     // tslint-microsoft-contrib rules:
     // ["max-func-body-length", convertMaxFuncBodyLength],

--- a/src/rules/converters/strict-boolean-expressions.ts
+++ b/src/rules/converters/strict-boolean-expressions.ts
@@ -1,0 +1,37 @@
+import { RuleConverter } from "../converter";
+
+export const ForbiddenOtherNonBooleanTypes =
+    "String, number, enum and mixed union types are forbidden.";
+
+export const convertStrictBooleanExpressions: RuleConverter = tslintRule => {
+    const notices: string[] = [];
+    const ruleArguments: { [key: string]: boolean } = {};
+
+    if (tslintRule.ruleArguments.length >= 2 || tslintRule.ruleArguments[0] === true) {
+        notices.push(ForbiddenOtherNonBooleanTypes);
+        tslintRule.ruleArguments.forEach(ruleArgument => {
+            switch (ruleArgument) {
+                case "allow-undefined-union":
+                case "allow-boolean-or-undefined":
+                case "allow-null-union":
+                    ruleArguments["allowNullable"] = true;
+                    break;
+                case "ignore-rhs":
+                    ruleArguments["ignoreRhs"] = true;
+                    break;
+                default:
+                    break;
+            }
+        });
+    }
+
+    return {
+        rules: [
+            {
+                ruleName: "@typescript-eslint/strict-boolean-expressions",
+                ruleArguments: Object.keys(ruleArguments).length !== 0 ? [ruleArguments] : [],
+                notices,
+            },
+        ],
+    };
+};

--- a/src/rules/converters/strict-boolean-expressions.ts
+++ b/src/rules/converters/strict-boolean-expressions.ts
@@ -1,7 +1,7 @@
 import { RuleConverter } from "../converter";
 
 export const ForbiddenOtherNonBooleanTypes =
-    "String, number, enum and mixed union types are forbidden.";
+    "String, number, enum, and mixed union types are now forbidden.";
 
 export const convertStrictBooleanExpressions: RuleConverter = tslintRule => {
     const notices: string[] = [];

--- a/src/rules/converters/tests/strict-boolean-expressions.test.ts
+++ b/src/rules/converters/tests/strict-boolean-expressions.test.ts
@@ -1,0 +1,109 @@
+import {
+    convertStrictBooleanExpressions,
+    ForbiddenOtherNonBooleanTypes,
+} from "../strict-boolean-expressions";
+
+describe(convertStrictBooleanExpressions, () => {
+    test("conversion without arguments", () => {
+        const result = convertStrictBooleanExpressions({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/strict-boolean-expressions",
+                    ruleArguments: [],
+                    notices: [],
+                },
+            ],
+        });
+    });
+
+    test("conversion with true argument", () => {
+        const result = convertStrictBooleanExpressions({
+            ruleArguments: [true],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/strict-boolean-expressions",
+                    ruleArguments: [],
+                    notices: [ForbiddenOtherNonBooleanTypes],
+                },
+            ],
+        });
+    });
+
+    test("conversion with allow-undefined-union argument", () => {
+        const result = convertStrictBooleanExpressions({
+            ruleArguments: [true, "allow-undefined-union"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/strict-boolean-expressions",
+                    ruleArguments: [
+                        {
+                            allowNullable: true,
+                        },
+                    ],
+                    notices: [ForbiddenOtherNonBooleanTypes],
+                },
+            ],
+        });
+    });
+
+    test("conversion with ignore-rhs argument", () => {
+        const result = convertStrictBooleanExpressions({
+            ruleArguments: [true, "ignore-rhs"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/strict-boolean-expressions",
+                    ruleArguments: [
+                        {
+                            ignoreRhs: true,
+                        },
+                    ],
+                    notices: [ForbiddenOtherNonBooleanTypes],
+                },
+            ],
+        });
+    });
+
+    test("conversion with all arguments", () => {
+        const result = convertStrictBooleanExpressions({
+            ruleArguments: [
+                true,
+                "allow-undefined-union",
+                "allow-boolean-or-undefined",
+                "allow-null-union",
+                "ignore-rhs",
+                "allow-string",
+                "allow-enum",
+                "allow-number",
+                "allow-mix",
+            ],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/strict-boolean-expressions",
+                    ruleArguments: [
+                        {
+                            allowNullable: true,
+                            ignoreRhs: true,
+                        },
+                    ],
+                    notices: [ForbiddenOtherNonBooleanTypes],
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #185
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

- Added a rule converter for `stric-boolean-expressions` in the TSLint ruleset.
- Added proper handling for the options that come with the rule itself.
- Added tests to make sure that the right comparative rules are being output.
- Added a notice so that the user is informed of things not automatically converted or covered.
- Remove comments at `converters` file of already solved converters.
