### PR TITLE
add no-import-side-effect converter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -54,6 +54,7 @@ import { convertNoFloatingPromises } from "./converters/no-floating-promises";
 import { convertNoForIn } from "./converters/no-for-in";
 import { convertNoForInArray } from "./converters/no-for-in-array";
 import { convertNoImplicitDependencies } from "./converters/no-implicit-dependencies";
+import { convertNoImportSideEffect } from "./converters/no-import-side-effect";
 import { convertNoInferrableTypes } from "./converters/no-inferrable-types";
 import { convertNoInternalModule } from "./converters/no-internal-module";
 import { convertNoInvalidRegexp } from "./converters/no-invalid-regexp";
@@ -184,6 +185,7 @@ export const converters = new Map([
     ["no-for-in-array", convertNoForInArray],
     ["no-implicit-dependencies", convertNoImplicitDependencies],
     ["no-for-in", convertNoForIn],
+    ["no-import-side-effect", convertNoImportSideEffect],
     ["no-inferrable-types", convertNoInferrableTypes],
     ["no-internal-module", convertNoInternalModule],
     ["no-invalid-regexp", convertNoInvalidRegexp],

--- a/src/rules/converters/no-import-side-effect.ts
+++ b/src/rules/converters/no-import-side-effect.ts
@@ -1,11 +1,9 @@
 import { RuleConverter } from "../converter";
 
 export const convertNoImportSideEffect: RuleConverter = tsLintRule => {
-    const rules = [];
     const notices = [];
 
     if (tsLintRule.ruleArguments.length > 0) {
-        rules.push({ allow: tsLintRule.ruleArguments[1]["ignore-module"] });
         notices.push(
             "ESLint's no-import-side-effect now accepts a glob pattern for ignores; you'll need to manually convert your ignore-module settings.",
         );
@@ -14,7 +12,7 @@ export const convertNoImportSideEffect: RuleConverter = tsLintRule => {
     return {
         rules: [
             {
-                ruleArguments: rules,
+                ruleArguments: [],
                 ruleName: "no-import-side-effect",
                 notices: notices,
             },

--- a/src/rules/converters/no-import-side-effect.ts
+++ b/src/rules/converters/no-import-side-effect.ts
@@ -1,0 +1,21 @@
+import { RuleConverter } from "../converter";
+
+export const convertNoImportSideEffect: RuleConverter = tsLintRule => {
+    const rules = [];
+    const notices = [];
+
+    if (tsLintRule.ruleArguments.length > 0) {
+        rules.push({ allow: tsLintRule.ruleArguments[1]["ignore-module"] });
+        notices.push("This now accepts a glob pattern, so your regex may need converted");
+    }
+
+    return {
+        rules: [
+            {
+                ruleArguments: rules,
+                ruleName: "no-import-side-effect",
+                notices: notices,
+            },
+        ],
+    };
+};

--- a/src/rules/converters/no-import-side-effect.ts
+++ b/src/rules/converters/no-import-side-effect.ts
@@ -6,7 +6,9 @@ export const convertNoImportSideEffect: RuleConverter = tsLintRule => {
 
     if (tsLintRule.ruleArguments.length > 0) {
         rules.push({ allow: tsLintRule.ruleArguments[1]["ignore-module"] });
-        notices.push("This now accepts a glob pattern, so your regex may need converted");
+        notices.push(
+            "ESLint's no-import-side-effect now accepts a glob pattern for ignores; you'll need to manually convert your ignore-module settings.",
+        );
     }
 
     return {

--- a/src/rules/converters/tests/no-import-side-effect.test.ts
+++ b/src/rules/converters/tests/no-import-side-effect.test.ts
@@ -1,0 +1,35 @@
+import { convertNoImportSideEffect } from "../no-import-side-effect";
+
+describe(convertNoImportSideEffect, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoImportSideEffect({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [],
+                    ruleName: "no-import-side-effect",
+                    notices: [],
+                },
+            ],
+        });
+    });
+
+    test("conversion with arguments", () => {
+        const result = convertNoImportSideEffect({
+            ruleArguments: [true, { "ignore-module": "(\\.html|\\.css)$" }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ allow: "(\\.html|\\.css)$" }],
+                    ruleName: "no-import-side-effect",
+                    notices: ["This now accepts a glob pattern, so your regex may need converted"],
+                },
+            ],
+        });
+    });
+});

--- a/src/rules/converters/tests/no-import-side-effect.test.ts
+++ b/src/rules/converters/tests/no-import-side-effect.test.ts
@@ -27,7 +27,9 @@ describe(convertNoImportSideEffect, () => {
                 {
                     ruleArguments: [{ allow: "(\\.html|\\.css)$" }],
                     ruleName: "no-import-side-effect",
-                    notices: ["This now accepts a glob pattern, so your regex may need converted"],
+                    notices: [
+                        "ESLint's no-import-side-effect now accepts a glob pattern for ignores; you'll need to manually convert your ignore-module settings.",
+                    ],
                 },
             ],
         });

--- a/src/rules/converters/tests/no-import-side-effect.test.ts
+++ b/src/rules/converters/tests/no-import-side-effect.test.ts
@@ -25,7 +25,7 @@ describe(convertNoImportSideEffect, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: [{ allow: "(\\.html|\\.css)$" }],
+                    ruleArguments: [],
                     ruleName: "no-import-side-effect",
                     notices: [
                         "ESLint's no-import-side-effect now accepts a glob pattern for ignores; you'll need to manually convert your ignore-module settings.",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #172
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

I added the converter to convert the rule to ESLint. I didn’t try and convert the reflex to glob syntax. I can explore that if you feel it would be valuable. 

<!-- Brief description of what is changed and how the code change does that. -->
