### PR TITLE
Add comment-format converter

### DIFF
--- a/src/rules/converters.ts
+++ b/src/rules/converters.ts
@@ -9,6 +9,7 @@ import { convertBanTypes } from "./converters/ban-types";
 import { convertBinaryExpressionOperandOrder } from "./converters/binary-expression-operand-order";
 import { convertCallableTypes } from "./converters/callable-types";
 import { convertClassName } from "./converters/class-name";
+import { convertCommentFormat } from "./converters/comment-format";
 import { convertCurly } from "./converters/curly";
 import { convertCyclomaticComplexity } from "./converters/cyclomatic-complexity";
 import { convertEofline } from "./converters/eofline";
@@ -139,6 +140,7 @@ export const converters = new Map([
     ["binary-expression-operand-order", convertBinaryExpressionOperandOrder],
     ["callable-types", convertCallableTypes],
     ["class-name", convertClassName],
+    ["comment-format", convertCommentFormat],
     ["curly", convertCurly],
     ["cyclomatic-complexity", convertCyclomaticComplexity],
     ["eofline", convertEofline],

--- a/src/rules/converters/comment-format.ts
+++ b/src/rules/converters/comment-format.ts
@@ -5,7 +5,6 @@ type CommentFormatOptions = {
     "ignore-pattern": string;
 };
 
-export const CheckTrailingLowercaseMessage = "Only first trailing comment can be configured.";
 export const CapitalizedIgnoreMessage = "Only accepts a single string pattern to be ignored.";
 
 export const convertCommentFormat: RuleConverter = tslintRule => {
@@ -16,7 +15,6 @@ export const convertCommentFormat: RuleConverter = tslintRule => {
     const hasCheckSpace = tslintRule.ruleArguments.includes("check-space");
     const hasCheckLowercase = tslintRule.ruleArguments.includes("check-lowercase");
     const hasCheckUppercase = tslintRule.ruleArguments.includes("check-uppercase");
-    const hasCheckTrailingLowercase = tslintRule.ruleArguments.includes("allow-trailing-lowercase");
 
     if (!hasCheckSpace) {
         spaceCommentRuleArguments.push("never");
@@ -28,14 +26,13 @@ export const convertCommentFormat: RuleConverter = tslintRule => {
         capitalizedRuleArguments.push("never");
     }
 
-    if (hasCheckTrailingLowercase) {
-        capitalizedNotices.push(CheckTrailingLowercaseMessage);
-    }
-
     if (typeof tslintRule.ruleArguments[tslintRule.ruleArguments.length - 1] === "object") {
         const objectArgument: CommentFormatOptions =
             tslintRule.ruleArguments[tslintRule.ruleArguments.length - 1];
-        if (objectArgument["ignore-words"] || objectArgument["ignore-pattern"]) {
+        if (
+            (objectArgument["ignore-words"] && objectArgument["ignore-words"].length) ||
+            objectArgument["ignore-pattern"]
+        ) {
             capitalizedNotices.push(CapitalizedIgnoreMessage);
         }
     }

--- a/src/rules/converters/comment-format.ts
+++ b/src/rules/converters/comment-format.ts
@@ -1,0 +1,56 @@
+import { RuleConverter } from "../converter";
+
+export const CheckTrailingLowercaseMessage: string =
+    "Only first trailing comment can be configured.";
+export const CapitalizedIgnoreMessage: string =
+    "Only accepts a single string pattern to be ignored.";
+
+export const convertCommentFormat: RuleConverter = tslintRule => {
+    const capitalizedRuleArguments: string[] = [];
+    const spaceCommentRuleArguments: string[] = [];
+    const capitalizedNotices: string[] = [];
+
+    const hasCheckSpace = tslintRule.ruleArguments.includes("check-space");
+    const hasCheckLowercase = tslintRule.ruleArguments.includes("check-lowercase");
+    const hasCheckUppercase = tslintRule.ruleArguments.includes("check-uppercase");
+    const hasCheckTrailingLowercase = tslintRule.ruleArguments.includes("allow-trailing-lowercase");
+
+    if (!hasCheckSpace) {
+        spaceCommentRuleArguments.push("never");
+    }
+
+    if (hasCheckUppercase) {
+        capitalizedRuleArguments.push("always");
+    } else if (hasCheckLowercase) {
+        capitalizedRuleArguments.push("never");
+    }
+
+    if (hasCheckTrailingLowercase) {
+        capitalizedNotices.push(CheckTrailingLowercaseMessage);
+    }
+
+    if (typeof tslintRule.ruleArguments[tslintRule.ruleArguments.length - 1] == "object") {
+        const objectArgument: Object =
+            tslintRule.ruleArguments[tslintRule.ruleArguments.length - 1];
+        if (
+            objectArgument.hasOwnProperty("ignore-words") ||
+            objectArgument.hasOwnProperty("ignore-pattern")
+        ) {
+            capitalizedNotices.push(CapitalizedIgnoreMessage);
+        }
+    }
+
+    return {
+        rules: [
+            {
+                ruleName: "capitalized-comments",
+                ruleArguments: capitalizedRuleArguments,
+                notices: capitalizedNotices,
+            },
+            {
+                ruleName: "spaced-comment",
+                ruleArguments: spaceCommentRuleArguments,
+            },
+        ],
+    };
+};

--- a/src/rules/converters/comment-format.ts
+++ b/src/rules/converters/comment-format.ts
@@ -1,9 +1,12 @@
 import { RuleConverter } from "../converter";
 
-export const CheckTrailingLowercaseMessage: string =
-    "Only first trailing comment can be configured.";
-export const CapitalizedIgnoreMessage: string =
-    "Only accepts a single string pattern to be ignored.";
+type CommentFormatOptions = {
+    "ignore-words": string[];
+    "ignore-pattern": string;
+};
+
+export const CheckTrailingLowercaseMessage = "Only first trailing comment can be configured.";
+export const CapitalizedIgnoreMessage = "Only accepts a single string pattern to be ignored.";
 
 export const convertCommentFormat: RuleConverter = tslintRule => {
     const capitalizedRuleArguments: string[] = [];
@@ -29,13 +32,10 @@ export const convertCommentFormat: RuleConverter = tslintRule => {
         capitalizedNotices.push(CheckTrailingLowercaseMessage);
     }
 
-    if (typeof tslintRule.ruleArguments[tslintRule.ruleArguments.length - 1] == "object") {
-        const objectArgument: Object =
+    if (typeof tslintRule.ruleArguments[tslintRule.ruleArguments.length - 1] === "object") {
+        const objectArgument: CommentFormatOptions =
             tslintRule.ruleArguments[tslintRule.ruleArguments.length - 1];
-        if (
-            objectArgument.hasOwnProperty("ignore-words") ||
-            objectArgument.hasOwnProperty("ignore-pattern")
-        ) {
+        if (objectArgument["ignore-words"] || objectArgument["ignore-pattern"]) {
             capitalizedNotices.push(CapitalizedIgnoreMessage);
         }
     }

--- a/src/rules/converters/tests/comment-format.test.ts
+++ b/src/rules/converters/tests/comment-format.test.ts
@@ -81,6 +81,26 @@ describe(convertCommentFormat, () => {
         });
     });
 
+    test("conversion with empty ignore-words argument", () => {
+        const result = convertCommentFormat({
+            ruleArguments: [{ "ignore-words": [] }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "capitalized-comments",
+                    ruleArguments: [],
+                    notices: [],
+                },
+                {
+                    ruleName: "spaced-comment",
+                    ruleArguments: ["never"],
+                },
+            ],
+        });
+    });
+
     test("conversion with ignore-words argument", () => {
         const result = convertCommentFormat({
             ruleArguments: [{ "ignore-words": ["TODO", "HACK"] }],

--- a/src/rules/converters/tests/comment-format.test.ts
+++ b/src/rules/converters/tests/comment-format.test.ts
@@ -1,0 +1,133 @@
+import {
+    convertCommentFormat,
+    CheckTrailingLowercaseMessage,
+    CapitalizedIgnoreMessage,
+} from "../comment-format";
+
+describe(convertCommentFormat, () => {
+    test("conversion without arguments", () => {
+        const result = convertCommentFormat({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "capitalized-comments",
+                    ruleArguments: [],
+                    notices: [],
+                },
+                {
+                    ruleName: "spaced-comment",
+                    ruleArguments: ["never"],
+                },
+            ],
+        });
+    });
+
+    test("conversion with check-space argument", () => {
+        const result = convertCommentFormat({
+            ruleArguments: ["check-space"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "capitalized-comments",
+                    ruleArguments: [],
+                    notices: [],
+                },
+                {
+                    ruleName: "spaced-comment",
+                    ruleArguments: [],
+                },
+            ],
+        });
+    });
+
+    test("conversion with check-lowercase arguments", () => {
+        const result = convertCommentFormat({
+            ruleArguments: ["check-lowercase"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "capitalized-comments",
+                    ruleArguments: ["never"],
+                    notices: [],
+                },
+                {
+                    ruleName: "spaced-comment",
+                    ruleArguments: ["never"],
+                },
+            ],
+        });
+    });
+
+    test("conversion with ignore-pattern argument", () => {
+        const result = convertCommentFormat({
+            ruleArguments: [{ "ignore-pattern": "STD\\w{2,3}\\b" }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "capitalized-comments",
+                    ruleArguments: [],
+                    notices: [CapitalizedIgnoreMessage],
+                },
+                {
+                    ruleName: "spaced-comment",
+                    ruleArguments: ["never"],
+                },
+            ],
+        });
+    });
+
+    test("conversion with ignore-words argument", () => {
+        const result = convertCommentFormat({
+            ruleArguments: [{ "ignore-words": ["TODO", "HACK"] }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "capitalized-comments",
+                    ruleArguments: [],
+                    notices: [CapitalizedIgnoreMessage],
+                },
+                {
+                    ruleName: "spaced-comment",
+                    ruleArguments: ["never"],
+                },
+            ],
+        });
+    });
+
+    test("conversion with all arguments", () => {
+        const result = convertCommentFormat({
+            ruleArguments: [
+                "check-space",
+                "check-lowercase",
+                "check-uppercase",
+                "allow-trailing-lowercase",
+                { "ignore-words": ["TODO", "HACK"], "ignore-pattern": "STD\\w{2,3}\\b" },
+            ],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "capitalized-comments",
+                    ruleArguments: ["always"],
+                    notices: [CheckTrailingLowercaseMessage, CapitalizedIgnoreMessage],
+                },
+                {
+                    ruleName: "spaced-comment",
+                    ruleArguments: [],
+                },
+            ],
+        });
+    });
+});

--- a/src/rules/converters/tests/comment-format.test.ts
+++ b/src/rules/converters/tests/comment-format.test.ts
@@ -1,8 +1,4 @@
-import {
-    convertCommentFormat,
-    CheckTrailingLowercaseMessage,
-    CapitalizedIgnoreMessage,
-} from "../comment-format";
+import { convertCommentFormat, CapitalizedIgnoreMessage } from "../comment-format";
 
 describe(convertCommentFormat, () => {
     test("conversion without arguments", () => {
@@ -121,7 +117,7 @@ describe(convertCommentFormat, () => {
                 {
                     ruleName: "capitalized-comments",
                     ruleArguments: ["always"],
-                    notices: [CheckTrailingLowercaseMessage, CapitalizedIgnoreMessage],
+                    notices: [CapitalizedIgnoreMessage],
                 },
                 {
                     ruleName: "spaced-comment",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Add missing `comment-format` converter as already being listed at [ROADMAP](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/ROADMAP.md)