### PR TITLE
Lowered minimum Node version to 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
 jobs:
     build:
         docker:
-            - image: circleci/node:latest
+            - image: circleci/node:8
 
         working_directory: ~/repo
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `tslint-to-eslint-config` command reads in any existing linter, TypeScript, 
 For any TSLint rules with corresponding ESLint equivalents, those equivalents will be used in the new configuration.
 TSLint rules without ESLint equivalents will be wrapped with [eslint-plugin-tslint](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin-tslint).
 
-> Requires Node 12+ (LTS)
+> Requires Node 8+ (LTS)
 
 ### CLI Flags
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "strictPropertyInitialization": true,
-        "target": "esnext"
+        "target": "es2015"
     },
     "exclude": ["test/tests/**/*"]
 }


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #267
-   ~[ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)~ _(I'm a maintainer, I do what I want!)_ 🤘

## Overview

Lowers the output target to `es2015` and the minimum Node version to 8 in docs, Circle, and TypeScript.