### PR TITLE
Add merger for @typescript-eslint/consistent-type-assertions

### DIFF
--- a/src/rules/mergers.ts
+++ b/src/rules/mergers.ts
@@ -1,12 +1,14 @@
 import { mergeBanTypes } from "./mergers/ban-types";
+import { mergeConsistentTypeAssertions } from "./mergers/consistent-type-assertions";
 import { mergeIndent } from "./mergers/indent";
-import { mergeNoMemberDelimiterStyle } from "./mergers/member-delimiter-style";
 import { mergeNoCaller } from "./mergers/no-caller";
 import { mergeNoEval } from "./mergers/no-eval";
+import { mergeNoMemberDelimiterStyle } from "./mergers/member-delimiter-style";
 import { mergeNoUnnecessaryTypeAssertion } from "./mergers/no-unnecessary-type-assertion";
 
 export const mergers = new Map([
     ["@typescript-eslint/ban-types", mergeBanTypes],
+    ["@typescript-eslint/consistent-type-assertions", mergeConsistentTypeAssertions],
     ["@typescript-eslint/indent", mergeIndent],
     ["@typescript-eslint/member-delimiter-style", mergeNoMemberDelimiterStyle],
     ["@typescript-eslint/no-unnecessary-type-assertion", mergeNoUnnecessaryTypeAssertion],

--- a/src/rules/mergers/consistent-type-assertions.ts
+++ b/src/rules/mergers/consistent-type-assertions.ts
@@ -1,0 +1,5 @@
+import { RuleMerger } from "../merger";
+
+export const mergeConsistentTypeAssertions: RuleMerger = (existingOptions, newOptions) => {
+    return [existingOptions?.[0] ?? newOptions?.[0]].filter(Boolean);
+};

--- a/src/rules/mergers/tests/consistent-type-assertions.test.ts
+++ b/src/rules/mergers/tests/consistent-type-assertions.test.ts
@@ -1,0 +1,25 @@
+import { mergeConsistentTypeAssertions } from "../consistent-type-assertions";
+
+const option = {
+    assertionStyle: "never",
+};
+
+describe(mergeConsistentTypeAssertions, () => {
+    test("neither options existing", () => {
+        const result = mergeConsistentTypeAssertions(undefined, undefined);
+
+        expect(result).toEqual([]);
+    });
+
+    test("only existing options", () => {
+        const result = mergeConsistentTypeAssertions([option], undefined);
+
+        expect(result).toEqual([option]);
+    });
+
+    test("only new options", () => {
+        const result = mergeConsistentTypeAssertions(undefined, [option]);
+
+        expect(result).toEqual([option]);
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #321
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Adds a merger for `@typescript-eslint/consistent-type-assertions` that preserves the first options object it finds. In theory it could give a warning if both input rules have an option object, but seeing as the converters in this project never emit the options, it seems fine as is for now to me.