### PR TITLE
Fixed member-access converter for option length 1

### DIFF
--- a/src/rules/converters/member-access.ts
+++ b/src/rules/converters/member-access.ts
@@ -22,7 +22,7 @@ export const convertMemberAccess: RuleConverter = tslintRule => {
         accessibility: AccessibilityLevel.Explicit,
     };
 
-    if (tslintRule.ruleArguments.length >= 2 || tslintRule.ruleArguments[0] === true) {
+    if (tslintRule.ruleArguments.length >= 1 || tslintRule.ruleArguments[0] === true) {
         for (const ruleArg of tslintRule.ruleArguments) {
             if (typeof ruleArg === "string") {
                 switch (ruleArg) {

--- a/src/rules/converters/tests/member-access.test.ts
+++ b/src/rules/converters/tests/member-access.test.ts
@@ -33,6 +33,21 @@ describe(convertMemberAccess, () => {
 
     test("conversion with no-public argument", () => {
         const result = convertMemberAccess({
+            ruleArguments: ["no-public"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ accessibility: AccessibilityLevel.NoPublic }],
+                    ruleName: "@typescript-eslint/explicit-member-accessibility",
+                },
+            ],
+        });
+    });
+
+    test("conversion with true and no-public argument", () => {
+        const result = convertMemberAccess({
             ruleArguments: [true, "no-public"],
         });
 
@@ -46,7 +61,7 @@ describe(convertMemberAccess, () => {
         });
     });
 
-    test("conversion with check-accessor argument", () => {
+    test("conversion with true and check-accessor argument", () => {
         const result = convertMemberAccess({
             ruleArguments: [true, "check-accessor"],
         });
@@ -68,7 +83,7 @@ describe(convertMemberAccess, () => {
         });
     });
 
-    test("conversion with check-constructor argument", () => {
+    test("conversion with true and check-constructor argument", () => {
         const result = convertMemberAccess({
             ruleArguments: [true, "check-constructor"],
         });
@@ -90,7 +105,7 @@ describe(convertMemberAccess, () => {
         });
     });
 
-    test("conversion with check-parameter-property argument", () => {
+    test("conversion with true and check-parameter-property argument", () => {
         const result = convertMemberAccess({
             ruleArguments: [true, "check-parameter-property"],
         });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #335
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Allows the rule arguments to not begin with `true,`.