### PR TITLE
Added missing 'never' argument to one-var output

### DIFF
--- a/src/rules/converters/one-variable-per-declaration.ts
+++ b/src/rules/converters/one-variable-per-declaration.ts
@@ -7,6 +7,7 @@ export const convertOneVariablePerDeclaration: RuleConverter = tslintRule => {
                 ...(!tslintRule.ruleArguments.includes("ignore-for-loop") && {
                     notices: ["Variables declared in for loops will no longer be checked."],
                 }),
+                ruleArguments: ["never"],
                 ruleName: "one-var",
             },
         ],

--- a/src/rules/converters/tests/one-variable-per-declaration.test.ts
+++ b/src/rules/converters/tests/one-variable-per-declaration.test.ts
@@ -10,6 +10,7 @@ describe(convertOneVariablePerDeclaration, () => {
             rules: [
                 {
                     notices: ["Variables declared in for loops will no longer be checked."],
+                    ruleArguments: ["never"],
                     ruleName: "one-var",
                 },
             ],
@@ -24,6 +25,7 @@ describe(convertOneVariablePerDeclaration, () => {
         expect(result).toEqual({
             rules: [
                 {
+                    ruleArguments: ["never"],
                     ruleName: "one-var",
                 },
             ],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #256
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Adds an ever-present `ruleArguments: ["never"]` to the `one-variable-per-declaration` converter.