### PR TITLE
Change notice behavior for trailing-comma esSpecCompliant

### DIFF
--- a/src/rules/converters/tests/trailing-comma.test.ts
+++ b/src/rules/converters/tests/trailing-comma.test.ts
@@ -22,24 +22,28 @@ describe(convertTrailingComma, () => {
                     singleline: "never",
                 },
                 expectedRuleArguments: [],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
                     singleline: "always",
                 },
                 expectedRuleArguments: [],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
                     multiline: "never",
                 },
                 expectedRuleArguments: [],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
                     multiline: "always",
                 },
                 expectedRuleArguments: ["always-multiline"],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -47,6 +51,7 @@ describe(convertTrailingComma, () => {
                     multiline: "never",
                 },
                 expectedRuleArguments: [],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -54,6 +59,7 @@ describe(convertTrailingComma, () => {
                     multiline: "always",
                 },
                 expectedRuleArguments: ["always-multiline"],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -61,6 +67,7 @@ describe(convertTrailingComma, () => {
                     multiline: "never",
                 },
                 expectedRuleArguments: [],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -68,6 +75,7 @@ describe(convertTrailingComma, () => {
                     multiline: "always",
                 },
                 expectedRuleArguments: ["always"],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
         ];
 
@@ -84,6 +92,7 @@ describe(convertTrailingComma, () => {
                             ...(testCase.expectedRuleArguments.length !== 0 && {
                                 ruleArguments: testCase.expectedRuleArguments,
                             }),
+                            notices: testCase.expectedNotices,
                         },
                     ],
                 });
@@ -113,6 +122,7 @@ describe(convertTrailingComma, () => {
                         exports: "always-multiline",
                     },
                 ],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -134,6 +144,7 @@ describe(convertTrailingComma, () => {
                         exports: "always",
                     },
                 ],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -154,6 +165,7 @@ describe(convertTrailingComma, () => {
                         exports: "never",
                     },
                 ],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -175,6 +187,7 @@ describe(convertTrailingComma, () => {
                         functions: "never",
                     },
                 ],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -195,6 +208,7 @@ describe(convertTrailingComma, () => {
                         exports: "always-multiline",
                     },
                 ],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -222,6 +236,7 @@ describe(convertTrailingComma, () => {
                         exports: "always",
                     },
                 ],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -242,6 +257,7 @@ describe(convertTrailingComma, () => {
                         functions: "always-multiline",
                     },
                 ],
+                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
         ];
 
@@ -258,6 +274,7 @@ describe(convertTrailingComma, () => {
                             ...(testCase.expectedRuleArguments.length && {
                                 ruleArguments: testCase.expectedRuleArguments,
                             }),
+                            notices: testCase.expectedNotices,
                         },
                     ],
                 });
