### PR TITLE
Stopped erroring when .vscode/settings.json doesn't exist

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -74,6 +74,7 @@ const findConfigurationDependencies = {
 };
 
 const findEditorConfigurationDependencies: FindEditorConfigurationDependencies = {
+    fileSystem: fsFileSystem,
     importer: boundImporter,
 };
 

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -6,7 +6,6 @@ import { version } from "../../package.json";
 import { Logger } from "../adapters/logger";
 import { SansDependencies } from "../binding";
 import { convertConfig } from "../conversion/convertConfig";
-import { DEFAULT_VSCODE_SETTINGS_PATH } from "../input/vsCodeSettings";
 import { ResultStatus, ResultWithStatus, TSLintToESLintSettings } from "../types";
 
 export type RunCliDependencies = {
@@ -25,11 +24,7 @@ export const runCli = async (
         .option("--package [package]", "package configuration file to convert using")
         .option("--tslint [tslint]", "tslint configuration file to convert using")
         .option("--typescript [typescript]", "typescript configuration file to convert using")
-        .option(
-            "--editor [editor]",
-            "editor configuration file to convert",
-            DEFAULT_VSCODE_SETTINGS_PATH,
-        )
+        .option("--editor [editor]", "editor configuration file to convert")
         .option("-V --version", "output the package version");
 
     const parsedArgv = {

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -27,7 +27,7 @@ export const runCli = async (
         .option("--typescript [typescript]", "typescript configuration file to convert using")
         .option(
             "--editor [editor]",
-            "editor configuration file to convert using",
+            "editor configuration file to convert",
             DEFAULT_VSCODE_SETTINGS_PATH,
         )
         .option("-V --version", "output the package version");

--- a/src/conversion/convertEditorConfig.test.ts
+++ b/src/conversion/convertEditorConfig.test.ts
@@ -43,7 +43,10 @@ describe("convertEditorConfig", () => {
         };
 
         const dependencies = createStubDependencies({
-            findEditorConfiguration: async () => error,
+            findEditorConfiguration: async () => ({
+                configPath: "",
+                result: error,
+            }),
         });
 
         // Act
@@ -74,14 +77,12 @@ describe("convertEditorConfig", () => {
         // Arrange
         const originalConfig = {
             "typescript.tsdk": "node_modules/typescript/lib",
-            "editor.tabSize": 4,
-            "editor.codeActionsOnSave": {
-                "source.organizeImports": false,
-            },
         };
 
         const dependencies = createStubDependencies({
-            findEditorConfiguration: jest.fn().mockResolvedValue(originalConfig),
+            findEditorConfiguration: jest.fn().mockResolvedValue({
+                result: originalConfig,
+            }),
         });
 
         // Act
@@ -127,21 +128,5 @@ describe("convertEditorConfig", () => {
         expect(result).toEqual({
             status: ResultStatus.Succeeded,
         });
-    });
-
-    it("uses VS Code default settings path if editor config parameter is undefined", async () => {
-        // Arrange
-        const expectedEditorPath = ".vscode/settings.json";
-        const settings = {
-            config: "./eslintrc.js",
-        };
-
-        const dependencies = createStubDependencies();
-
-        // Act
-        await convertEditorConfig(dependencies, settings);
-
-        // Assert
-        expect(dependencies.findEditorConfiguration).toHaveBeenCalledWith(expectedEditorPath);
     });
 });

--- a/src/conversion/convertEditorConfig.test.ts
+++ b/src/conversion/convertEditorConfig.test.ts
@@ -19,6 +19,21 @@ const createStubDependencies = (
 });
 
 describe("convertEditorConfig", () => {
+    it("returns a success result when there is no original configuration", async () => {
+        // Arrange
+        const dependencies = createStubDependencies({
+            findEditorConfiguration: async () => undefined,
+        });
+
+        // Act
+        const result = await convertEditorConfig(dependencies, stubSettings);
+
+        // Assert
+        expect(result).toEqual({
+            status: ResultStatus.Succeeded,
+        });
+    });
+
     it("returns the failure result when finding the original configurations fails", async () => {
         // Arrange
         const error = new Error();

--- a/src/conversion/convertEditorConfig.ts
+++ b/src/conversion/convertEditorConfig.ts
@@ -20,10 +20,17 @@ export const convertEditorConfig = async (
     dependencies: ConvertEditorConfigDependencies,
     settings: TSLintToESLintSettings,
 ): Promise<ResultWithStatus> => {
-    const editorConfigPath = settings.editor ? settings.editor : DEFAULT_VSCODE_SETTINGS_PATH;
+    const editorConfigPath = settings.editor ?? DEFAULT_VSCODE_SETTINGS_PATH;
     const originalEditorConfiguration = await dependencies.findEditorConfiguration(
         editorConfigPath,
     );
+
+    if (originalEditorConfiguration === undefined) {
+        return {
+            status: ResultStatus.Succeeded,
+        };
+    }
+
     if (originalEditorConfiguration instanceof Error) {
         return {
             errors: [originalEditorConfiguration],

--- a/src/input/findEditorConfiguration.ts
+++ b/src/input/findEditorConfiguration.ts
@@ -3,21 +3,23 @@ import { EditorConfiguration } from "./editorConfiguration";
 import { findRawConfiguration } from "./findRawConfiguration";
 import { DeepPartial } from "./findReportedConfiguration";
 import { importer } from "./importer";
-import { DEFAULT_VSCODE_SETTINGS_PATH } from "./vsCodeSettings";
+import { FileSystem } from "../adapters/fileSystem";
 
 export type FindEditorConfigurationDependencies = {
+    fileSystem: Pick<FileSystem, "fileExists">;
     importer: SansDependencies<typeof importer>;
 };
 
 export const findEditorConfiguration = async (
     dependencies: FindEditorConfigurationDependencies,
-    config: string | undefined,
-): Promise<DeepPartial<EditorConfiguration> | Error> => {
-    const filePath = config ?? DEFAULT_VSCODE_SETTINGS_PATH;
-    const rawConfiguration = await findRawConfiguration<DeepPartial<EditorConfiguration>>(
-        dependencies.importer,
-        filePath,
-    );
+    config: string,
+): Promise<DeepPartial<EditorConfiguration> | Error | undefined> => {
+    if (!(await dependencies.fileSystem.fileExists(config))) {
+        return undefined;
+    }
 
-    return rawConfiguration;
+    return await findRawConfiguration<DeepPartial<EditorConfiguration>>(
+        dependencies.importer,
+        config,
+    );
 };


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #303
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Uses `fs.fileExists` to check if the file exists. If it doesn't but a file was specified, nothing is converted.