### PR TITLE
Fix arrow-parens converter

### DIFF
--- a/src/rules/converters/arrow-parens.ts
+++ b/src/rules/converters/arrow-parens.ts
@@ -2,9 +2,10 @@ import { RuleConverter } from "../converter";
 
 export const convertArrowParens: RuleConverter = tslintRule => {
     const ruleArguments = [
-        tslintRule.ruleArguments.length !== 0 && tslintRule.ruleArguments[0] === "always"
-            ? "always"
-            : "as-needed",
+        tslintRule.ruleArguments.length !== 0 &&
+        tslintRule.ruleArguments[0] === "ban-single-arg-parens"
+            ? "as-needed"
+            : "always",
     ];
 
     return {

--- a/src/rules/converters/tests/arrow-parens.test.ts
+++ b/src/rules/converters/tests/arrow-parens.test.ts
@@ -9,21 +9,6 @@ describe(convertArrowParens, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: ["as-needed"],
-                    ruleName: "arrow-parens",
-                },
-            ],
-        });
-    });
-
-    test("conversion with an always argument", () => {
-        const result = convertArrowParens({
-            ruleArguments: ["always"],
-        });
-
-        expect(result).toEqual({
-            rules: [
-                {
                     ruleArguments: ["always"],
                     ruleName: "arrow-parens",
                 },
@@ -31,9 +16,9 @@ describe(convertArrowParens, () => {
         });
     });
 
-    test("conversion with an as-needed argument", () => {
+    test("conversion with a ban-single-arg-parens argument", () => {
         const result = convertArrowParens({
-            ruleArguments: ["as-needed"],
+            ruleArguments: ["ban-single-arg-parens"],
         });
 
         expect(result).toEqual({


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #346 
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

`arrow-parens` converter now handles `"ban-single-arg-parens"` in semantically proper way, according to each rule's definition:
https://palantir.github.io/tslint/rules/arrow-parens/
https://eslint.org/docs/rules/arrow-parens

Tests have also been updated, since only two possible argument sets are either `"ban-single-arg-parens"` or no arguments.