@@ -272,7 +289,6 @@ describe(convertTrailingComma, () => {
                     esSpecCompliant: true,
                 },
                 expectedRuleArguments: [],
-                expectedNotices: ["ESLint does not support config property esSpecCompliant"],
             },
             {
                 argument: {
@@ -281,7 +297,10 @@ describe(convertTrailingComma, () => {
                     },
                 },
                 expectedRuleArguments: [{}],
-                expectedNotices: ["ESLint does not support config property typeLiterals"],
+                expectedNotices: [
+                    "ESLint only supports esSpecCompliant enabled",
+                    "ESLint does not support config property typeLiterals",
+                ],
             },
             {
                 argument: {
@@ -290,7 +309,10 @@ describe(convertTrailingComma, () => {
                     },
                 },
                 expectedRuleArguments: [{}],
-                expectedNotices: ["ESLint does not support config property typeLiterals"],
+                expectedNotices: [
+                    "ESLint only supports esSpecCompliant enabled",
+                    "ESLint does not support config property typeLiterals",
+                ],
             },
             {
                 argument: {
@@ -301,7 +323,6 @@ describe(convertTrailingComma, () => {
                 },
                 expectedRuleArguments: [{}],
                 expectedNotices: [
-                    "ESLint does not support config property esSpecCompliant",
                     "ESLint does not support config property typeLiterals",
                 ],
             },
@@ -314,7 +335,7 @@ describe(convertTrailingComma, () => {
                 },
                 expectedRuleArguments: [{}],
                 expectedNotices: [
-                    "ESLint does not support config property esSpecCompliant",
+                    "ESLint only supports esSpecCompliant enabled",
                     "ESLint does not support config property typeLiterals",
                 ],
             },
@@ -330,7 +351,7 @@ describe(convertTrailingComma, () => {
                 },
                 expectedRuleArguments: [{}],
                 expectedNotices: [
-                    "ESLint does not support config property esSpecCompliant",
+                    "ESLint only supports esSpecCompliant enabled",
                     "ESLint does not support config property typeLiterals",
                 ],
             },

--- a/src/rules/converters/tests/trailing-comma.test.ts
+++ b/src/rules/converters/tests/trailing-comma.test.ts
@@ -22,28 +22,24 @@ describe(convertTrailingComma, () => {
                     singleline: "never",
                 },
                 expectedRuleArguments: [],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
                     singleline: "always",
                 },
                 expectedRuleArguments: [],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
                     multiline: "never",
                 },
                 expectedRuleArguments: [],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
                     multiline: "always",
                 },
                 expectedRuleArguments: ["always-multiline"],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -51,7 +47,6 @@ describe(convertTrailingComma, () => {
                     multiline: "never",
                 },
                 expectedRuleArguments: [],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -59,7 +54,6 @@ describe(convertTrailingComma, () => {
                     multiline: "always",
                 },
                 expectedRuleArguments: ["always-multiline"],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -67,7 +61,6 @@ describe(convertTrailingComma, () => {
                     multiline: "never",
                 },
                 expectedRuleArguments: [],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -75,7 +68,6 @@ describe(convertTrailingComma, () => {
                     multiline: "always",
                 },
                 expectedRuleArguments: ["always"],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
         ];
 
@@ -92,7 +84,6 @@ describe(convertTrailingComma, () => {
                             ...(testCase.expectedRuleArguments.length !== 0 && {
                                 ruleArguments: testCase.expectedRuleArguments,
                             }),
-                            notices: testCase.expectedNotices,
                         },
                     ],
                 });
@@ -122,7 +113,6 @@ describe(convertTrailingComma, () => {
                         exports: "always-multiline",
                     },
                 ],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -144,7 +134,6 @@ describe(convertTrailingComma, () => {
                         exports: "always",
                     },
                 ],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -165,7 +154,6 @@ describe(convertTrailingComma, () => {
                         exports: "never",
                     },
                 ],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -187,7 +175,6 @@ describe(convertTrailingComma, () => {
                         functions: "never",
                     },
                 ],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -208,7 +195,6 @@ describe(convertTrailingComma, () => {
                         exports: "always-multiline",
                     },
                 ],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -236,7 +222,6 @@ describe(convertTrailingComma, () => {
                         exports: "always",
                     },
                 ],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
             {
                 argument: {
@@ -257,7 +242,6 @@ describe(convertTrailingComma, () => {
                         functions: "always-multiline",
                     },
                 ],
-                expectedNotices: ["ESLint only supports esSpecCompliant enabled"],
             },
         ];
 
@@ -274,7 +258,6 @@ describe(convertTrailingComma, () => {
                             ...(testCase.expectedRuleArguments.length && {
                                 ruleArguments: testCase.expectedRuleArguments,
                             }),
-                            notices: testCase.expectedNotices,
                         },
                     ],
                 });
@@ -297,10 +280,7 @@ describe(convertTrailingComma, () => {
                     },
                 },
                 expectedRuleArguments: [{}],
-                expectedNotices: [
-                    "ESLint only supports esSpecCompliant enabled",
-                    "ESLint does not support config property typeLiterals",
-                ],
+                expectedNotices: ["ESLint does not support config property typeLiterals"],
             },
             {
                 argument: {
@@ -309,10 +289,7 @@ describe(convertTrailingComma, () => {
                     },
                 },
                 expectedRuleArguments: [{}],
-                expectedNotices: [
-                    "ESLint only supports esSpecCompliant enabled",
-                    "ESLint does not support config property typeLiterals",
-                ],
+                expectedNotices: ["ESLint does not support config property typeLiterals"],
             },
             {
                 argument: {
@@ -322,9 +299,7 @@ describe(convertTrailingComma, () => {
                     },
                 },
                 expectedRuleArguments: [{}],
-                expectedNotices: [
-                    "ESLint does not support config property typeLiterals",
-                ],
+                expectedNotices: ["ESLint does not support config property typeLiterals"],
             },
             {
                 argument: {

--- a/src/rules/converters/trailing-comma.ts
+++ b/src/rules/converters/trailing-comma.ts
@@ -125,7 +125,7 @@ function collectNotices(args: TSLintArg[]): string[] {
 }
 
 function buildNoticeForEsSpecCompliant(arg: TSLintArg): string {
-    if (!arg.esSpecCompliant) {
+    if (arg.esSpecCompliant === false) {
         return `ESLint only supports esSpecCompliant enabled`;
     }
 

--- a/src/rules/converters/trailing-comma.ts
+++ b/src/rules/converters/trailing-comma.ts
@@ -125,10 +125,8 @@ function collectNotices(args: TSLintArg[]): string[] {
 }
 
 function buildNoticeForEsSpecCompliant(arg: TSLintArg): string {
-    const unsupportedConfigKey = "esSpecCompliant";
-
-    if (Object.keys(arg).includes(unsupportedConfigKey)) {
-        return `ESLint does not support config property ${unsupportedConfigKey}`;
+    if (!arg.esSpecCompliant) {
+        return `ESLint only supports esSpecCompliant enabled`;
     }
 
     return "";


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #329
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
I've changed the notice behavior of `esSpecCompliant` property for rule trailing-comma. Previously, a notice would be given when the `esSpecCompliant` was present. Since eslint only supports `esSpecCompliant == true` no notice should be given in that instance.

After this change, a notice will be given when `esSpecCompliant` is either `undefined` or `false`. 