### PR TITLE
Fix ruleArguments

### DIFF
--- a/src/rules/converters/newline-before-return.ts
+++ b/src/rules/converters/newline-before-return.ts
@@ -6,7 +6,6 @@ export const convertNewlineBeforeReturn: RuleConverter = () => {
             {
                 ruleName: "padding-line-between-statements",
                 ruleArguments: [
-                    "error",
                     {
                         blankLine: "always",
                         prev: "*",

--- a/src/rules/converters/semicolon.ts
+++ b/src/rules/converters/semicolon.ts
@@ -24,7 +24,6 @@ export const convertSemicolon: RuleConverter = tslintRule => {
                 : [
                       {
                           ruleArguments: [
-                              "error",
                               {
                                   multiline: {
                                       delimiter: getMultilineDelimiter(tslintRule.ruleArguments[0]),

--- a/src/rules/converters/tests/newline-before-return.test.ts
+++ b/src/rules/converters/tests/newline-before-return.test.ts
@@ -11,7 +11,6 @@ describe(convertNewlineBeforeReturn, () => {
                 {
                     ruleName: "padding-line-between-statements",
                     ruleArguments: [
-                        "error",
                         {
                             blankLine: "always",
                             next: "return",

--- a/src/rules/converters/tests/semicolon.test.ts
+++ b/src/rules/converters/tests/semicolon.test.ts
@@ -14,7 +14,6 @@ describe(convertSemicolon, () => {
                 },
                 {
                     ruleArguments: [
-                        "error",
                         {
                             multiline: {
                                 delimiter: "semi",
@@ -45,7 +44,6 @@ describe(convertSemicolon, () => {
                 },
                 {
                     ruleArguments: [
-                        "error",
                         {
                             multiline: {
                                 delimiter: "none",
@@ -77,7 +75,6 @@ describe(convertSemicolon, () => {
                 {
                     ruleName: "@typescript-eslint/member-delimiter-style",
                     ruleArguments: [
-                        "error",
                         {
                             multiline: {
                                 delimiter: "semi",
@@ -111,7 +108,6 @@ describe(convertSemicolon, () => {
                 {
                     ruleName: "@typescript-eslint/member-delimiter-style",
                     ruleArguments: [
-                        "error",
                         {
                             multiline: {
                                 delimiter: "none",


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #285
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

### 1. Prepare tslint.json

`tslint.json`

```json
{
    "rules": {
        "newline-before-return": true,
        "semicolon": [true, "always"]
    }
}
```

### 2. Run tslint-to-eslint-config

`npx tslint-to-eslint-config@0.3.1`

### 3. A broken config file is generated

`.eslintrc.js`

```javascript
module.exports = {
    "env": {
        "es6": true,
        "node": true
    },
    "extends": [],
    "parser": "@typescript-eslint/parser",
    "parserOptions": {
        "project": "tsconfig.json",
        "sourceType": "module"
    },
    "plugins": [
        "@typescript-eslint"
    ],
    "rules": {
        "@typescript-eslint/member-delimiter-style": [
            "error",
            "error",
            {
                "multiline": {
                    "delimiter": "semi",
                    "requireLast": true
                },
                "singleline": {
                    "delimiter": "semi",
                    "requireLast": false
                }
            }
        ],
        "@typescript-eslint/semi": [
            "error",
            "always"
        ],
        "padding-line-between-statements": [
            "error",
            "error",
            {
                "blankLine": "always",
                "prev": "*",
                "next": "return"
            }
        ]
    },
    "settings": {}
};
```

`@typescript-eslint/member-delimiter-style` and `padding-line-between-statements` rules are broken.

---

```bash
#!/bin/bash
mkdir example
cd example/
npm init -y
npm i -D typescript tslint
cat <<EOS >tslint.json
{
    "rules": {
        "newline-before-return": true,
        "semicolon": [true, "always"]
    }
}
EOS
npx tslint-to-eslint-config@0.3.1
cat .eslintrc.js
```