### PR TITLE
chore: set minimum node version to 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
 jobs:
     build:
         docker:
-            - image: circleci/node:8
+            - image: circleci/node:10
 
         working_directory: ~/repo
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "description": "Converts your TSLint configuration to the closest reasonable ESLint equivalent.",
     "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
     },
     "dependencies": {
         "chalk": "3.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "declaration": true,
         "esModuleInterop": true,
         "incremental": true,
-        "lib": ["es2017"],
+        "lib": [],
         "module": "commonjs",
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,
@@ -19,7 +19,7 @@
         "strictFunctionTypes": true,
         "strictNullChecks": true,
         "strictPropertyInitialization": true,
-        "target": "es2015"
+        "target": "es2018"
     },
     "exclude": ["test/tests/**/*"],
     "include": ["src/**/*"]


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #328
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
- Set minimum engine to Node +10.
- Set `target` to `es2018` and remove `es2017` from `lib` option. See [tsconfig target](https://www.typescriptlang.org/v2/en/tsconfig#target) and [tsconfig lib](https://www.typescriptlang.org/v2/en/tsconfig#lib).
