### PR TITLE
Fix space-within-parens with option 0

### DIFF
--- a/src/rules/converters/space-within-parens.ts
+++ b/src/rules/converters/space-within-parens.ts
@@ -4,7 +4,7 @@ export const convertSpaceWithinParens: RuleConverter = tslintRule => {
     let notices: string[] | undefined;
     let arg: string;
 
-    if (tslintRule.ruleArguments.length === 1) {
+    if (tslintRule.ruleArguments.length === 1 && tslintRule.ruleArguments[0] !== 0) {
         arg = "always";
         notices = ["The number of spaces will be ignored"];
     } else {

--- a/src/rules/converters/tests/space-within-parens.test.ts
+++ b/src/rules/converters/tests/space-within-parens.test.ts
@@ -16,6 +16,21 @@ describe(convertSpaceWithinParens, () => {
         });
     });
 
+    test("conversion with 0 spaces required", () => {
+        const result = convertSpaceWithinParens({
+            ruleArguments: [0],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: ["never"],
+                    ruleName: "space-in-parens",
+                },
+            ],
+        });
+    });
+
     test("conversion with min spaces arguement", () => {
         const result = convertSpaceWithinParens({
             ruleArguments: [5],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #331
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
If the requirement is `0` spaces, the result will be `never`.
