### PR TITLE
Factor in 'raw' configurations on top of 'reported' ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6781,8 +6781,7 @@
         "strip-json-comments": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-            "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
-            "dev": true
+            "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
         },
         "supports-color": {
             "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dependencies": {
         "chalk": "2.4.2",
         "commander": "3.0.2",
+        "strip-json-comments": "^3.0.1",
         "tslint": "5.20.0",
         "typescript": "3.6.3"
     },

--- a/src/adapters/nativeImporter.ts
+++ b/src/adapters/nativeImporter.ts
@@ -1,4 +1,4 @@
-export type Importer = (moduleName: string) => unknown | Error;
+export type NativeImporter = (moduleName: string) => unknown | Error;
 
 export const nativeImporter = async (moduleName: string) => {
     try {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -45,6 +45,7 @@ const convertRulesDependencies = {
 
 const nativeImporterDependencies: ImporterDependencies = {
     fileSystem: fsFileSystem,
+    getCwd: () => process.cwd(),
     nativeImporter: nativeImporter,
 };
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,9 +1,9 @@
 import { EOL } from "os";
 
-import { nativeImporter } from "../adapters/importer";
-import { processLogger } from "../adapters/processLogger";
 import { childProcessExec } from "../adapters/childProcessExec";
 import { fsFileSystem } from "../adapters/fsFileSystem";
+import { nativeImporter } from "../adapters/nativeImporter";
+import { processLogger } from "../adapters/processLogger";
 import { bind } from "../binding";
 import { ConvertConfigDependencies, convertConfig } from "../conversion/convertConfig";
 import { removeExtendsDuplicatedRules } from "../creation/simplification/removeExtendsDuplicatedRules";
@@ -27,6 +27,7 @@ import { findPackagesConfiguration } from "../input/findPackagesConfiguration";
 import { findESLintConfiguration } from "../input/findESLintConfiguration";
 import { findTSLintConfiguration } from "../input/findTSLintConfiguration";
 import { findTypeScriptConfiguration } from "../input/findTypeScriptConfiguration";
+import { importer, ImporterDependencies } from "../input/importer";
 import { mergeLintConfigurations } from "../input/mergeLintConfigurations";
 import {
     reportConversionResults,
@@ -42,8 +43,16 @@ const convertRulesDependencies = {
     mergers,
 };
 
+const nativeImporterDependencies: ImporterDependencies = {
+    fileSystem: fsFileSystem,
+    nativeImporter: nativeImporter,
+};
+
+const boundImporter = bind(importer, nativeImporterDependencies);
+
 const findConfigurationDependencies = {
     exec: childProcessExec,
+    importer: boundImporter,
 };
 
 const findOriginalConfigurationsDependencies: FindOriginalConfigurationsDependencies = {
@@ -59,7 +68,7 @@ const reportConversionResultsDependencies: ReportConversionResultsDependencies =
 };
 
 const retrieveExtendsValuesDependencies: RetrieveExtendsValuesDependencies = {
-    importer: nativeImporter,
+    importer: boundImporter,
 };
 
 const simplifyPackageRulesDependencies: SimplifyPackageRulesDependencies = {

--- a/src/conversion/convertConfig.test.ts
+++ b/src/conversion/convertConfig.test.ts
@@ -21,8 +21,11 @@ const createStubDependencies = (
 
 const createStubOriginalConfigurationsData = () => ({
     tslint: {
-        rules: [],
-        rulesDirectory: [],
+        full: {
+            rules: [],
+            rulesDirectory: [],
+        },
+        raw: {},
     },
 });
 

--- a/src/conversion/convertConfig.ts
+++ b/src/conversion/convertConfig.ts
@@ -30,14 +30,14 @@ export const convertConfig = async (
 
     // 2. TSLint rules are converted into their ESLint configurations
     const ruleConversionResults = dependencies.convertRules(
-        originalConfigurations.data.tslint.rules,
+        originalConfigurations.data.tslint.full.rules,
     );
 
     // 3. ESLint configurations are simplified based on extended ESLint presets
     const simplifiedConfiguration = {
         ...ruleConversionResults,
         ...(await dependencies.simplifyPackageRules(
-            originalConfigurations.data.eslint,
+            originalConfigurations.data.eslint && originalConfigurations.data.eslint.full,
             ruleConversionResults,
         )),
     };

--- a/src/conversion/convertConfig.ts
+++ b/src/conversion/convertConfig.ts
@@ -37,7 +37,7 @@ export const convertConfig = async (
     const simplifiedConfiguration = {
         ...ruleConversionResults,
         ...(await dependencies.simplifyPackageRules(
-            originalConfigurations.data.eslint && originalConfigurations.data.eslint.full,
+            originalConfigurations.data.eslint,
             ruleConversionResults,
         )),
     };

--- a/src/creation/eslint/createEnv.ts
+++ b/src/creation/eslint/createEnv.ts
@@ -1,9 +1,9 @@
-import { OriginalConfigurations } from "../../input/findOriginalConfigurations";
+import { AllOriginalConfigurations } from "../../input/findOriginalConfigurations";
 
 export const createEnv = ({
     packages,
     typescript,
-}: Pick<OriginalConfigurations, "packages" | "typescript">) => {
+}: Pick<AllOriginalConfigurations, "packages" | "typescript">) => {
     const browser =
         typescript === undefined ||
         typescript.compilerOptions.lib === undefined ||

--- a/src/creation/formatting/formatters/formatJsOutput.ts
+++ b/src/creation/formatting/formatters/formatJsOutput.ts
@@ -1,4 +1,7 @@
 import { EOL } from "os";
 
-export const formatJsOutput = (configuration: unknown) =>
-    `module.exports = ${JSON.stringify(configuration, undefined, 4)};${EOL}`;
+import { withKeysSorted } from "./withKeysSorted";
+
+export const formatJsOutput = (configuration: any) => {
+    return `module.exports = ${JSON.stringify(withKeysSorted(configuration), undefined, 4)};${EOL}`;
+};

--- a/src/creation/formatting/formatters/formatJsonOutput.ts
+++ b/src/creation/formatting/formatters/formatJsonOutput.ts
@@ -1,8 +1,7 @@
 import { EOL } from "os";
 
-export const formatJsonOutput = (configuration: any) => {
-    const keys = Object.keys(configuration).sort();
-    const sortedConfiguration = Object.fromEntries(keys.map(key => [key, configuration[key]]));
+import { withKeysSorted } from "./withKeysSorted";
 
-    return `${JSON.stringify(sortedConfiguration, undefined, 4)}${EOL}`;
+export const formatJsonOutput = (configuration: any) => {
+    return `${JSON.stringify(withKeysSorted(configuration), undefined, 4)}${EOL}`;
 };

--- a/src/creation/formatting/formatters/formatJsonOutput.ts
+++ b/src/creation/formatting/formatters/formatJsonOutput.ts
@@ -1,4 +1,8 @@
 import { EOL } from "os";
 
-export const formatJsonOutput = (configuration: unknown) =>
-    `${JSON.stringify(configuration, undefined, 4)}${EOL}`;
+export const formatJsonOutput = (configuration: any) => {
+    const keys = Object.keys(configuration).sort();
+    const sortedConfiguration = Object.fromEntries(keys.map(key => [key, configuration[key]]));
+
+    return `${JSON.stringify(sortedConfiguration, undefined, 4)}${EOL}`;
+};

--- a/src/creation/formatting/formatters/withKeysSorted.ts
+++ b/src/creation/formatting/formatters/withKeysSorted.ts
@@ -1,0 +1,7 @@
+export const withKeysSorted = (input: any) => {
+    return Object.fromEntries(
+        Object.keys(input)
+            .sort((a, b) => a.localeCompare(b))
+            .map(key => [key, input[key]]),
+    );
+};

--- a/src/creation/simplification/simplifyPackageRules.test.ts
+++ b/src/creation/simplification/simplifyPackageRules.test.ts
@@ -8,6 +8,14 @@ const createStubDependencies = () => ({
     retrieveExtendsValues: jest.fn(),
 });
 
+const createStubESLintConfiguration = (fullExtends: string | string[]) => ({
+    full: {
+        env: {},
+        extends: fullExtends,
+        rules: {},
+    },
+});
+
 describe("simplifyPackageRules", () => {
     it("returns the conversion results directly when there is no loaded eslint configuration", async () => {
         // Arrange
@@ -26,29 +34,10 @@ describe("simplifyPackageRules", () => {
         expect(simplifiedResults).toBe(ruleConversionResults);
     });
 
-    it("returns the conversion results directly when the eslint configuration doesn't extend", async () => {
-        // Arrange
-        const dependencies = createStubDependencies();
-        const eslint = {};
-        const ruleConversionResults = createEmptyConversionResults();
-
-        // Act
-        const simplifiedResults = await simplifyPackageRules(
-            dependencies,
-            eslint,
-            ruleConversionResults,
-        );
-
-        // Assert
-        expect(simplifiedResults).toBe(ruleConversionResults);
-    });
-
     it("returns the conversion results directly when the eslint configuration has an empty extends", async () => {
         // Arrange
         const dependencies = createStubDependencies();
-        const eslint = {
-            extends: [],
-        };
+        const eslint = createStubESLintConfiguration([]);
         const ruleConversionResults = createEmptyConversionResults();
 
         // Act
@@ -82,9 +71,7 @@ describe("simplifyPackageRules", () => {
                 importedExtensions: [],
             }),
         };
-        const eslint = {
-            extends: ["extension-name"],
-        };
+        const eslint = createStubESLintConfiguration(["extension-name"]);
         const ruleConversionResults = createEmptyConversionResults();
 
         // Act

--- a/src/creation/simplification/simplifyPackageRules.ts
+++ b/src/creation/simplification/simplifyPackageRules.ts
@@ -3,6 +3,7 @@ import { RuleConversionResults } from "../../rules/convertRules";
 import { removeExtendsDuplicatedRules } from "./removeExtendsDuplicatedRules";
 import { retrieveExtendsValues } from "./retrieveExtendsValues";
 import { ESLintConfiguration } from "../../input/findESLintConfiguration";
+import { OriginalConfigurations } from "../../input/findOriginalConfigurations";
 
 export type SimplifyPackageRulesDependencies = {
     removeExtendsDuplicatedRules: typeof removeExtendsDuplicatedRules;
@@ -13,15 +14,15 @@ export type SimplifiedRuleConversionResults = Pick<RuleConversionResults, "conve
 
 export const simplifyPackageRules = async (
     dependencies: SimplifyPackageRulesDependencies,
-    eslint: Partial<ESLintConfiguration> | undefined,
+    eslint: Pick<OriginalConfigurations<ESLintConfiguration>, "full"> | undefined,
     ruleConversionResults: SimplifiedRuleConversionResults,
 ): Promise<SimplifiedRuleConversionResults> => {
-    if (eslint === undefined || eslint.extends === undefined || eslint.extends.length === 0) {
+    if (eslint === undefined || eslint.full.extends.length === 0) {
         return ruleConversionResults;
     }
 
     const { configurationErrors, importedExtensions } = await dependencies.retrieveExtendsValues(
-        eslint.extends,
+        eslint.full.extends,
     );
 
     const converted = dependencies.removeExtendsDuplicatedRules(

--- a/src/creation/writeConversionResults.test.ts
+++ b/src/creation/writeConversionResults.test.ts
@@ -1,12 +1,15 @@
 import { createEmptyConversionResults } from "../conversion/conversionResults.stubs";
 import { writeConversionResults } from "./writeConversionResults";
-import { OriginalConfigurations } from "../input/findOriginalConfigurations";
+import { AllOriginalConfigurations } from "../input/findOriginalConfigurations";
 import { formatJsonOutput } from "./formatting/formatters/formatJsonOutput";
 
-const createStubOriginalConfigurations = (overrides: Partial<OriginalConfigurations> = {}) => ({
+const createStubOriginalConfigurations = (overrides: Partial<AllOriginalConfigurations> = {}) => ({
     tslint: {
-        rulesDirectory: [],
-        rules: {},
+        full: {
+            rulesDirectory: [],
+            rules: {},
+        },
+        raw: {},
     },
     ...overrides,
 });
@@ -14,9 +17,7 @@ const createStubOriginalConfigurations = (overrides: Partial<OriginalConfigurati
 describe("writeConversionResults", () => {
     it("excludes the tslint plugin when there are no missing rules", async () => {
         // Arrange
-        const conversionResults = createEmptyConversionResults({
-            converted: new Map(),
-        });
+        const conversionResults = createEmptyConversionResults();
         const fileSystem = { writeFile: jest.fn().mockReturnValue(Promise.resolve()) };
 
         // Act
@@ -50,7 +51,6 @@ describe("writeConversionResults", () => {
     it("includes typescript-eslint plugin settings when there are missing rules", async () => {
         // Arrange
         const conversionResults = createEmptyConversionResults({
-            converted: new Map(),
             missing: [
                 {
                     ruleArguments: [],
@@ -100,16 +100,17 @@ describe("writeConversionResults", () => {
 
     it("includes the original eslint configuration when it exists", async () => {
         // Arrange
-        const conversionResults = createEmptyConversionResults({
-            converted: new Map(),
-        });
+        const conversionResults = createEmptyConversionResults();
         const eslint = {
-            env: {},
-            extends: [],
-            globals: {
-                Promise: true,
+            full: {
+                env: {},
+                extends: [],
+                globals: {
+                    Promise: true,
+                },
+                rules: {},
             },
-            rules: {},
+            raw: {},
         };
         const originalConfigurations = createStubOriginalConfigurations({
             eslint,
@@ -128,11 +129,64 @@ describe("writeConversionResults", () => {
         expect(fileSystem.writeFile).toHaveBeenLastCalledWith(
             ".eslintrc.json",
             formatJsonOutput({
-                ...eslint,
                 env: {
                     browser: true,
                     es6: true,
                     node: true,
+                },
+                extends: [],
+                rules: {},
+                parser: "@typescript-eslint/parser",
+                parserOptions: {
+                    project: "tsconfig.json",
+                    sourceType: "module",
+                },
+                plugins: ["@typescript-eslint"],
+            }),
+        );
+    });
+
+    it("includes raw globals when they exist", async () => {
+        // Arrange
+        const conversionResults = createEmptyConversionResults();
+        const eslint = {
+            full: {
+                env: {},
+                extends: [],
+                rules: {},
+            },
+            raw: {
+                globals: {
+                    Promise: true,
+                },
+            },
+        };
+        const originalConfigurations = createStubOriginalConfigurations({
+            eslint,
+        });
+        const fileSystem = { writeFile: jest.fn().mockReturnValue(Promise.resolve()) };
+
+        // Act
+        await writeConversionResults(
+            { fileSystem },
+            ".eslintrc.json",
+            conversionResults,
+            originalConfigurations,
+        );
+
+        // Assert
+        expect(fileSystem.writeFile).toHaveBeenLastCalledWith(
+            ".eslintrc.json",
+            formatJsonOutput({
+                env: {
+                    browser: true,
+                    es6: true,
+                    node: true,
+                },
+                extends: [],
+                rules: {},
+                globals: {
+                    Promise: true,
                 },
                 parser: "@typescript-eslint/parser",
                 parserOptions: {
@@ -140,7 +194,6 @@ describe("writeConversionResults", () => {
                     sourceType: "module",
                 },
                 plugins: ["@typescript-eslint"],
-                rules: {},
             }),
         );
     });

--- a/src/input/findESLintConfiguration.ts
+++ b/src/input/findESLintConfiguration.ts
@@ -42,7 +42,7 @@ export const findESLintConfiguration = async (
 ): Promise<OriginalConfigurations<ESLintConfiguration> | Error> => {
     const filePath = rawSettings.eslint || rawSettings.config;
     const [rawConfiguration, reportedConfiguration] = await Promise.all([
-        findRawConfiguration<Partial<ESLintConfiguration>>(dependencies.importer, filePath, {
+        findRawConfiguration<ESLintConfiguration>(dependencies.importer, filePath, {
             extends: [],
         }),
         findReportedConfiguration<Partial<ESLintConfiguration>>(
@@ -60,17 +60,15 @@ export const findESLintConfiguration = async (
         return reportedConfiguration;
     }
 
+    const extensions = [rawConfiguration.extends, [reportedConfiguration.extends || []]].flat(
+        Infinity,
+    );
+
     return {
         full: {
             ...defaultESLintConfiguration,
             ...reportedConfiguration,
-            extends: Array.from(
-                new Set(
-                    [[rawConfiguration.extends || []], [reportedConfiguration.extends || []]].flat(
-                        Infinity,
-                    ),
-                ),
-            ),
+            extends: Array.from(new Set(extensions)),
         },
         raw: rawConfiguration,
     };

--- a/src/input/findESLintConfiguration.ts
+++ b/src/input/findESLintConfiguration.ts
@@ -1,12 +1,16 @@
+import { Exec } from "../adapters/exec";
+import { SansDependencies } from "../binding";
 import { ESLintRuleSeverity } from "../rules/types";
 import { TSLintToESLintSettings } from "../types";
-import { findConfiguration, FindConfigurationDependencies } from "./findConfiguration";
+import { findRawConfiguration } from "./findRawConfiguration";
+import { findReportedConfiguration } from "./findReportedConfiguration";
+import { OriginalConfigurations } from "./findOriginalConfigurations";
+import { importer } from "./importer";
 
 export type ESLintConfiguration = {
-    env: {
-        [i: string]: boolean;
-    };
+    env: Record<string, boolean>;
     extends: string | string[];
+    globals?: Record<string, boolean>;
     rules: ESLintConfigurationRules;
 };
 
@@ -27,20 +31,47 @@ const defaultESLintConfiguration = {
     rules: {},
 };
 
-export const findESLintConfiguration = async (
-    dependencies: FindConfigurationDependencies,
-    rawSettings: Pick<TSLintToESLintSettings, "config" | "eslint">,
-): Promise<ESLintConfiguration | Error> => {
-    const rawConfiguration = await findConfiguration<ESLintConfiguration>(
-        dependencies.exec,
-        "eslint --print-config",
-        rawSettings.eslint || rawSettings.config,
-    );
+export type FindESLintConfigurationDependencies = {
+    exec: Exec;
+    importer: SansDependencies<typeof importer>;
+};
 
-    return rawConfiguration instanceof Error
-        ? rawConfiguration
-        : {
-              ...defaultESLintConfiguration,
-              ...rawConfiguration,
-          };
+export const findESLintConfiguration = async (
+    dependencies: FindESLintConfigurationDependencies,
+    rawSettings: Pick<TSLintToESLintSettings, "config" | "eslint">,
+): Promise<OriginalConfigurations<ESLintConfiguration> | Error> => {
+    const filePath = rawSettings.eslint || rawSettings.config;
+    const [rawConfiguration, reportedConfiguration] = await Promise.all([
+        findRawConfiguration<Partial<ESLintConfiguration>>(dependencies.importer, filePath, {
+            extends: [],
+        }),
+        findReportedConfiguration<Partial<ESLintConfiguration>>(
+            dependencies.exec,
+            "eslint --print-config",
+            filePath,
+        ),
+    ]);
+
+    if (rawConfiguration instanceof Error) {
+        return rawConfiguration;
+    }
+
+    if (reportedConfiguration instanceof Error) {
+        return reportedConfiguration;
+    }
+
+    return {
+        full: {
+            ...defaultESLintConfiguration,
+            ...reportedConfiguration,
+            extends: Array.from(
+                new Set(
+                    [[rawConfiguration.extends || []], [reportedConfiguration.extends || []]].flat(
+                        Infinity,
+                    ),
+                ),
+            ),
+        },
+        raw: rawConfiguration,
+    };
 };

--- a/src/input/findOriginalConfigurations.ts
+++ b/src/input/findOriginalConfigurations.ts
@@ -17,8 +17,18 @@ export type FindOriginalConfigurationsDependencies = {
     mergeLintConfigurations: typeof mergeLintConfigurations;
 };
 
+/**
+ * Both found configurations for a particular linter.
+ */
 export type OriginalConfigurations<Configuration> = {
+    /**
+     * Settings reported by the linter's native --print-config equivalent.
+     */
     full: Configuration;
+
+    /**
+     * Raw import results from `import`ing the configuration file.
+     */
     raw: Partial<Configuration>;
 };
 

--- a/src/input/findOriginalConfigurations.ts
+++ b/src/input/findOriginalConfigurations.ts
@@ -17,17 +17,22 @@ export type FindOriginalConfigurationsDependencies = {
     mergeLintConfigurations: typeof mergeLintConfigurations;
 };
 
-export type OriginalConfigurations = {
-    eslint?: ESLintConfiguration;
+export type OriginalConfigurations<Configuration> = {
+    full: Configuration;
+    raw: Partial<Configuration>;
+};
+
+export type AllOriginalConfigurations = {
+    eslint?: OriginalConfigurations<ESLintConfiguration>;
     packages?: PackagesConfiguration;
-    tslint: TSLintConfiguration;
+    tslint: OriginalConfigurations<TSLintConfiguration>;
     typescript?: TypeScriptConfiguration;
 };
 
 export const findOriginalConfigurations = async (
     dependencies: FindOriginalConfigurationsDependencies,
     rawSettings: TSLintToESLintSettings,
-): Promise<ResultWithDataStatus<OriginalConfigurations>> => {
+): Promise<ResultWithDataStatus<AllOriginalConfigurations>> => {
     // Simultaneously search for all required configuration types
     const [eslint, packages, tslint, typescript] = await Promise.all([
         dependencies.findESLintConfiguration(rawSettings),

--- a/src/input/findPackagesConfiguration.ts
+++ b/src/input/findPackagesConfiguration.ts
@@ -1,4 +1,7 @@
-import { findConfiguration, FindConfigurationDependencies } from "./findConfiguration";
+import {
+    findReportedConfiguration,
+    FindReportedConfigurationDependencies,
+} from "./findReportedConfiguration";
 
 export type PackagesConfiguration = {
     dependencies: {
@@ -15,10 +18,10 @@ const defaultPackagesConfiguration = {
 };
 
 export const findPackagesConfiguration = async (
-    dependencies: FindConfigurationDependencies,
+    dependencies: FindReportedConfigurationDependencies,
     config: string | undefined,
 ): Promise<PackagesConfiguration | Error> => {
-    const rawConfiguration = await findConfiguration<PackagesConfiguration>(
+    const rawConfiguration = await findReportedConfiguration<PackagesConfiguration>(
         dependencies.exec,
         "cat",
         config || "./package.json",

--- a/src/input/findRawConfiguration.ts
+++ b/src/input/findRawConfiguration.ts
@@ -1,0 +1,21 @@
+import { SansDependencies } from "../binding";
+import { importer } from "./importer";
+
+export const findRawConfiguration = async <Configuration>(
+    fileImporter: SansDependencies<typeof importer>,
+    filePath: string,
+    defaults: Partial<Configuration>,
+): Promise<Configuration | Error> => {
+    let results: Configuration;
+
+    try {
+        results = (await fileImporter(filePath)) as Configuration;
+    } catch (error) {
+        return error;
+    }
+
+    return {
+        ...defaults,
+        ...results,
+    };
+};

--- a/src/input/findReportedConfiguration.test.ts
+++ b/src/input/findReportedConfiguration.test.ts
@@ -1,14 +1,14 @@
 import { createStubExec, createStubThrowingExec } from "../adapters/exec.stubs";
-import { findConfiguration } from "./findConfiguration";
+import { findReportedConfiguration } from "./findReportedConfiguration";
 
-describe("findConfiguration", () => {
+describe("findReportedConfiguration", () => {
     it("returns stderr as an error when the command fails with a zero exit code", async () => {
         // Arrange
         const stderr = "error";
         const exec = createStubExec({ stderr });
 
         // Act
-        const result = await findConfiguration(exec, "command", "sample.json");
+        const result = await findReportedConfiguration(exec, "command", "sample.json");
 
         // Assert
         expect(result).toEqual(new Error(stderr));
@@ -20,7 +20,7 @@ describe("findConfiguration", () => {
         const exec = createStubThrowingExec({ stderr });
 
         // Act
-        const result = await findConfiguration(exec, "command", "sample.json");
+        const result = await findReportedConfiguration(exec, "command", "sample.json");
 
         // Assert
         expect(result).toEqual(new Error(stderr));
@@ -32,7 +32,7 @@ describe("findConfiguration", () => {
         const exec = createStubExec({ stdout });
 
         // Act
-        const result = await findConfiguration(exec, "command", "sample.json");
+        const result = await findReportedConfiguration(exec, "command", "sample.json");
 
         // Assert
         expect(result).toEqual(
@@ -49,7 +49,7 @@ describe("findConfiguration", () => {
         const exec = createStubExec({ stdout });
 
         // Act
-        const result = await findConfiguration(exec, "command", "sample.json");
+        const result = await findReportedConfiguration(exec, "command", "sample.json");
 
         // Assert
         expect(result).toEqual({

--- a/src/input/findReportedConfiguration.ts
+++ b/src/input/findReportedConfiguration.ts
@@ -4,11 +4,11 @@ export type DeepPartial<T> = {
     [P in keyof T]: T[P] extends {} ? DeepPartial<T[P]> : T[P];
 };
 
-export type FindConfigurationDependencies = {
+export type FindReportedConfigurationDependencies = {
     exec: Exec;
 };
 
-export const findConfiguration = async <Configuration>(
+export const findReportedConfiguration = async <Configuration>(
     exec: Exec,
     command: string,
     config: string,

--- a/src/input/findTSLintConfiguration.ts
+++ b/src/input/findTSLintConfiguration.ts
@@ -1,44 +1,67 @@
+import { findRawConfiguration } from "./findRawConfiguration";
+import { findReportedConfiguration } from "./findReportedConfiguration";
 import { Exec } from "../adapters/exec";
-import { findConfiguration } from "./findConfiguration";
+import { OriginalConfigurations } from "./findOriginalConfigurations";
+import { SansDependencies } from "../binding";
+import { importer } from "./importer";
 
 export type TSLintConfiguration = {
+    extends?: string[];
     rulesDirectory: string[];
     rules: TSLintConfigurationRules;
 };
 
-export type TSLintConfigurationRules = {
-    [i: string]: any;
-};
+export type TSLintConfigurationRules = Record<string, any>;
 
 const defaultTSLintConfiguration = {
+    extends: [],
     rulesDirectory: [],
     rules: {},
 };
 
 export type FindTSLintConfigurationDependencies = {
     exec: Exec;
+    importer: SansDependencies<typeof importer>;
 };
 
 export const findTSLintConfiguration = async (
     dependencies: FindTSLintConfigurationDependencies,
     config: string | undefined,
-): Promise<TSLintConfiguration | Error> => {
-    const rawConfiguration = await findConfiguration<TSLintConfiguration>(
-        dependencies.exec,
-        "tslint --print-config",
-        config || "./tslint.json",
-    );
+): Promise<OriginalConfigurations<TSLintConfiguration> | Error> => {
+    const filePath = config || "./tslint.json";
+    const [rawConfiguration, reportedConfiguration] = await Promise.all([
+        findRawConfiguration<Partial<TSLintConfiguration>>(dependencies.importer, filePath, {
+            extends: [],
+        }),
+        findReportedConfiguration<TSLintConfiguration>(
+            dependencies.exec,
+            "tslint --print-config",
+            config || "./tslint.json",
+        ),
+    ]);
 
-    if (rawConfiguration instanceof Error) {
-        if (rawConfiguration.message.includes("unknown option `--print-config")) {
+    if (reportedConfiguration instanceof Error) {
+        if (reportedConfiguration.message.includes("unknown option `--print-config")) {
             return new Error("TSLint v5.18 required. Please update your version.");
         }
 
+        return reportedConfiguration;
+    }
+
+    if (rawConfiguration instanceof Error) {
         return rawConfiguration;
     }
 
     return {
-        ...defaultTSLintConfiguration,
-        ...rawConfiguration,
+        full: {
+            ...defaultTSLintConfiguration,
+            ...rawConfiguration,
+            extends: Array.from(
+                new Set(
+                    [[rawConfiguration.extends], [reportedConfiguration.extends]].flat(Infinity),
+                ),
+            ),
+        },
+        raw: rawConfiguration,
     };
 };

--- a/src/input/findTslintConfiguration.test.ts
+++ b/src/input/findTslintConfiguration.test.ts
@@ -1,11 +1,22 @@
-import { findTSLintConfiguration } from "./findTSLintConfiguration";
+import {
+    findTSLintConfiguration,
+    FindTSLintConfigurationDependencies,
+} from "./findTSLintConfiguration";
 import { createStubExec, createStubThrowingExec } from "../adapters/exec.stubs";
 
+const createStubDependencies = (overrides: Partial<FindTSLintConfigurationDependencies> = {}) => ({
+    exec: createStubExec({ stdout: "{}" }),
+    importer: async () => ({}),
+    ...overrides,
+});
+
 describe("findTSLintConfiguration", () => {
-    it("returns an error when one occurs", async () => {
+    it("returns an error when exec returns one", async () => {
         // Arrange
         const stderr = "error";
-        const dependencies = { exec: createStubThrowingExec({ stderr }) };
+        const dependencies = createStubDependencies({
+            exec: createStubThrowingExec({ stderr }),
+        });
 
         // Act
         const result = await findTSLintConfiguration(dependencies, undefined);
@@ -18,10 +29,32 @@ describe("findTSLintConfiguration", () => {
         );
     });
 
+    it("returns an error when importer returns one", async () => {
+        // Arrange
+        const message = "error";
+        const dependencies = createStubDependencies({
+            importer: async () => {
+                throw new Error(message);
+            },
+        });
+
+        // Act
+        const result = await findTSLintConfiguration(dependencies, undefined);
+
+        // Assert
+        expect(result).toEqual(
+            expect.objectContaining({
+                message,
+            }),
+        );
+    });
+
     it("replaces an error with a v5.18 request when the --print-config option is unsupported", async () => {
         // Arrange
         const stderr = "unknown option `--print-config";
-        const dependencies = { exec: createStubThrowingExec({ stderr }) };
+        const dependencies = createStubDependencies({
+            exec: createStubThrowingExec({ stderr }),
+        });
 
         // Act
         const result = await findTSLintConfiguration(dependencies, undefined);
@@ -36,7 +69,9 @@ describe("findTSLintConfiguration", () => {
 
     it("defaults the configuration file when one isn't provided", async () => {
         // Arrange
-        const dependencies = { exec: createStubExec() };
+        const dependencies = createStubDependencies({
+            exec: createStubExec(),
+        });
 
         // Act
         await findTSLintConfiguration(dependencies, undefined);
@@ -47,7 +82,9 @@ describe("findTSLintConfiguration", () => {
 
     it("includes a configuration file in the TSLint command when one is provided", async () => {
         // Arrange
-        const dependencies = { exec: createStubExec() };
+        const dependencies = createStubDependencies({
+            exec: createStubExec(),
+        });
         const config = "./custom/tslint.json";
 
         // Act
@@ -61,7 +98,18 @@ describe("findTSLintConfiguration", () => {
 
     it("applies TSLint defaults when none are provided", async () => {
         // Arrange
-        const dependencies = { exec: createStubExec({ stdout: "{}" }) };
+        const raw = {
+            extends: ["raw", "duplicated"],
+        };
+        const reportedExtends = ["reported", "duplicated"];
+        const dependencies = createStubDependencies({
+            exec: createStubExec({
+                stdout: JSON.stringify({
+                    extends: reportedExtends,
+                }),
+            }),
+            importer: async () => raw,
+        });
         const config = "./custom/tslint.json";
 
         // Act
@@ -69,8 +117,12 @@ describe("findTSLintConfiguration", () => {
 
         // Assert
         expect(result).toEqual({
-            rulesDirectory: [],
-            rules: {},
+            full: {
+                extends: ["raw", "duplicated", "reported"],
+                rulesDirectory: [],
+                rules: {},
+            },
+            raw,
         });
     });
 });

--- a/src/input/findTypeScriptConfiguration.ts
+++ b/src/input/findTypeScriptConfiguration.ts
@@ -1,4 +1,7 @@
-import { findConfiguration, FindConfigurationDependencies } from "./findConfiguration";
+import {
+    findReportedConfiguration,
+    FindReportedConfigurationDependencies,
+} from "./findReportedConfiguration";
 
 export type TypeScriptConfiguration = {
     compilerOptions: {
@@ -14,10 +17,10 @@ const defaultTypeScriptConfiguration = {
 };
 
 export const findTypeScriptConfiguration = async (
-    dependencies: FindConfigurationDependencies,
+    dependencies: FindReportedConfigurationDependencies,
     config: string | undefined,
 ): Promise<TypeScriptConfiguration | Error> => {
-    const rawConfiguration = await findConfiguration<TypeScriptConfiguration>(
+    const rawConfiguration = await findReportedConfiguration<TypeScriptConfiguration>(
         dependencies.exec,
         "tsc --showConfig -p",
         config || "./tsconfig.json",

--- a/src/input/importer.test.ts
+++ b/src/input/importer.test.ts
@@ -1,0 +1,145 @@
+import * as path from "path";
+
+import { importer } from "./importer";
+
+const stubCwd = "/path/to/cwd";
+
+type StubImporterSettings = {
+    files?: Record<string, string | Error>;
+    modules?: Record<string, unknown>;
+};
+
+const createStubDependencies = ({ files = {}, modules = {} }: StubImporterSettings = {}) => {
+    const fileSystem = {
+        fileExists: async (filePath: string) => filePath in files,
+        readFile: async (filePath: string) => files[filePath],
+    };
+
+    const getCwd = () => stubCwd;
+    const nativeImporter = async (filePath: string) => modules[filePath];
+
+    return { fileSystem, getCwd, nativeImporter };
+};
+
+describe("importer", () => {
+    it("natively imports a non-JSON module when its relative path exists", async () => {
+        // Arrange
+        const moduleName = "./relative.js";
+        const contents = { key: "value" };
+        const dependencies = createStubDependencies({
+            modules: {
+                [moduleName]: contents,
+            },
+        });
+
+        // Act
+        const imported = await importer(dependencies, moduleName);
+
+        // Assert
+        expect(imported).toEqual(contents);
+    });
+
+    it("natively imports a non-JSON module when its cwd-joined path exists", async () => {
+        // Arrange
+        const moduleName = "./relative.js";
+        const contents = { key: "value" };
+        const dependencies = createStubDependencies({
+            modules: {
+                [path.join(stubCwd, moduleName)]: contents,
+            },
+        });
+
+        // Act
+        const imported = await importer(dependencies, moduleName);
+
+        // Assert
+        expect(imported).toEqual(contents);
+    });
+
+    it("reads a JSONC module when its relative path exists", async () => {
+        // Arrange
+        const moduleName = "./relative.json";
+        const contents = { key: "value" };
+        const dependencies = createStubDependencies({
+            files: {
+                [moduleName]: JSON.stringify(contents),
+            },
+        });
+
+        // Act
+        const imported = await importer(dependencies, moduleName);
+
+        // Assert
+        expect(imported).toEqual(contents);
+    });
+
+    it("reads a JSONC module when its cwd-joined path exists", async () => {
+        // Arrange
+        const moduleName = "./relative.json";
+        const contents = { key: "value" };
+        const dependencies = createStubDependencies({
+            files: {
+                [path.join(stubCwd, moduleName)]: JSON.stringify(contents),
+            },
+        });
+
+        // Act
+        const imported = await importer(dependencies, moduleName);
+
+        // Assert
+        expect(imported).toEqual(contents);
+    });
+
+    it("returns an error when reading a JSONC module gives an error", async () => {
+        // Arrange
+        const moduleName = "./relative.json";
+        const error = new Error("NOPE, INVALID");
+        const dependencies = createStubDependencies({
+            files: {
+                [moduleName]: error,
+            },
+        });
+
+        // Act
+        const imported = await importer(dependencies, moduleName);
+
+        // Assert
+        expect(imported).toEqual(error);
+    });
+
+    it("returns an error when parsing a JSONC module gives an error", async () => {
+        // Arrange
+        const moduleName = "./relative.json";
+        const dependencies = createStubDependencies({
+            files: {
+                [moduleName]: "NOPE, INVALID",
+            },
+        });
+
+        // Act
+        const imported = await importer(dependencies, moduleName);
+
+        // Assert
+        expect(imported).toEqual(
+            expect.objectContaining({
+                message: "Unexpected token N in JSON at position 0",
+            }),
+        );
+    });
+
+    it("returns an error when neither module locations exist for a path", async () => {
+        // Arrange
+        const moduleName = "./relative.json";
+        const dependencies = createStubDependencies();
+
+        // Act
+        const imported = await importer(dependencies, moduleName);
+
+        // Assert
+        expect(imported).toEqual(
+            expect.objectContaining({
+                message: expect.stringContaining(`Could not find '${moduleName}' after trying:`),
+            }),
+        );
+    });
+});

--- a/src/input/importer.ts
+++ b/src/input/importer.ts
@@ -1,16 +1,17 @@
 import * as path from "path";
-import * as stripJsonComments from "strip-json-comments";
+import stripJsonComments from "strip-json-comments";
 
 import { FileSystem } from "../adapters/fileSystem";
 import { NativeImporter } from "../adapters/nativeImporter";
 
 export type ImporterDependencies = {
     fileSystem: Pick<FileSystem, "fileExists" | "readFile">;
+    getCwd: () => string;
     nativeImporter: NativeImporter;
 };
 
 export const importer = async (dependencies: ImporterDependencies, moduleName: string) => {
-    const pathAttempts = [path.join(process.cwd(), moduleName), moduleName];
+    const pathAttempts = [path.join(dependencies.getCwd(), moduleName), moduleName];
 
     const importFile = async (filePath: string) => {
         if (!filePath.endsWith(".json")) {

--- a/src/input/importer.ts
+++ b/src/input/importer.ts
@@ -1,0 +1,50 @@
+import * as path from "path";
+import * as stripJsonComments from "strip-json-comments";
+
+import { FileSystem } from "../adapters/fileSystem";
+import { NativeImporter } from "../adapters/nativeImporter";
+
+export type ImporterDependencies = {
+    fileSystem: Pick<FileSystem, "fileExists" | "readFile">;
+    nativeImporter: NativeImporter;
+};
+
+export const importer = async (dependencies: ImporterDependencies, moduleName: string) => {
+    const pathAttempts = [path.join(process.cwd(), moduleName), moduleName];
+
+    const importFile = async (filePath: string) => {
+        if (!filePath.endsWith(".json")) {
+            return await dependencies.nativeImporter(filePath);
+        }
+
+        if (!(await dependencies.fileSystem.fileExists(filePath))) {
+            return undefined;
+        }
+
+        const rawJsonContents = await dependencies.fileSystem.readFile(filePath);
+        if (rawJsonContents instanceof Error) {
+            return rawJsonContents;
+        }
+
+        try {
+            return JSON.parse(stripJsonComments(rawJsonContents));
+        } catch (error) {
+            return error;
+        }
+    };
+
+    for (const pathAttempt of pathAttempts) {
+        try {
+            const result = await importFile(pathAttempt);
+            if (result) {
+                return result;
+            }
+        } catch {}
+    }
+
+    return new Error(
+        `Could not find '${moduleName}' after trying: ${pathAttempts
+            .map(attempt => `'${attempt}'`)
+            .join(", ")}`,
+    );
+};

--- a/src/input/mergeLintConfigurations.test.ts
+++ b/src/input/mergeLintConfigurations.test.ts
@@ -1,12 +1,17 @@
 import { mergeLintConfigurations } from "./mergeLintConfigurations";
 import { ESLintConfiguration } from "./findESLintConfiguration";
+import { OriginalConfigurations } from "./findOriginalConfigurations";
+import { TSLintConfiguration } from "./findTSLintConfiguration";
 
-const stubTSLintConfiguration = {
-    rulesDirectory: [],
-    rules: {
-        disabled: true,
-        enabled: true,
+const stubTSLintConfiguration: OriginalConfigurations<TSLintConfiguration> = {
+    full: {
+        rulesDirectory: [],
+        rules: {
+            disabled: true,
+            enabled: true,
+        },
     },
+    raw: {},
 };
 
 describe("mergeLintConfigurations", () => {
@@ -23,10 +28,13 @@ describe("mergeLintConfigurations", () => {
 
     it("returns the tslint configuration when the eslint configuration doesn't have tslint rules", () => {
         // Arrange
-        const eslint: ESLintConfiguration = {
-            env: {},
-            extends: [],
-            rules: {},
+        const eslint: OriginalConfigurations<ESLintConfiguration> = {
+            full: {
+                env: {},
+                extends: [],
+                rules: {},
+            },
+            raw: {},
         };
 
         // Act
@@ -38,17 +46,20 @@ describe("mergeLintConfigurations", () => {
 
     it("returns the tslint configuration when the eslint configuration's tslint rules are disabled", () => {
         // Arrange
-        const eslint: ESLintConfiguration = {
-            env: {},
-            extends: [],
-            rules: {
-                "@typescript-eslint/tslint/config": [
-                    "off",
-                    {
-                        extra: true,
-                    },
-                ],
+        const eslint: OriginalConfigurations<ESLintConfiguration> = {
+            full: {
+                env: {},
+                extends: [],
+                rules: {
+                    "@typescript-eslint/tslint/config": [
+                        "off",
+                        {
+                            extra: true,
+                        },
+                    ],
+                },
             },
+            raw: {},
         };
 
         // Act
@@ -63,17 +74,20 @@ describe("mergeLintConfigurations", () => {
         const extraRules = {
             extra: true,
         };
-        const eslint: ESLintConfiguration = {
-            env: {},
-            extends: [],
-            rules: {
-                "@typescript-eslint/tslint/config": [
-                    "error",
-                    {
-                        rules: extraRules,
-                    },
-                ],
+        const eslint: OriginalConfigurations<ESLintConfiguration> = {
+            full: {
+                env: {},
+                extends: [],
+                rules: {
+                    "@typescript-eslint/tslint/config": [
+                        "error",
+                        {
+                            rules: extraRules,
+                        },
+                    ],
+                },
             },
+            raw: {},
         };
 
         // Act
@@ -82,9 +96,12 @@ describe("mergeLintConfigurations", () => {
         // Assert
         expect(result).toEqual({
             ...stubTSLintConfiguration,
-            rules: {
-                ...stubTSLintConfiguration.rules,
-                ...extraRules,
+            full: {
+                ...stubTSLintConfiguration.full,
+                rules: {
+                    ...stubTSLintConfiguration.full.rules,
+                    ...extraRules,
+                },
             },
         });
     });

--- a/src/input/mergeLintConfigurations.ts
+++ b/src/input/mergeLintConfigurations.ts
@@ -1,24 +1,28 @@
-import { TSLintConfiguration } from "./findTSLintConfiguration";
 import { ESLintConfiguration } from "./findESLintConfiguration";
+import { OriginalConfigurations } from "./findOriginalConfigurations";
+import { TSLintConfiguration } from "./findTSLintConfiguration";
 
 export const mergeLintConfigurations = (
-    eslint: ESLintConfiguration | Error,
-    tslint: TSLintConfiguration,
-) => {
+    eslint: OriginalConfigurations<ESLintConfiguration> | Error,
+    tslint: OriginalConfigurations<TSLintConfiguration>,
+): OriginalConfigurations<TSLintConfiguration> => {
     if (eslint instanceof Error) {
         return tslint;
     }
 
-    const mappedConfig = eslint.rules["@typescript-eslint/tslint/config"];
+    const mappedConfig = eslint.full.rules["@typescript-eslint/tslint/config"];
     if (!(mappedConfig instanceof Array) || mappedConfig[0] === "off") {
         return tslint;
     }
 
     return {
         ...tslint,
-        rules: {
-            ...tslint.rules,
-            ...mappedConfig[1].rules,
+        full: {
+            ...tslint.full,
+            rules: {
+                ...tslint.full.rules,
+                ...mappedConfig[1].rules,
+            },
         },
     };
 };

--- a/src/rules/converters/tests/member-access.test.ts
+++ b/src/rules/converters/tests/member-access.test.ts
@@ -10,9 +10,7 @@ describe(convertMemberAccess, () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/explicit-member-accessibility",
-                    ruleArguments: [
-                        { overrides: { constructors: "off" } },
-                    ],
+                    ruleArguments: [{ overrides: { constructors: "off" } }],
                 },
             ],
         });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "alwaysStrict": true,
         "declaration": true,
+        "esModuleInterop": true,
         "incremental": true,
         "lib": ["esnext"],
         "module": "commonjs",


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #232
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Before this change, `find*Configuration` functions for linters only returned the 'reported' config, meaning the CLI output of `--print-config` or similar. This change makes them return two things:

* `full`: that reported configuration, considered to be the complete list of all original settings
* `raw`: the naive results of `import`ing the configuration file

The `raw` config is used to override some settings in the printed output, namely `globals` and `extends`, because ESLint prints _way_ too many globals but none of the extends (#232).

A few tangential changes:

* A new `importer` was necessary for importing `.json` files with comments.
* Added root object key sorting to the output formatters, since they were getting a little oddly sorted from the raw overrides
* Enabled `esModuleInterop` in `tsconfig.json` because `strip-json-comments`' types don't have a default export

Still to do:

- [x] Flesh out test coverage, especially for the new `importer`
- [x] Add some JSDoc comments around the more confusing areas... perhaps a `.md` addition?
- [x] Double-check this works locally _(initial runs worked well!)_