### PR TITLE
Improved spacing around reporting line groups

### DIFF
--- a/src/cli/runCli.test.ts
+++ b/src/cli/runCli.test.ts
@@ -68,7 +68,7 @@ describe("runCli", () => {
         expectEqualWrites(
             dependencies.logger.stderr.write,
             "❌ Could not start tslint-to-eslint: ❌",
-            complaint,
+            `  ${complaint}`,
         );
     });
 
@@ -93,7 +93,7 @@ describe("runCli", () => {
         expectEqualWrites(
             dependencies.logger.stderr.write,
             "❌ 1 error running tslint-to-eslint: ❌",
-            `${error.stack}`,
+            `  ${error.stack}`,
         );
     });
 
@@ -121,8 +121,8 @@ describe("runCli", () => {
         expectEqualWrites(
             dependencies.logger.stderr.write,
             "❌ 2 errors running tslint-to-eslint: ❌",
-            `${errors[0].stack}`,
-            `${errors[1].stack}`,
+            `  ${errors[0].stack}`,
+            `  ${errors[1].stack}`,
         );
     });
 

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -79,18 +79,18 @@ const logErrorResult = (result: ResultWithStatus, dependencies: RunCliDependenci
             dependencies.logger.stderr.write(chalk.red("Could not start tslint-to-eslint:"));
             dependencies.logger.stderr.write(chalk.redBright(` ❌${EOL}`));
             for (const complaint of result.complaints) {
-                dependencies.logger.stderr.write(chalk.yellowBright(`${complaint}${EOL}`));
+                dependencies.logger.stderr.write(chalk.yellowBright(`  ${complaint}${EOL}`));
             }
             break;
 
         case ResultStatus.Failed:
             dependencies.logger.stderr.write(chalk.redBright("❌ "));
-            dependencies.logger.stderr.write(chalk.yellow(`${result.errors.length} error`));
-            dependencies.logger.stderr.write(chalk.yellow(result.errors.length === 1 ? "" : "s"));
-            dependencies.logger.stderr.write(chalk.yellow(" running tslint-to-eslint:"));
+            dependencies.logger.stderr.write(chalk.red(`${result.errors.length} error`));
+            dependencies.logger.stderr.write(chalk.red(result.errors.length === 1 ? "" : "s"));
+            dependencies.logger.stderr.write(chalk.red(" running tslint-to-eslint:"));
             dependencies.logger.stderr.write(chalk.redBright(` ❌${EOL}`));
             for (const error of result.errors) {
-                dependencies.logger.stderr.write(chalk.yellowBright(`${error.stack}${EOL}`));
+                dependencies.logger.stderr.write(chalk.gray(`  ${error.stack}${EOL}`));
             }
             break;
     }

--- a/src/reporting/reportConversionResults.test.ts
+++ b/src/reporting/reportConversionResults.test.ts
@@ -57,11 +57,11 @@ describe("reportConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            `✨ 1 rule replaced with its ESLint equivalent. ✨${EOL}` +
-                `📢 1 ESLint rule behaves differently from their TSLint counterparts: 📢${EOL}` +
-                `* tslint-rule-one:${EOL}` +
-                `  - 1${EOL}` +
-                `  - 2${EOL}`,
+            `✨ 1 rule replaced with its ESLint equivalent. ✨${EOL}`,
+            `❗ 1 ESLint rule behaves differently from its TSLint counterpart ❗`,
+            `  * tslint-rule-one:`,
+            `    - 1`,
+            `    - 2`,
         );
     });
 
@@ -98,14 +98,14 @@ describe("reportConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            `✨ 2 rules replaced with their ESLint equivalents. ✨${EOL}` +
-                `📢 2 ESLint rules behave differently from their TSLint counterparts: 📢${EOL}` +
-                `* tslint-rule-one:${EOL}` +
-                `  - 1${EOL}` +
-                `  - 2${EOL}` +
-                `* tslint-rule-two:${EOL}` +
-                `  - 3${EOL}` +
-                `  - 4${EOL}`,
+            `✨ 2 rules replaced with their ESLint equivalents. ✨${EOL}`,
+            `❗ 2 ESLint rules behave differently from their TSLint counterparts ❗`,
+            `  * tslint-rule-one:`,
+            `    - 1`,
+            `    - 2`,
+            `  * tslint-rule-two:`,
+            `    - 3`,
+            `    - 4`,
         );
     });
 
@@ -123,8 +123,8 @@ describe("reportConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stderr.write,
-            "💀 1 error thrown. 💀",
-            `Check ${logger.debugFileName} for details.`,
+            "❌ 1 error thrown. ❌",
+            `  Check ${logger.debugFileName} for details.`,
         );
     });
 
@@ -142,8 +142,8 @@ describe("reportConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stderr.write,
-            "💀 2 errors thrown. 💀",
-            `Check ${logger.debugFileName} for details.`,
+            "❌ 2 errors thrown. ❌",
+            `  Check ${logger.debugFileName} for details.`,
         );
     });
 
