### PR TITLE
Convert space-within-parens to space-in-parens

### DIFF
--- a/src/rules/converters/space-within-parens.ts
+++ b/src/rules/converters/space-within-parens.ts
@@ -16,7 +16,7 @@ export const convertSpaceWithinParens: RuleConverter = tslintRule => {
             {
                 ...(notices !== undefined && { notices }),
                 ruleArguments: [arg],
-                ruleName: "@typescript-eslint/space-within-parens",
+                ruleName: "space-in-parens",
             },
         ],
     };

--- a/src/rules/converters/tests/space-within-parens.test.ts
+++ b/src/rules/converters/tests/space-within-parens.test.ts
@@ -10,7 +10,7 @@ describe(convertSpaceWithinParens, () => {
             rules: [
                 {
                     ruleArguments: ["never"],
-                    ruleName: "@typescript-eslint/space-within-parens",
+                    ruleName: "space-in-parens",
                 },
             ],
         });
@@ -26,7 +26,7 @@ describe(convertSpaceWithinParens, () => {
                 {
                     notices: ["The number of spaces will be ignored"],
                     ruleArguments: ["always"],
-                    ruleName: "@typescript-eslint/space-within-parens",
+                    ruleName: "space-in-parens",
                 },
             ],
         });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #307 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

TSLint rule `space-within-parens` will be converted to `space-in-parens` instead of `@typescript-eslint/space-within-parens`


