### PR TITLE
Add ruleArguments mapping to indent converter

### DIFF
--- a/src/rules/converters/indent.ts
+++ b/src/rules/converters/indent.ts
@@ -1,10 +1,19 @@
 import { RuleConverter } from "../converter";
 
-export const convertIndent: RuleConverter = () => {
+export const convertIndent: RuleConverter = tslintRule => {
+    let indentSize: number | string = 4; // @typescript-eslint/indent default
+
+    if (tslintRule.ruleArguments[0] === "tabs") {
+        indentSize = "tabs";
+    } else if (tslintRule.ruleArguments[1] === 2) {
+        indentSize = 2;
+    }
+
     return {
         rules: [
             {
                 ruleName: "@typescript-eslint/indent",
+                ...(indentSize !== 4 && { ruleArguments: [indentSize] }),
             },
         ],
     };

--- a/src/rules/converters/tests/indent.test.ts
+++ b/src/rules/converters/tests/indent.test.ts
@@ -14,4 +14,48 @@ describe(convertIndent, () => {
             ],
         });
     });
+
+    test("conversion with 2 spaces", () => {
+        const result = convertIndent({
+            ruleArguments: ["spaces", 2],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/indent",
+                    ruleArguments: [2],
+                },
+            ],
+        });
+    });
+
+    test("conversion with 4 spaces", () => {
+        const result = convertIndent({
+            ruleArguments: ["spaces", 4],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/indent",
+                },
+            ],
+        });
+    });
+
+    test("conversion with tabs", () => {
+        const result = convertIndent({
+            ruleArguments: ["tabs", 4],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/indent",
+                    ruleArguments: ["tabs"],
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #251
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview



<!-- Brief description of what is changed and how the code change does that. -->
This PR adds mapping of the rule arguments from TSLint `indent` to @typescript-eslint/indent`.

TSLint's `indent` [rule](https://palantir.github.io/tslint/rules/indent/) accepts 2 arguments: indent type (required) and indent size (optional). I was unsure how indent size would work in the case of tab indentation but from looking at [TSLint source](https://github.com/palantir/tslint/blob/e493270e314541e2f14b35bddbe9b74ea50cbfa9/src/rules/indentRule.ts#L110), the second argument is ignored in the case of `"tabs"` indentation. 