### PR TITLE
fix `no-underscore-dangle`

### DIFF
--- a/src/rules/converters/tests/variable-name.test.ts
+++ b/src/rules/converters/tests/variable-name.test.ts
@@ -198,8 +198,8 @@ describe(convertVariableName, () => {
                 },
                 {
                     notices: [IgnoreLeadingTrailingIdentifierMsg],
-                    ruleArguments: ["off"],
                     ruleName: "no-underscore-dangle",
+                    ruleSeverity: "off",
                 },
                 {
                     ruleName: "id-blacklist",
@@ -224,8 +224,8 @@ describe(convertVariableName, () => {
                 },
                 {
                     notices: [IgnoreLeadingTrailingIdentifierMsg],
-                    ruleArguments: ["off"],
                     ruleName: "no-underscore-dangle",
+                    ruleSeverity: "off",
                 },
                 {
                     ruleName: "id-blacklist",
@@ -254,8 +254,8 @@ describe(convertVariableName, () => {
                 },
                 {
                     notices: [IgnoreLeadingTrailingIdentifierMsg],
-                    ruleArguments: ["off"],
                     ruleName: "no-underscore-dangle",
+                    ruleSeverity: "off",
                 },
                 {
                     ruleName: "id-blacklist",
@@ -288,8 +288,8 @@ describe(convertVariableName, () => {
                 },
                 {
                     ruleName: "no-underscore-dangle",
-                    ruleArguments: ["off"],
                     notices: [IgnoreLeadingTrailingIdentifierMsg],
+                    ruleSeverity: "off",
                 },
                 {
                     ruleName: "id-blacklist",

--- a/src/rules/converters/variable-name.ts
+++ b/src/rules/converters/variable-name.ts
@@ -56,11 +56,11 @@ export const convertVariableName: RuleConverter = tslintRule => {
     };
 
     const getUnderscoreDangleRuleOptions = () => {
-        const underscoreDangleOptionArguments: string[] = [];
+        let underscoreDangleOptionSeverity: string | null = null;
         const underscoreDangleOptionNotice: string[] = [];
 
         if (hasCheckFormat && (allowedLeadingUnderscore || allowedTrailingUnderscore)) {
-            underscoreDangleOptionArguments.push("off");
+            underscoreDangleOptionSeverity = "off";
             underscoreDangleOptionNotice.push(IgnoreLeadingTrailingIdentifierMsg);
         } else {
             underscoreDangleOptionNotice.push(ForbiddenLeadingTrailingIdentifierMsg);
@@ -68,8 +68,8 @@ export const convertVariableName: RuleConverter = tslintRule => {
 
         return {
             notices: underscoreDangleOptionNotice,
-            ...(underscoreDangleOptionArguments.length !== 0 && {
-                ruleArguments: underscoreDangleOptionArguments,
+            ...(underscoreDangleOptionSeverity !== null && {
+                ruleSeverity: underscoreDangleOptionSeverity,
             }),
             ruleName: "no-underscore-dangle",
         };


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #266 and fixes #290
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

See: #290