### PR TITLE
Fix arguments passed to array-type

### DIFF
--- a/src/rules/converters/array-type.ts
+++ b/src/rules/converters/array-type.ts
@@ -1,9 +1,12 @@
 import { RuleConverter } from "../converter";
 
-export const convertArrayType: RuleConverter = () => {
+export const convertArrayType: RuleConverter = tslintRule => {
     return {
         rules: [
             {
+                ...(tslintRule.ruleArguments.length > 0 && {
+                    ruleArguments: [{ default: tslintRule.ruleArguments[0] }],
+                }),
                 ruleName: "@typescript-eslint/array-type",
             },
         ],

--- a/src/rules/converters/tests/array-type.test.ts
+++ b/src/rules/converters/tests/array-type.test.ts
@@ -14,4 +14,46 @@ describe(convertArrayType, () => {
             ],
         });
     });
+    test("conversion with argument array-simple", () => {
+        const result = convertArrayType({
+            ruleArguments: ["array-simple"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/array-type",
+                    ruleArguments: [{ default: "array-simple" }],
+                },
+            ],
+        });
+    });
+    test("conversion with argument generic", () => {
+        const result = convertArrayType({
+            ruleArguments: ["generic"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/array-type",
+                    ruleArguments: [{ default: "generic" }],
+                },
+            ],
+        });
+    });
+    test("conversion with argument simple", () => {
+        const result = convertArrayType({
+            ruleArguments: ["simple"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/array-type",
+                    ruleArguments: [{ default: "simple" }],
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #333
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Options are now kept. See See https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/array-type.md.
