### PR TITLE
always set markers for spaced-comment rule to support reference types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,13 @@ module.exports = {
     },
     plugins: ["@typescript-eslint"],
     rules: {
+        "@typescript-eslint/array-type": [
+            "error",
+            {
+                default: "array-simple",
+                readonly: "array-simple",
+            },
+        ],
         "@typescript-eslint/consistent-type-definitions": ["error", "type"],
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/generic-type-naming": "off",

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@
 *.map
 coverage/
 node_modules/
+pnpm-lock.yaml
 src/**/*.js
 test/*.js
 ~test/jest.config.js
 !test/tests/**/.eslintrc*
 !test/tests/**/*.log
+.idea/

--- a/src/rules/converters/comment-format.ts
+++ b/src/rules/converters/comment-format.ts
@@ -9,12 +9,13 @@ export const CapitalizedIgnoreMessage = "Only accepts a single string pattern to
 
 export const convertCommentFormat: RuleConverter = tslintRule => {
     const capitalizedRuleArguments: string[] = [];
-    const spaceCommentRuleArguments: string[] = [];
+    const spaceCommentRuleArguments: Array<string | { markers: string[] }> = [];
     const capitalizedNotices: string[] = [];
 
-    if (!tslintRule.ruleArguments.includes("check-space")) {
-        spaceCommentRuleArguments.push("never");
+    if (!spaceCommentRuleArguments.includes("always")) {
+        spaceCommentRuleArguments.push("always");
     }
+    spaceCommentRuleArguments.push({ markers: ["/"] });
 
     if (tslintRule.ruleArguments.includes("check-uppercase")) {
         capitalizedRuleArguments.push("always");

--- a/src/rules/converters/tests/comment-format.test.ts
+++ b/src/rules/converters/tests/comment-format.test.ts
@@ -9,7 +9,7 @@ describe(convertCommentFormat, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: ["never"],
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -24,6 +24,7 @@ describe(convertCommentFormat, () => {
         expect(result).toEqual({
             rules: [
                 {
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -42,7 +43,7 @@ describe(convertCommentFormat, () => {
                     ruleName: "capitalized-comments",
                 },
                 {
-                    ruleArguments: ["never"],
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -62,7 +63,7 @@ describe(convertCommentFormat, () => {
                     ruleName: "capitalized-comments",
                 },
                 {
-                    ruleArguments: ["never"],
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -77,7 +78,7 @@ describe(convertCommentFormat, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: ["never"],
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -96,7 +97,7 @@ describe(convertCommentFormat, () => {
                     ruleName: "capitalized-comments",
                 },
                 {
-                    ruleArguments: ["never"],
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -111,7 +112,7 @@ describe(convertCommentFormat, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: ["never"],
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -131,7 +132,7 @@ describe(convertCommentFormat, () => {
                     ruleName: "capitalized-comments",
                 },
                 {
-                    ruleArguments: ["never"],
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -146,7 +147,7 @@ describe(convertCommentFormat, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: ["never"],
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -172,6 +173,7 @@ describe(convertCommentFormat, () => {
                     ruleName: "capitalized-comments",
                 },
                 {
+                    ruleArguments: ["always", { markers: ["/"] }],
                     ruleName: "spaced-comment",
                 },
             ],


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #317
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
Always set markers for spaced-comment rule to support reference types.

Example:
```ts
/// <reference types="path-to-file" />
```