### PR TITLE
Generating `space-before-function-paren` (#147)

### DIFF
--- a/src/rules/converters/space-before-function-paren.ts
+++ b/src/rules/converters/space-before-function-paren.ts
@@ -1,11 +1,26 @@
 import { RuleConverter } from "../converter";
 
+const NOT_SUPPORTED_OPTIONS = ["constructor", "method"];
+
+function isExistedESLintOption(rule: string) {
+    return !NOT_SUPPORTED_OPTIONS.includes(rule);
+}
+
 export const convertSpaceBeforeFunctionParen: RuleConverter = tslintRule => {
+    const ruleArguments = tslintRule.ruleArguments.filter(isExistedESLintOption);
+    const notices = NOT_SUPPORTED_OPTIONS.reduce<string[]>((acc, option) => {
+        if (tslintRule.ruleArguments.includes(option)) {
+            acc.push(`Option "${option}" is not supported by ESLint.`);
+        }
+        return acc;
+    }, []);
+
     return {
         rules: [
             {
                 ...(tslintRule.ruleArguments.length !== 0 && {
-                    ruleArguments: tslintRule.ruleArguments,
+                    ruleArguments,
+                    ...(notices.length !== 0 && { notices }),
                 }),
                 ruleName: "space-before-function-paren",
             },

--- a/src/rules/converters/tests/space-before-function-paren.test.ts
+++ b/src/rules/converters/tests/space-before-function-paren.test.ts
@@ -29,4 +29,42 @@ describe(convertSpaceBeforeFunctionParen, () => {
             ],
         });
     });
+
+    test("conversion with all existing arguments", () => {
+        const result = convertSpaceBeforeFunctionParen({
+            ruleArguments: ["anonymous", "named", "asyncArrow", "method", "constructor"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [
+                        'Option "constructor" is not supported by ESLint.',
+                        'Option "method" is not supported by ESLint.',
+                    ],
+                    ruleArguments: ["anonymous", "named", "asyncArrow"],
+                    ruleName: "space-before-function-paren",
+                },
+            ],
+        });
+    });
+
+    test('conversion with not supported options ["method", "constructor"]', () => {
+        const result = convertSpaceBeforeFunctionParen({
+            ruleArguments: ["method", "constructor"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [
+                        'Option "constructor" is not supported by ESLint.',
+                        'Option "method" is not supported by ESLint.',
+                    ],
+                    ruleArguments: [],
+                    ruleName: "space-before-function-paren",
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #147 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

- Added filtering of TSLint [rules arguments](https://palantir.github.io/tslint/rules/space-before-function-paren/) to allow only some of them, which are available in [ESLint](https://eslint.org/docs/rules/space-before-function-paren#options).
- Added test.