### PR TITLE
Added tslint-eslint-plugin package as necessary to install commands

### DIFF
--- a/src/reporting/reportConversionResults.test.ts
+++ b/src/reporting/reportConversionResults.test.ts
@@ -223,8 +223,8 @@ describe("reportConversionResults", () => {
             `  The "@typescript-eslint/tslint/config" section of .eslintrc.js configures eslint-plugin-tslint to run it in TSLint within ESLint.`,
             `  Check ${logger.debugFileName} for details.`,
             ``,
-            `⚡ 3 packages are required for running with ESLint. ⚡`,
-            `  yarn add @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint --dev`,
+            `⚡ 4 packages are required for running with ESLint. ⚡`,
+            `  yarn add @typescript-eslint/eslint-plugin @typescript-eslint/parser @typescript-eslint/tslint-eslint-plugin eslint --dev`,
         );
         expectEqualWrites(
             logger.info.write,
@@ -266,8 +266,8 @@ describe("reportConversionResults", () => {
             `  The "@typescript-eslint/tslint/config" section of .eslintrc.js configures eslint-plugin-tslint to run them in TSLint within ESLint.`,
             `  Check ${logger.debugFileName} for details.`,
             ``,
-            `⚡ 3 packages are required for running with ESLint. ⚡`,
-            `  yarn add @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint --dev`,
+            `⚡ 4 packages are required for running with ESLint. ⚡`,
+            `  yarn add @typescript-eslint/eslint-plugin @typescript-eslint/parser @typescript-eslint/tslint-eslint-plugin eslint --dev`,
         );
         expectEqualWrites(
             logger.info.write,

--- a/src/reporting/reportConversionResults.ts
+++ b/src/reporting/reportConversionResults.ts
@@ -48,7 +48,7 @@ export const reportConversionResults = async (
         );
     }
 
-    logMissingPackages(ruleConversionResults.plugins, packageManager, dependencies.logger);
+    logMissingPackages(ruleConversionResults, packageManager, dependencies.logger);
 };
 
 type RuleWithNotices = {

--- a/src/reporting/reportOutputs.test.ts
+++ b/src/reporting/reportOutputs.test.ts
@@ -1,20 +1,24 @@
-import { PackageManager } from "./packages/packageManagers";
 import { createStubLogger, expectEqualWrites } from "../adapters/logger.stubs";
+import { createEmptyConversionResults } from "../conversion/conversionResults.stubs";
+import { PackageManager } from "./packages/packageManagers";
 import { logMissingPackages } from "./reportOutputs";
 
 const createStubDependencies = (packageManager: PackageManager) => ({
-    packageManager,
-    plugins: new Set<string>(),
     logger: createStubLogger(),
+    packageManager,
+    ruleConversionResults: createEmptyConversionResults(),
 });
 
 describe("reportOutputs", () => {
     it("reports an npm command when the package manager is npm", () => {
         // Arrange
-        const { logger, packageManager, plugins } = createStubDependencies(PackageManager.npm);
+        createEmptyConversionResults();
+        const { logger, packageManager, ruleConversionResults } = createStubDependencies(
+            PackageManager.npm,
+        );
 
         // Act
-        logMissingPackages(plugins, packageManager, logger);
+        logMissingPackages(ruleConversionResults, packageManager, logger);
 
         // Assert
         expectEqualWrites(
@@ -26,10 +30,12 @@ describe("reportOutputs", () => {
 
     it("reports a pnpm command when the package manager is pnpm", () => {
         // Arrange
-        const { logger, packageManager, plugins } = createStubDependencies(PackageManager.pnpm);
+        const { logger, packageManager, ruleConversionResults } = createStubDependencies(
+            PackageManager.pnpm,
+        );
 
         // Act
-        logMissingPackages(plugins, packageManager, logger);
+        logMissingPackages(ruleConversionResults, packageManager, logger);
 
         // Assert
         expectEqualWrites(
@@ -41,10 +47,12 @@ describe("reportOutputs", () => {
 
     it("reports a Yarn command when the package manager is Yarn", () => {
         // Arrange
-        const { logger, packageManager, plugins } = createStubDependencies(PackageManager.Yarn);
+        const { logger, packageManager, ruleConversionResults } = createStubDependencies(
+            PackageManager.Yarn,
+        );
 
         // Act
-        logMissingPackages(plugins, packageManager, logger);
+        logMissingPackages(ruleConversionResults, packageManager, logger);
 
         // Assert
         expectEqualWrites(

--- a/src/reporting/reportOutputs.ts
+++ b/src/reporting/reportOutputs.ts
@@ -6,6 +6,7 @@ import { EditorSetting } from "../editorSettings/types";
 import { ErrorSummary } from "../errors/errorSummary";
 import { ESLintRuleOptions } from "../rules/types";
 import { PackageManager, installationMessages } from "./packages/packageManagers";
+import { RuleConversionResults } from "../rules/convertRules";
 
 export type EditorSettingEntry = Pick<EditorSetting, "editorSettingName">;
 
@@ -69,16 +70,19 @@ export const logMissingConversionTarget = <T>(
 };
 
 export const logMissingPackages = (
-    plugins: Set<string>,
+    ruleConversionResults: Pick<RuleConversionResults, "missing" | "plugins">,
     packageManager: PackageManager,
     logger: Logger,
 ) => {
     const packageNames = [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
+        ruleConversionResults.missing.length !== 0 && "@typescript-eslint/tslint-eslint-plugin",
         "eslint",
-        ...Array.from(plugins),
-    ].sort();
+        ...Array.from(ruleConversionResults.plugins),
+    ]
+        .filter(Boolean)
+        .sort();
 
     logger.stdout.write(chalk.cyanBright(`${EOL}⚡ ${packageNames.length}`));
     logger.stdout.write(chalk.cyan(" packages are required for running with ESLint."));


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #406
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

`@typescript-eslint/tslint-to-eslint-config` isn't explicitly added to the `missing` list in rule conversion results. It's more of an "implied" missing package. 😄 