### PR TITLE
Added basic @typescript-eslint/triple-slash-reference merger

### DIFF
--- a/src/rules/mergers.ts
+++ b/src/rules/mergers.ts
@@ -5,6 +5,7 @@ import { mergeNoCaller } from "./mergers/no-caller";
 import { mergeNoEval } from "./mergers/no-eval";
 import { mergeNoMemberDelimiterStyle } from "./mergers/member-delimiter-style";
 import { mergeNoUnnecessaryTypeAssertion } from "./mergers/no-unnecessary-type-assertion";
+import { mergeTripleSlashReference } from "./mergers/triple-slash-reference";
 
 export const mergers = new Map([
     ["@typescript-eslint/ban-types", mergeBanTypes],
@@ -12,6 +13,7 @@ export const mergers = new Map([
     ["@typescript-eslint/indent", mergeIndent],
     ["@typescript-eslint/member-delimiter-style", mergeNoMemberDelimiterStyle],
     ["@typescript-eslint/no-unnecessary-type-assertion", mergeNoUnnecessaryTypeAssertion],
+    ["@typescript-eslint/triple-slash-reference", mergeTripleSlashReference],
     ["no-caller", mergeNoCaller],
     ["no-eval", mergeNoEval],
 ]);

--- a/src/rules/mergers/tests/triple-slash-reference.test.ts
+++ b/src/rules/mergers/tests/triple-slash-reference.test.ts
@@ -1,0 +1,27 @@
+import { mergeTripleSlashReference } from "../triple-slash-reference";
+
+const option = {
+    path: "always",
+    types: "prefer-import",
+    lib: "always",
+};
+
+describe(mergeTripleSlashReference, () => {
+    test("neither options existing", () => {
+        const result = mergeTripleSlashReference(undefined, undefined);
+
+        expect(result).toEqual([]);
+    });
+
+    test("only existing options", () => {
+        const result = mergeTripleSlashReference([option], undefined);
+
+        expect(result).toEqual([option]);
+    });
+
+    test("only new options", () => {
+        const result = mergeTripleSlashReference(undefined, [option]);
+
+        expect(result).toEqual([option]);
+    });
+});

--- a/src/rules/mergers/triple-slash-reference.ts
+++ b/src/rules/mergers/triple-slash-reference.ts
@@ -1,0 +1,5 @@
+import { RuleMerger } from "../merger";
+
+export const mergeTripleSlashReference: RuleMerger = (existingOptions, newOptions) => {
+    return [existingOptions?.[0] ?? newOptions?.[0]].filter(Boolean);
+};


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #400
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

There's probably some subtlety I'm missing with the two separate rule configurations... but only one rule converter right now outputs options for it, so this is probably fine for now.