### PR TITLE
[Bugfix] Replace removed rules

### DIFF
--- a/src/rules/converters/interface-over-type-literal.ts
+++ b/src/rules/converters/interface-over-type-literal.ts
@@ -4,7 +4,7 @@ export const convertInterfaceOverTypeLiteral: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "@typescript-eslint/prefer-interface",
+                ruleName: "@typescript-eslint/consistent-type-definitions",
             },
         ],
     };

--- a/src/rules/converters/no-angle-bracket-type-assertion.ts
+++ b/src/rules/converters/no-angle-bracket-type-assertion.ts
@@ -4,7 +4,7 @@ export const convertNoAngleBracketTypeAssertion: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "@typescript-eslint/no-angle-bracket-type-assertion",
+                ruleName: "@typescript-eslint/consistent-type-assertions",
             },
         ],
     };

--- a/src/rules/converters/no-object-literal-type-assertion.ts
+++ b/src/rules/converters/no-object-literal-type-assertion.ts
@@ -4,7 +4,7 @@ export const convertNoObjectLiteralTypeAssertion: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "@typescript-eslint/no-object-literal-type-assertion",
+                ruleName: "@typescript-eslint/consistent-type-assertions",
             },
         ],
     };

--- a/src/rules/converters/tests/interface-over-type-literal.test.ts
+++ b/src/rules/converters/tests/interface-over-type-literal.test.ts
@@ -9,7 +9,7 @@ describe(convertInterfaceOverTypeLiteral, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@typescript-eslint/prefer-interface",
+                    ruleName: "@typescript-eslint/consistent-type-definitions",
                 },
             ],
         });

--- a/src/rules/converters/tests/no-angle-bracket-type-assertion.test.ts
+++ b/src/rules/converters/tests/no-angle-bracket-type-assertion.test.ts
@@ -9,7 +9,7 @@ describe(convertNoAngleBracketTypeAssertion, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@typescript-eslint/no-angle-bracket-type-assertion",
+                    ruleName: "@typescript-eslint/consistent-type-assertions",
                 },
             ],
         });

--- a/src/rules/converters/tests/no-object-literal-type-assertion.test.ts
+++ b/src/rules/converters/tests/no-object-literal-type-assertion.test.ts
@@ -9,7 +9,7 @@ describe(convertNoObjectLiteralTypeAssertion, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@typescript-eslint/no-object-literal-type-assertion",
+                    ruleName: "@typescript-eslint/consistent-type-assertions",
                 },
             ],
         });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #153
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
Fixes these rule converters:

- `@typescript-eslint/prefer-interface` is replaced by `@typescript-eslint/consistent-type-definitions`.
- `@typescript-eslint/no-object-literal-type-assertion` and `@typescript-eslint/no-angle-bracket-type-assertion` are combined in to one single rule `@typescript-eslint/consistent-type-assertions`

I am a bit worried about the `no-object-literal-type-assertion` one because it has one option called `allow-arguments` which can be set to true to allow type casting inside a function/class argument.

Check [TSLint rule](https://palantir.github.io/tslint/rules/no-object-literal-type-assertion/) and compare against [Typescript-ESLint](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-assertions.md) one.