### PR TITLE
Update Node requirement to >= 12 (latest LTS)

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -9,7 +9,7 @@ Please do file issues if you find bugs or lacking features!
 
 ## Local Setup
 
-After installing [Node >=10](https://nodejs.org/en/download), clone and install packages locally with:
+After installing [Node >= 12 (latest LTS)](https://nodejs.org/en/download), clone and install packages locally with:
 
 ```shell
 git clone https://github.com/typescript-eslint/tslint-to-eslint-config


### PR DESCRIPTION
## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

The node requirement has to be incremented since e.g. Array.prototype.flat does not work with 10 anymore.
see: https://node.green/#ESNEXT-candidate--stage-3--Array-prototype--flat--flatMap--Array-prototype-flat

-> There is no issue yet. Should I create one?