### PR TITLE
Support a converter for `no-reference-import` rule

### DIFF
--- a/src/rules/converters/no-reference-import.ts
+++ b/src/rules/converters/no-reference-import.ts
@@ -1,0 +1,18 @@
+import { RuleConverter } from "../converter";
+
+export const convertNoReferenceImport: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@typescript-eslint/triple-slash-reference",
+                ruleArguments: [
+                    {
+                        path: "always",
+                        types: "prefer-import",
+                        lib: "always",
+                    },
+                ],
+            },
+        ],
+    };
+};

--- a/src/rules/converters/tests/no-reference-import.test.ts
+++ b/src/rules/converters/tests/no-reference-import.test.ts
@@ -1,0 +1,24 @@
+import { convertNoReferenceImport } from "../no-reference-import";
+
+describe(convertNoReferenceImport, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoReferenceImport({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/triple-slash-reference",
+                    ruleArguments: [
+                        {
+                            path: "always",
+                            types: "prefer-import",
+                            lib: "always",
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -133,6 +133,7 @@ import { convertUnnecessaryConstructor } from "./converters/unnecessary-construc
 import { convertUseDefaultTypeParameter } from "./converters/use-default-type-parameter";
 import { convertUseIsnan } from "./converters/use-isnan";
 import { convertVariableName } from "./converters/variable-name";
+import { convertNoReferenceImport } from "./converters/no-reference-import";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -219,6 +220,7 @@ export const rulesConverters = new Map([
     ["no-parameter-reassignment", convertNoParameterReassignment],
     ["no-redundant-jsdoc", convertNoRedundantJsdoc],
     ["no-reference", convertNoReference],
+    ["no-reference-import", convertNoReferenceImport],
     ["no-regex-spaces", convertNoRegexSpaces],
     ["no-require-imports", convertNoRequireImports],
     ["no-return-await", convertNoReturnAwait],

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -79,6 +79,7 @@ import { convertNoParameterProperties } from "./converters/no-parameter-properti
 import { convertNoParameterReassignment } from "./converters/no-parameter-reassignment";
 import { convertNoRedundantJsdoc } from "./converters/no-redundant-jsdoc";
 import { convertNoReference } from "./converters/no-reference";
+import { convertNoReferenceImport } from "./converters/no-reference-import";
 import { convertNoRegexSpaces } from "./converters/no-regex-spaces";
 import { convertNoRequireImports } from "./converters/no-require-imports";
 import { convertNoReturnAwait } from "./converters/no-return-await";
@@ -133,7 +134,6 @@ import { convertUnnecessaryConstructor } from "./converters/unnecessary-construc
 import { convertUseDefaultTypeParameter } from "./converters/use-default-type-parameter";
 import { convertUseIsnan } from "./converters/use-isnan";
 import { convertVariableName } from "./converters/variable-name";
-import { convertNoReferenceImport } from "./converters/no-reference-import";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #367
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Support a rule `no-reference-import`.

If this patch was applied,

```
{
  "rules": {
    "no-reference-import": true
  }
}
```

this rule will be converted to

```
    "rules": {
        "@typescript-eslint/triple-slash-reference": [
            "error",
            {
                "path": "always",
                "types": "prefer-import",
                "lib": "always",
            }
        ]
    }
```

## Note

I think `"path": "always"` and `"lib": "always"` are not needed, but `path` one is necessary because if that was omitted, the ESLint points out the violation caused by reference of `path`.

reploducing code:

```
/// <reference path="foo" />
/// <reference types="bar" />
/// <reference lib="buz" />
import b from "bar";
```

Originally the `lib`'s one isn't needed, but I put it on the code for consistency.
(I wonder if this should be an issue of typescript-eslint?)