@@ -167,7 +167,8 @@ describe("reportConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            "👀 1 rule does not yet have an ESLint equivalent (see generated log file); defaulting to eslint-plugin-tslint for these rules. 👀",
+            "❓ 1 rule does not yet have an ESLint equivalent ❓",
+            `  See generated log file; defaulting to eslint-plugin-tslint for it.`,
         );
         expectEqualWrites(
             logger.info.write,
@@ -200,7 +201,8 @@ describe("reportConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            "👀 2 rules do not yet have ESLint equivalents (see generated log file); defaulting to eslint-plugin-tslint for these rules. 👀",
+            "❓ 2 rules do not yet have ESLint equivalents ❓",
+            `  See generated log file; defaulting to eslint-plugin-tslint for these rules.`,
         );
         expectEqualWrites(
             logger.info.write,
@@ -224,7 +226,7 @@ describe("reportConversionResults", () => {
         expectEqualWrites(
             logger.stdout.write,
             "⚡ 1 package is required for new ESLint rules. ⚡",
-            "\tplugin-one",
+            "  plugin-one",
         );
     });
 
@@ -243,8 +245,8 @@ describe("reportConversionResults", () => {
         expectEqualWrites(
             logger.stdout.write,
             "⚡ 2 packages are required for new ESLint rules. ⚡",
-            "\tplugin-one",
-            "\tplugin-two",
+            "  plugin-one",
+            "  plugin-two",
         );
     });
 });

--- a/src/reporting/reportConversionResults.ts
+++ b/src/reporting/reportConversionResults.ts
@@ -26,15 +26,17 @@ export const reportConversionResults = (
     }
 
     if (ruleConversionResults.missing.length !== 0) {
-        const missingSettingOutputMapping = (setting: TSLintRuleOptions) =>
-            `${setting.ruleName} does not yet have an ESLint equivalent.${EOL}`;
-        const additionalWarnings = [`defaulting to eslint-plugin-tslint for these rules`];
         logMissingConversionTarget(
             "rule",
-            missingSettingOutputMapping,
+            (setting: TSLintRuleOptions) =>
+                `${setting.ruleName} does not yet have an ESLint equivalent.${EOL}`,
             ruleConversionResults.missing,
             dependencies.logger,
-            additionalWarnings,
+            [
+                ruleConversionResults.missing.length === 1
+                    ? "defaulting to eslint-plugin-tslint for it."
+                    : "defaulting to eslint-plugin-tslint for these rules.",
+            ],
         );
     }
 
@@ -54,19 +56,27 @@ const logNotices = (converted: Map<string, ESLintRuleOptions>, logger: Logger) =
     ) as RuleWithNotices[];
 
     if (rulesWithNotices.length !== 0) {
-        logger.stdout.write(chalk.yellowBright(`📢 ${rulesWithNotices.length} ESLint`));
-        logger.stdout.write(
-            chalk.yellowBright(rulesWithNotices.length === 1 ? ` rule behaves` : ` rules behave`),
-        );
-        logger.stdout.write(
-            chalk.yellowBright(` differently from their TSLint counterparts: 📢${EOL}`),
-        );
+        logger.stdout.write(chalk.yellowBright(`${EOL}❗ ${rulesWithNotices.length} ESLint`));
+
+        if (rulesWithNotices.length === 1) {
+            logger.stdout.write(
+                chalk.yellowBright(
+                    ` rule behaves differently from its TSLint counterpart ❗${EOL}`,
+                ),
+            );
+        } else {
+            logger.stdout.write(
+                chalk.yellowBright(
+                    ` rules behave differently from their TSLint counterparts ❗${EOL}`,
+                ),
+            );
+        }
 
         for (const rule of rulesWithNotices) {
-            logger.stdout.write(chalk.yellow(`* ${rule.ruleName}:${EOL}`));
+            logger.stdout.write(chalk.yellow(`  * ${rule.ruleName}:${EOL}`));
 
             for (const notice of rule.notices) {
-                logger.stdout.write(chalk.yellow(`  - ${notice}${EOL}`));
+                logger.stdout.write(chalk.yellow(`    - ${notice}${EOL}`));
             }
         }
     }

--- a/src/reporting/reportEditorSettingConversionResults.test.ts
+++ b/src/reporting/reportEditorSettingConversionResults.test.ts
@@ -28,7 +28,7 @@ describe("reportEditorSettingConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            `✨ 1 editor setting replaced with its ESLint equivalent. ✨${EOL}`,
+            `${EOL}✨ 1 editor setting replaced with its ESLint equivalent. ✨${EOL}`,
         );
     });
 
@@ -61,7 +61,7 @@ describe("reportEditorSettingConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            `✨ 2 editor settings replaced with their ESLint equivalents. ✨${EOL}`,
+            `${EOL}✨ 2 editor settings replaced with their ESLint equivalents. ✨${EOL}`,
         );
     });
 
@@ -79,8 +79,8 @@ describe("reportEditorSettingConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stderr.write,
-            "💀 1 error thrown. 💀",
-            `Check ${logger.debugFileName} for details.`,
+            `❌ 1 error thrown. ❌`,
+            `  Check ${logger.debugFileName} for details.`,
         );
     });
 
