### PR TITLE
Fix typescript-eslint rulename to no-reference converter

### DIFF
--- a/src/rules/converters/no-reference.ts
+++ b/src/rules/converters/no-reference.ts
@@ -4,7 +4,7 @@ export const convertNoReference: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "@typescript-eslint/no-triple-slash-reference",
+                ruleName: "@typescript-eslint/triple-slash-reference",
             },
         ],
     };

--- a/src/rules/converters/tests/no-reference.test.ts
+++ b/src/rules/converters/tests/no-reference.test.ts
@@ -9,7 +9,7 @@ describe(convertNoReference, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@typescript-eslint/no-triple-slash-reference",
+                    ruleName: "@typescript-eslint/triple-slash-reference",
                 },
             ],
         });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #241
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
Provide the correct rulename to the `no-reference` converter.

Also, it fixes one of the four rules as stated on #153.
