### PR TITLE
Corrected no-import-side-effect output rule

### DIFF
--- a/src/rules/converters/no-import-side-effect.ts
+++ b/src/rules/converters/no-import-side-effect.ts
@@ -4,10 +4,11 @@ export const convertNoImportSideEffect: RuleConverter = tsLintRule => {
     return {
         rules: [
             {
-                ruleName: "no-import-side-effect",
+                plugins: ["eslint-plugin-import"],
+                ruleName: "import/no-unassigned-import",
                 ...(tsLintRule.ruleArguments.length !== 0 && {
                     notices: [
-                        "ESLint's no-import-side-effect now accepts a glob pattern for ignores; you'll need to manually convert your ignore-module settings.",
+                        "ESLint's import/no-unassigned-import now accepts a glob pattern for ignores; you'll need to manually convert your ignore-module settings.",
                     ],
                 }),
             },

--- a/src/rules/converters/tests/no-import-side-effect.test.ts
+++ b/src/rules/converters/tests/no-import-side-effect.test.ts
@@ -9,7 +9,8 @@ describe(convertNoImportSideEffect, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "no-import-side-effect",
+                    plugins: ["eslint-plugin-import"],
+                    ruleName: "import/no-unassigned-import",
                 },
             ],
         });
@@ -23,10 +24,11 @@ describe(convertNoImportSideEffect, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "no-import-side-effect",
+                    plugins: ["eslint-plugin-import"],
                     notices: [
-                        "ESLint's no-import-side-effect now accepts a glob pattern for ignores; you'll need to manually convert your ignore-module settings.",
+                        "ESLint's import/no-unassigned-import now accepts a glob pattern for ignores; you'll need to manually convert your ignore-module settings.",
                     ],
+                    ruleName: "import/no-unassigned-import",
                 },
             ],
         });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #172, #239
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

As noted by @buu700, ESLint itself does not have a `no-import-side-effect` rule.