### PR TITLE
Lowered lib version to support Node 10

### DIFF
--- a/src/creation/formatting/formatters/withKeysSorted.ts
+++ b/src/creation/formatting/formatters/withKeysSorted.ts
@@ -1,7 +1,10 @@
 export const withKeysSorted = (input: any) => {
-    return Object.fromEntries(
-        Object.keys(input)
-            .sort((a, b) => a.localeCompare(b))
-            .map(key => [key, input[key]]),
-    );
+    const output: Record<string, any> = {};
+    const keys = Object.keys(input).sort((a, b) => a.localeCompare(b));
+
+    for (const key of keys) {
+        output[key] = input[key];
+    }
+
+    return output;
 };

--- a/src/input/findESLintConfiguration.ts
+++ b/src/input/findESLintConfiguration.ts
@@ -2,6 +2,7 @@ import { Exec } from "../adapters/exec";
 import { SansDependencies } from "../binding";
 import { ESLintRuleSeverity } from "../rules/types";
 import { TSLintToESLintSettings } from "../types";
+import { uniqueFromSources } from "../utils";
 import { findRawConfiguration } from "./findRawConfiguration";
 import { findReportedConfiguration } from "./findReportedConfiguration";
 import { OriginalConfigurations } from "./findOriginalConfigurations";
@@ -60,9 +61,7 @@ export const findESLintConfiguration = async (
         return reportedConfiguration;
     }
 
-    const extensions = [rawConfiguration.extends, [reportedConfiguration.extends || []]].flat(
-        Infinity,
-    );
+    const extensions = uniqueFromSources(rawConfiguration.extends, reportedConfiguration.extends);
 
     return {
         full: {

--- a/src/input/findTSLintConfiguration.ts
+++ b/src/input/findTSLintConfiguration.ts
@@ -2,8 +2,7 @@ import { findRawConfiguration } from "./findRawConfiguration";
 import { findReportedConfiguration } from "./findReportedConfiguration";
 import { Exec } from "../adapters/exec";
 import { SansDependencies } from "../binding";
-import { flattenTwo } from "../creation/formatting/formatters/flattenTwo";
-import { isDefined } from "../utils";
+import { uniqueFromSources } from "../utils";
 import { importer } from "./importer";
 
 export type TSLintConfiguration = {
@@ -45,7 +44,7 @@ export const findTSLintConfiguration = async (
         return rawConfiguration;
     }
 
-    const extensions = flattenExtensions(rawConfiguration.extends, reportedConfiguration.extends);
+    const extensions = uniqueFromSources(rawConfiguration.extends, reportedConfiguration.extends);
 
     const rules = {
         ...rawConfiguration.rules,
@@ -59,16 +58,4 @@ export const findTSLintConfiguration = async (
         },
         raw: rawConfiguration,
     };
-};
-
-const flattenExtensions = (...sources: (string[] | undefined)[]) => {
-    const items: string[] = [];
-
-    for (const source of sources) {
-        if (source !== undefined) {
-            items.push(...source.filter(isDefined));
-        }
-    }
-
-    return Array.from(new Set(items));
 };

--- a/src/input/findTSLintConfiguration.ts
+++ b/src/input/findTSLintConfiguration.ts
@@ -2,8 +2,9 @@ import { findRawConfiguration } from "./findRawConfiguration";
 import { findReportedConfiguration } from "./findReportedConfiguration";
 import { Exec } from "../adapters/exec";
 import { SansDependencies } from "../binding";
-import { importer } from "./importer";
+import { flattenTwo } from "../creation/formatting/formatters/flattenTwo";
 import { isDefined } from "../utils";
+import { importer } from "./importer";
 
 export type TSLintConfiguration = {
     extends?: string[];
@@ -44,13 +45,7 @@ export const findTSLintConfiguration = async (
         return rawConfiguration;
     }
 
-    const extensions = Array.from(
-        new Set(
-            [[rawConfiguration.extends], [reportedConfiguration.extends]]
-                .flat(Infinity)
-                .filter(isDefined),
-        ),
-    );
+    const extensions = flattenExtensions(rawConfiguration.extends, reportedConfiguration.extends);
 
     const rules = {
         ...rawConfiguration.rules,
@@ -64,4 +59,16 @@ export const findTSLintConfiguration = async (
         },
         raw: rawConfiguration,
     };
+};
+
+const flattenExtensions = (...sources: (string[] | undefined)[]) => {
+    const items: string[] = [];
+
+    for (const source of sources) {
+        if (source !== undefined) {
+            items.push(...source.filter(isDefined));
+        }
+    }
+
+    return Array.from(new Set(items));
 };

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { isDefined, isError } from "./utils";
+import { isDefined, isError, uniqueFromSources } from "./utils";
 
 describe("isDefined", () => {
     it("returns true when the item is defined", () => {
@@ -45,5 +45,40 @@ describe("isError", () => {
 
         // Assert
         expect(result).toBe(false);
+    });
+});
+
+describe("uniqueFromSources", () => {
+    it("returns unique items when multiple are given", () => {
+        // Arange
+        const sources = ["a", "b", "b", "c"];
+
+        // Act
+        const result = uniqueFromSources(...sources);
+
+        // Assert
+        expect(result).toEqual(["a", "b", "c"]);
+    });
+
+    it("returns items from a nested array", () => {
+        // Arange
+        const sources = ["a", ["b"], "c"];
+
+        // Act
+        const result = uniqueFromSources(...sources);
+
+        // Assert
+        expect(result).toEqual(["a", "b", "c"]);
+    });
+
+    it("filters out undefined inputs", () => {
+        // Arange
+        const sources = ["a", "b", "c", undefined];
+
+        // Act
+        const result = uniqueFromSources(...sources);
+
+        // Assert
+        expect(result).toEqual(["a", "b", "c"]);
     });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,3 +7,17 @@ export type RemoveErrors<Items> = {
 };
 
 export type PromiseValue<T> = T extends Promise<infer R> ? R : never;
+
+export const uniqueFromSources = <T>(...sources: (T | T[] | undefined)[]) => {
+    const items: T[] = [];
+
+    for (const source of sources) {
+        if (source instanceof Array) {
+            items.push(...source.filter(isDefined));
+        } else if (source !== undefined) {
+            items.push(source);
+        }
+    }
+
+    return Array.from(new Set(items));
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "declaration": true,
         "esModuleInterop": true,
         "incremental": true,
-        "lib": ["esnext"],
+        "lib": ["es2017"],
         "module": "commonjs",
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #264
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Lowers the TypeScript lib target down to `es2017` to make sure 2018+ features not supported by Node 10 aren't added.