### PR TITLE
Again allowed rules from extended rulesets (via reported configs) to be factored in

### DIFF
--- a/src/creation/formatMissingRules.test.ts
+++ b/src/creation/formatMissingRules.test.ts
@@ -13,7 +13,7 @@ describe("formatMissingRules", () => {
         ];
 
         // Act
-        const output = formatMissingRules(missing, []);
+        const output = formatMissingRules(missing);
 
         // Assert
         expect(output).toEqual([

--- a/src/creation/formatMissingRules.ts
+++ b/src/creation/formatMissingRules.ts
@@ -1,7 +1,7 @@
 import { TSLintRuleOptions } from "../rules/types";
 
-export const formatMissingRules = (missing: TSLintRuleOptions[], rulesDirectory: string[]) => {
-    const rules: { [i: string]: unknown } = {};
+export const formatMissingRules = (missing: TSLintRuleOptions[], rulesDirectory: string[] = []) => {
+    const rules: Record<string, unknown> = {};
 
     for (const rule of missing.sort((a, b) => a.ruleName.localeCompare(b.ruleName))) {
         if (rule.ruleSeverity !== "off") {

--- a/src/input/findRawConfiguration.ts
+++ b/src/input/findRawConfiguration.ts
@@ -4,7 +4,7 @@ import { importer } from "./importer";
 export const findRawConfiguration = async <Configuration>(
     fileImporter: SansDependencies<typeof importer>,
     filePath: string,
-    defaults: Partial<Configuration>,
+    defaults: Partial<Configuration> = {},
 ): Promise<Configuration | Error> => {
     let results: Configuration;
 

--- a/src/input/findTSLintConfiguration.ts
+++ b/src/input/findTSLintConfiguration.ts
@@ -1,23 +1,17 @@
 import { findRawConfiguration } from "./findRawConfiguration";
 import { findReportedConfiguration } from "./findReportedConfiguration";
 import { Exec } from "../adapters/exec";
-import { OriginalConfigurations } from "./findOriginalConfigurations";
 import { SansDependencies } from "../binding";
 import { importer } from "./importer";
+import { isDefined } from "../utils";
 
 export type TSLintConfiguration = {
     extends?: string[];
-    rulesDirectory: string[];
+    rulesDirectory?: string[];
     rules: TSLintConfigurationRules;
 };
 
 export type TSLintConfigurationRules = Record<string, any>;
-
-const defaultTSLintConfiguration = {
-    extends: [],
-    rulesDirectory: [],
-    rules: {},
-};
 
 export type FindTSLintConfigurationDependencies = {
     exec: Exec;
@@ -27,12 +21,10 @@ export type FindTSLintConfigurationDependencies = {
 export const findTSLintConfiguration = async (
     dependencies: FindTSLintConfigurationDependencies,
     config: string | undefined,
-): Promise<OriginalConfigurations<TSLintConfiguration> | Error> => {
+) => {
     const filePath = config || "./tslint.json";
     const [rawConfiguration, reportedConfiguration] = await Promise.all([
-        findRawConfiguration<Partial<TSLintConfiguration>>(dependencies.importer, filePath, {
-            extends: [],
-        }),
+        findRawConfiguration<Partial<TSLintConfiguration>>(dependencies.importer, filePath),
         findReportedConfiguration<TSLintConfiguration>(
             dependencies.exec,
             "tslint --print-config",
@@ -52,15 +44,23 @@ export const findTSLintConfiguration = async (
         return rawConfiguration;
     }
 
+    const extensions = Array.from(
+        new Set(
+            [[rawConfiguration.extends], [reportedConfiguration.extends]]
+                .flat(Infinity)
+                .filter(isDefined),
+        ),
+    );
+
+    const rules = {
+        ...rawConfiguration.rules,
+        ...reportedConfiguration.rules,
+    };
+
     return {
         full: {
-            ...defaultTSLintConfiguration,
-            ...rawConfiguration,
-            extends: Array.from(
-                new Set(
-                    [[rawConfiguration.extends], [reportedConfiguration.extends]].flat(Infinity),
-                ),
-            ),
+            ...(extensions.length !== 0 && { extends: extensions }),
+            rules,
         },
         raw: rawConfiguration,
     };

--- a/src/input/findTslintConfiguration.test.ts
+++ b/src/input/findTslintConfiguration.test.ts
@@ -119,8 +119,42 @@ describe("findTSLintConfiguration", () => {
         expect(result).toEqual({
             full: {
                 extends: ["raw", "duplicated", "reported"],
-                rulesDirectory: [],
                 rules: {},
+            },
+            raw,
+        });
+    });
+
+    it("adds reported configuration rules on top of raw rules", async () => {
+        // Arrange
+        const raw = {
+            rules: {
+                "raw-rule": true,
+            },
+        };
+        const reported = {
+            rules: {
+                "reported-rule": true,
+            },
+        };
+        const dependencies = createStubDependencies({
+            exec: createStubExec({
+                stdout: JSON.stringify(reported),
+            }),
+            importer: async () => raw,
+        });
+        const config = "./custom/tslint.json";
+
+        // Act
+        const result = await findTSLintConfiguration(dependencies, config);
+
+        // Assert
+        expect(result).toEqual({
+            full: {
+                rules: {
+                    ...raw.rules,
+                    ...reported.rules,
+                },
             },
             raw,
         });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #261
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Rules from reported configurations (`tslint --print-config`) weren't being added to the `full` output of `findTSLintConfigurationDependencies`. This adds them back in.