### PR TITLE
Respect the original TSLint configuration of `ban-types`

### DIFF
--- a/src/rules/converters/ban-types.ts
+++ b/src/rules/converters/ban-types.ts
@@ -8,12 +8,12 @@ export const convertBanTypes: RuleConverter = tslintRule => {
     const bannedTypes: Record<string, ConvertBanTypeArgument | null> = {};
 
     for (const rule of tslintRule.ruleArguments) {
-        const typ = rule[0];
-        if (!typ) {
+        const bannedType = rule[0];
+        if (!bannedType) {
             break;
         }
 
-        bannedTypes[typ] = rule[1]
+        bannedTypes[bannedType] = rule[1]
             ? {
                   message: rule[1],
               }

--- a/src/rules/converters/ban-types.ts
+++ b/src/rules/converters/ban-types.ts
@@ -1,10 +1,33 @@
 import { RuleConverter } from "../converter";
 
-export const convertBanTypes: RuleConverter = () => {
+export const convertBanTypes: RuleConverter = tslintRule => {
+    type ConvertBanTypeArgument = {
+        message: string;
+    };
+
+    const bannedTypesObj: { [key: string]: ConvertBanTypeArgument | null } = {};
+
+    for (const rule of tslintRule.ruleArguments) {
+        const typ = rule[0];
+        if (!typ) {
+            break;
+        }
+
+        bannedTypesObj[typ] = rule[1]
+            ? {
+                  message: rule[1],
+              }
+            : null;
+    }
+
+    const ruleArguments =
+        Object.keys(bannedTypesObj).length === 0 ? undefined : [{ types: bannedTypesObj }];
+
     return {
         rules: [
             {
                 ruleName: "@typescript-eslint/ban-types",
+                ...{ ruleArguments },
             },
         ],
     };

--- a/src/rules/converters/ban-types.ts
+++ b/src/rules/converters/ban-types.ts
@@ -5,7 +5,7 @@ export const convertBanTypes: RuleConverter = tslintRule => {
         message: string;
     };
 
-    const bannedTypesObj: Record<string, ConvertBanTypeArgument | null> = {};
+    const bannedTypes: Record<string, ConvertBanTypeArgument | null> = {};
 
     for (const rule of tslintRule.ruleArguments) {
         const typ = rule[0];
@@ -13,7 +13,7 @@ export const convertBanTypes: RuleConverter = tslintRule => {
             break;
         }
 
-        bannedTypesObj[typ] = rule[1]
+        bannedTypes[typ] = rule[1]
             ? {
                   message: rule[1],
               }
@@ -21,7 +21,7 @@ export const convertBanTypes: RuleConverter = tslintRule => {
     }
 
     const ruleArguments =
-        Object.keys(bannedTypesObj).length === 0 ? undefined : [{ types: bannedTypesObj }];
+        Object.keys(bannedTypes).length === 0 ? undefined : [{ types: bannedTypes }];
 
     return {
         rules: [

--- a/src/rules/converters/ban-types.ts
+++ b/src/rules/converters/ban-types.ts
@@ -8,6 +8,10 @@ export const convertBanTypes: RuleConverter = tslintRule => {
     const bannedTypes: Record<string, ConvertBanTypeArgument | null> = {};
 
     for (const rule of tslintRule.ruleArguments) {
+        if (!Array.isArray(rule)) {
+            break;
+        }
+
         const [bannedType, message] = rule;
         if (!bannedType) {
             break;

--- a/src/rules/converters/ban-types.ts
+++ b/src/rules/converters/ban-types.ts
@@ -8,16 +8,12 @@ export const convertBanTypes: RuleConverter = tslintRule => {
     const bannedTypes: Record<string, ConvertBanTypeArgument | null> = {};
 
     for (const rule of tslintRule.ruleArguments) {
-        const bannedType = rule[0];
+        const [bannedType, message] = rule;
         if (!bannedType) {
             break;
         }
 
-        bannedTypes[bannedType] = rule[1]
-            ? {
-                  message: rule[1],
-              }
-            : null;
+        bannedTypes[bannedType] = message ? { message } : null;
     }
 
     const ruleArguments =

--- a/src/rules/converters/ban-types.ts
+++ b/src/rules/converters/ban-types.ts
@@ -5,7 +5,7 @@ export const convertBanTypes: RuleConverter = tslintRule => {
         message: string;
     };
 
-    const bannedTypesObj: { [key: string]: ConvertBanTypeArgument | null } = {};
+    const bannedTypesObj: Record<string, ConvertBanTypeArgument | null> = {};
 
     for (const rule of tslintRule.ruleArguments) {
         const typ = rule[0];

--- a/src/rules/converters/tests/ban-types.test.ts
+++ b/src/rules/converters/tests/ban-types.test.ts
@@ -14,4 +14,59 @@ describe(convertBanTypes, () => {
             ],
         });
     });
+
+    test("conversion with arguments", () => {
+        const result = convertBanTypes({
+            ruleArguments: [
+                ["Object", "Use {} instead."],
+                ["String"],
+                ["Number"],
+                ["Boolean", "Use 'boolean' instead."],
+                [], // empty array: this should be ignored
+            ],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/ban-types",
+                    ruleArguments: [
+                        {
+                            types: {
+                                Object: {
+                                    message: "Use {} instead.",
+                                },
+                                String: null,
+                                Number: null,
+                                Boolean: {
+                                    message: "Use 'boolean' instead.",
+                                },
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    test("conversion with duplicated arguments", () => {
+        const result = convertBanTypes({
+            ruleArguments: [["Object", "Use {} instead."], ["Object"]],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/ban-types",
+                    ruleArguments: [
+                        {
+                            types: {
+                                Object: null,
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });

--- a/src/rules/converters/tests/ban-types.test.ts
+++ b/src/rules/converters/tests/ban-types.test.ts
@@ -69,4 +69,18 @@ describe(convertBanTypes, () => {
             ],
         });
     });
+
+    test("conversion with duplicated arguments", () => {
+        const result = convertBanTypes({
+            ruleArguments: ["!!!this-is-not-array!!!"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/ban-types",
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #352
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

When it gives the following TSLint configuration:

```
{
  "rules": {
    "ban-types": [true,
      ["Object", "Use {} instead."],
    ]
  }
}
```

as-is:

```
  "rules": {
      "@typescript-eslint/ban-types": "error"
  }
```

maybe this doesn't make sense.

to-be:

```
  "rules": {
      "@typescript-eslint/ban-types": [
          "error",
          {
              "types": {
                  "Object": {
                      "message": "Use {} instead."
                  }
              }
          }
      ]
  }
```

This pull-request enhances a converter for ban-types to make the behaviour to be expected: https://github.com/typescript-eslint/typescript-eslint/blob/f3160b471f8247e157555b6cf5b40a1f6ccdc233/packages/eslint-plugin/docs/rules/ban-types.md