### PR TITLE
Add one-line rule converter

### DIFF
--- a/src/rules/converters/one-line.ts
+++ b/src/rules/converters/one-line.ts
@@ -1,0 +1,17 @@
+import { RuleConverter } from "../converter";
+
+export const CheckAllTokensMsg = "ESLint's brace-style will check all tokens.";
+
+export const convertOneLine: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    notices: [CheckAllTokensMsg],
+                }),
+                ruleArguments: ["1tbs"],
+                ruleName: "brace-style",
+            },
+        ],
+    };
+};

--- a/src/rules/converters/one-line.ts
+++ b/src/rules/converters/one-line.ts
@@ -3,13 +3,12 @@ import { RuleConverter } from "../converter";
 export const CheckAllTokensMsg = "ESLint's brace-style will check all tokens.";
 
 export const convertOneLine: RuleConverter = (tslintRule) => {
+    const ruleLen = tslintRule.ruleArguments.length;
     return {
         rules: [
             {
-                ...(tslintRule.ruleArguments.length !== 0 && {
-                    notices: [CheckAllTokensMsg],
-                }),
-                ruleArguments: ["1tbs"],
+                notices: ruleLen > 0 && ruleLen < 5 ? [CheckAllTokensMsg] : undefined,
+                ruleArguments: [ruleLen > 0 ? "1tbs" : "off"],
                 ruleName: "brace-style",
             },
         ],

--- a/src/rules/converters/tests/one-line.test.ts
+++ b/src/rules/converters/tests/one-line.test.ts
@@ -9,14 +9,14 @@ describe(convertOneLine, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: ["1tbs"],
+                    ruleArguments: ["off"],
                     ruleName: "brace-style",
                 },
             ],
         });
     });
 
-    test("conversion with arguments", () => {
+    test("conversion with some arguments", () => {
         const result = convertOneLine({
             ruleArguments: ["check-catch"],
         });
@@ -25,6 +25,27 @@ describe(convertOneLine, () => {
             rules: [
                 {
                     notices: [CheckAllTokensMsg],
+                    ruleArguments: ["1tbs"],
+                    ruleName: "brace-style",
+                },
+            ],
+        });
+    });
+
+    test("conversion with all arguments", () => {
+        const result = convertOneLine({
+            ruleArguments: [
+                "check-else",
+                "check-catch",
+                "check-finally",
+                "check-open-brace",
+                "check-whitespace",
+            ],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
                     ruleArguments: ["1tbs"],
                     ruleName: "brace-style",
                 },

--- a/src/rules/converters/tests/one-line.test.ts
+++ b/src/rules/converters/tests/one-line.test.ts
@@ -1,0 +1,34 @@
+import { convertOneLine, CheckAllTokensMsg } from "../one-line";
+
+describe(convertOneLine, () => {
+    test("conversion without arguments", () => {
+        const result = convertOneLine({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: ["1tbs"],
+                    ruleName: "brace-style",
+                },
+            ],
+        });
+    });
+
+    test("conversion with arguments", () => {
+        const result = convertOneLine({
+            ruleArguments: ["check-catch"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [CheckAllTokensMsg],
+                    ruleArguments: ["1tbs"],
+                    ruleName: "brace-style",
+                },
+            ],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -105,6 +105,7 @@ import { convertNoVarRequires } from "./converters/no-var-requires";
 import { convertNoVoidExpression } from "./converters/no-void-expression";
 import { convertObjectLiteralKeyQuotes } from "./converters/object-literal-key-quotes";
 import { convertObjectLiteralShorthand } from "./converters/object-literal-shorthand";
+import { convertOneLine } from "./converters/one-line";
 import { convertOneVariablePerDeclaration } from "./converters/one-variable-per-declaration";
 import { convertOnlyArrowFunctions } from "./converters/only-arrow-functions";
 import { convertOrderedImports } from "./converters/ordered-imports";
@@ -246,6 +247,7 @@ export const rulesConverters = new Map([
     ["no-void-expression", convertNoVoidExpression],
     ["object-literal-key-quotes", convertObjectLiteralKeyQuotes],
     ["object-literal-shorthand", convertObjectLiteralShorthand],
+    ["one-line", convertOneLine],
     ["one-variable-per-declaration", convertOneVariablePerDeclaration],
     ["only-arrow-functions", convertOnlyArrowFunctions],
     ["ordered-imports", convertOrderedImports],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #410
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Add `one-line` TSLint converter to ESLint `brace-style` which will check all kind of tokens using the _one true brace style_ option.