@@ -98,8 +98,8 @@ describe("reportEditorSettingConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stderr.write,
-            "💀 2 errors thrown. 💀",
-            `Check ${logger.debugFileName} for details.`,
+            `❌ 2 errors thrown. ❌`,
+            `  Check ${logger.debugFileName} for details.`,
         );
     });
 
@@ -121,7 +121,8 @@ describe("reportEditorSettingConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            "👀 1 editor setting does not yet have an ESLint equivalent (see generated log file). 👀",
+            `❓ 1 editor setting does not yet have an ESLint equivalent ❓`,
+            `  See generated log file.`,
         );
         expectEqualWrites(
             logger.info.write,
@@ -150,7 +151,8 @@ describe("reportEditorSettingConversionResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            "👀 2 editor settings do not yet have ESLint equivalents (see generated log file). 👀",
+            `❓ 2 editor settings do not yet have ESLint equivalents ❓`,
+            `  See generated log file.`,
         );
         expectEqualWrites(
             logger.info.write,

--- a/src/reporting/reportOutputs.ts
+++ b/src/reporting/reportOutputs.ts
@@ -23,14 +23,12 @@ export const logSuccessfulConversions = (
 };
 
 export const logFailedConversions = (failed: ErrorSummary[], logger: Logger) => {
-    logger.stderr.write(`${chalk.redBright(`💀 ${failed.length}`)}`);
+    logger.stderr.write(`${chalk.redBright(`${EOL}❌ ${failed.length}`)}`);
     logger.stderr.write(chalk.red(` error${failed.length === 1 ? "" : "s"}`));
     logger.stderr.write(chalk.red(" thrown."));
-    logger.stderr.write(chalk.redBright(` 💀${EOL}`));
-
+    logger.stderr.write(chalk.redBright(` ❌${EOL}`));
     logger.info.write(failed.map(failed => failed.getSummary()).join("\n\n") + "\n\n");
-
-    logger.stderr.write(chalk.gray(`Check ${logger.debugFileName} for details.${EOL}`));
+    logger.stderr.write(chalk.gray(`  Check ${logger.debugFileName} for details.${EOL}`));
 };
 
 export const logMissingConversionTarget = <T>(
@@ -40,7 +38,7 @@ export const logMissingConversionTarget = <T>(
     logger: Logger,
     additionalWarnings: string[] = [],
 ) => {
-    logger.stdout.write(chalk.yellowBright(`️👀 ${missing.length}`));
+    logger.stdout.write(chalk.yellowBright(`️${EOL}❓ ${missing.length}`));
     logger.stdout.write(
         chalk.yellow(
             missing.length === 1
@@ -48,23 +46,27 @@ export const logMissingConversionTarget = <T>(
                 : ` ${conversionTypeName}s do not yet have ESLint equivalents`,
         ),
     );
-    logger.stdout.write(chalk.yellow(` (see generated log file)`));
+    logger.stdout.write(chalk.yellowBright(` ❓${EOL}`));
+    logger.stdout.write(chalk.yellow(`  See generated log file`));
 
     if (additionalWarnings.length > 0) {
         logger.stdout.write(chalk.yellow("; "));
-    }
-    for (const warning of additionalWarnings) {
-        logger.stdout.write(chalk.yellow(warning));
-    }
-    logger.stdout.write(chalk.yellow("."));
 
-    logger.stdout.write(chalk.yellowBright(` 👀${EOL}`));
+        for (const warning of additionalWarnings) {
+            logger.stdout.write(chalk.yellow(warning));
+        }
+    } else {
+        logger.stdout.write(chalk.yellow("."));
+    }
 
-    logger.info.write(missing.map(conversion => missingOutputMapping(conversion)).join(""));
+    logger.info.write(
+        chalk.yellow(missing.map(conversion => missingOutputMapping(conversion)).join("")),
+    );
+    logger.stdout.write(chalk.yellow(EOL));
 };
 
 export const logMissingPlugins = (plugins: Set<string>, logger: Logger) => {
-    logger.stdout.write(chalk.cyanBright(`⚡ ${plugins.size}`));
+    logger.stdout.write(chalk.cyanBright(`${EOL}⚡ ${plugins.size}`));
     logger.stdout.write(chalk.cyan(" package"));
     logger.stdout.write(chalk.cyan(plugins.size === 1 ? " is" : "s are"));
     logger.stdout.write(chalk.cyan(` required for new ESLint rules.`));
@@ -72,7 +74,8 @@ export const logMissingPlugins = (plugins: Set<string>, logger: Logger) => {
 
     logger.stdout.write(
         Array.from(plugins)
-            .map(pluginName => `\t${chalk.cyanBright(pluginName)}${EOL}`)
+            .map(pluginName => `  ${chalk.cyanBright(pluginName)}${EOL}`)
             .join(""),
     );
+    logger.stdout.write(EOL);
 };


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #306
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Changes padding around and in groups to look like this:


![Screenshot of standardized spacing between groups](https://user-images.githubusercontent.com/3335181/71420272-58ef5b80-2642-11ea-9933-4cdf367969e8.png)

Also uses emojis supported on Cmder (Windows) where they weren't before.