### PR TITLE
Adjusted comment-format's check-space output for markers

### DIFF
--- a/src/rules/converters/comment-format.ts
+++ b/src/rules/converters/comment-format.ts
@@ -7,14 +7,10 @@ type CommentFormatOptions = {
 
 export const CapitalizedIgnoreMessage = "Only accepts a single string pattern to be ignored.";
 
-export const convertCommentFormat: RuleConverter = tslintRule => {
+export const convertCommentFormat: RuleConverter = (tslintRule) => {
     const capitalizedRuleArguments: string[] = [];
-    const spaceCommentRuleArguments: string[] = [];
     const capitalizedNotices: string[] = [];
-
-    if (!tslintRule.ruleArguments.includes("check-space")) {
-        spaceCommentRuleArguments.push("never");
-    }
+    const checkSpace = tslintRule.ruleArguments.includes("check-space");
 
     if (tslintRule.ruleArguments.includes("check-uppercase")) {
         capitalizedRuleArguments.push("always");
@@ -44,12 +40,19 @@ export const convertCommentFormat: RuleConverter = tslintRule => {
                           ...(capitalizedNotices.length !== 0 && { notices: capitalizedNotices }),
                       },
                   ]),
-            {
-                ruleName: "spaced-comment",
-                ...(spaceCommentRuleArguments.length !== 0 && {
-                    ruleArguments: spaceCommentRuleArguments,
-                }),
-            },
+            ...(checkSpace
+                ? [
+                      {
+                          ruleName: "spaced-comment",
+                          ruleArguments: [
+                              "always",
+                              {
+                                  markers: ["/"],
+                              },
+                          ],
+                      },
+                  ]
+                : []),
         ],
     };
 };

--- a/src/rules/converters/comment-format.ts
+++ b/src/rules/converters/comment-format.ts
@@ -7,7 +7,7 @@ type CommentFormatOptions = {
 
 export const CapitalizedIgnoreMessage = "Only accepts a single string pattern to be ignored.";
 
-export const convertCommentFormat: RuleConverter = (tslintRule) => {
+export const convertCommentFormat: RuleConverter = tslintRule => {
     const capitalizedRuleArguments: string[] = [];
     const capitalizedNotices: string[] = [];
     const checkSpace = tslintRule.ruleArguments.includes("check-space");

--- a/src/rules/converters/tests/comment-format.test.ts
+++ b/src/rules/converters/tests/comment-format.test.ts
@@ -7,12 +7,7 @@ describe(convertCommentFormat, () => {
         });
 
         expect(result).toEqual({
-            rules: [
-                {
-                    ruleArguments: ["never"],
-                    ruleName: "spaced-comment",
-                },
-            ],
+            rules: [],
         });
     });
 
@@ -24,6 +19,12 @@ describe(convertCommentFormat, () => {
         expect(result).toEqual({
             rules: [
                 {
+                    ruleArguments: [
+                        "always",
+                        {
+                            markers: ["/"],
+                        },
+                    ],
                     ruleName: "spaced-comment",
                 },
             ],
@@ -41,10 +42,6 @@ describe(convertCommentFormat, () => {
                     ruleArguments: ["never"],
                     ruleName: "capitalized-comments",
                 },
-                {
-                    ruleArguments: ["never"],
-                    ruleName: "spaced-comment",
-                },
             ],
         });
     });
@@ -61,10 +58,6 @@ describe(convertCommentFormat, () => {
                     ruleArguments: ["always"],
                     ruleName: "capitalized-comments",
                 },
-                {
-                    ruleArguments: ["never"],
-                    ruleName: "spaced-comment",
-                },
             ],
         });
     });
@@ -75,12 +68,7 @@ describe(convertCommentFormat, () => {
         });
 
         expect(result).toEqual({
-            rules: [
-                {
-                    ruleArguments: ["never"],
-                    ruleName: "spaced-comment",
-                },
-            ],
+            rules: [],
         });
     });
 
@@ -95,10 +83,6 @@ describe(convertCommentFormat, () => {
                     ruleArguments: ["always"],
                     ruleName: "capitalized-comments",
                 },
-                {
-                    ruleArguments: ["never"],
-                    ruleName: "spaced-comment",
-                },
             ],
         });
     });
@@ -109,12 +93,7 @@ describe(convertCommentFormat, () => {
         });
 
         expect(result).toEqual({
-            rules: [
-                {
-                    ruleArguments: ["never"],
-                    ruleName: "spaced-comment",
-                },
-            ],
+            rules: [],
         });
     });
 
@@ -130,10 +109,6 @@ describe(convertCommentFormat, () => {
                     ruleArguments: ["always"],
                     ruleName: "capitalized-comments",
                 },
-                {
-                    ruleArguments: ["never"],
-                    ruleName: "spaced-comment",
-                },
             ],
         });
     });
@@ -144,12 +119,7 @@ describe(convertCommentFormat, () => {
         });
 
         expect(result).toEqual({
-            rules: [
-                {
-                    ruleArguments: ["never"],
-                    ruleName: "spaced-comment",
-                },
-            ],
+            rules: [],
         });
     });
 
@@ -172,6 +142,12 @@ describe(convertCommentFormat, () => {
                     ruleName: "capitalized-comments",
                 },
                 {
+                    ruleArguments: [
+                        "always",
+                        {
+                            markers: ["/"],
+                        },
+                    ],
                     ruleName: "spaced-comment",
                 },
             ],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #317
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Continues #318, but I think corrects the behavior of the rule. TSLint doesn't enforce spacing behavior unless `check-space` is provided, so I think this converter actually should only output a `spaced-comment` configuration when TSLint's `check-space` argument is provided, right? Thoughts @beenotung @KingDarBoja? 

https://palantir.github.io/tslint/rules/comment-format
https://eslint.org/docs/rules/spaced-comment
