### PR TITLE
Add no-unused-variable converter

### DIFF
--- a/src/rules/converters/no-unused-variable.ts
+++ b/src/rules/converters/no-unused-variable.ts
@@ -1,0 +1,20 @@
+import { RuleConverter } from "../converter";
+
+export const NO_UNUSED_VARIABLE_NOTICE =
+    "Please read the following article as the rule behaviour may change on the short term: " +
+    "https://github.com/typescript-eslint/typescript-eslint/issues/1856";
+
+export const convertNoUnusedVariable: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@typescript-eslint/no-unused-vars",
+                notices: [NO_UNUSED_VARIABLE_NOTICE],
+            },
+            {
+                ruleName: "no-unused-vars",
+                ruleArguments: ["off"],
+            },
+        ],
+    };
+};

--- a/src/rules/converters/no-unused-variable.ts
+++ b/src/rules/converters/no-unused-variable.ts
@@ -11,10 +11,6 @@ export const convertNoUnusedVariable: RuleConverter = () => {
                 ruleName: "@typescript-eslint/no-unused-vars",
                 notices: [NO_UNUSED_VARIABLE_NOTICE],
             },
-            {
-                ruleName: "no-unused-vars",
-                ruleArguments: ["off"],
-            },
         ],
     };
 };

--- a/src/rules/converters/tests/no-unused-variable.test.ts
+++ b/src/rules/converters/tests/no-unused-variable.test.ts
@@ -1,0 +1,22 @@
+import { convertNoUnusedVariable, NO_UNUSED_VARIABLE_NOTICE } from "../no-unused-variable";
+
+describe(convertNoUnusedVariable, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoUnusedVariable({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/no-unused-vars",
+                    notices: [NO_UNUSED_VARIABLE_NOTICE],
+                },
+                {
+                    ruleName: "no-unused-vars",
+                    ruleArguments: ["off"],
+                },
+            ],
+        });
+    });
+});

--- a/src/rules/converters/tests/no-unused-variable.test.ts
+++ b/src/rules/converters/tests/no-unused-variable.test.ts
@@ -12,10 +12,6 @@ describe(convertNoUnusedVariable, () => {
                     ruleName: "@typescript-eslint/no-unused-vars",
                     notices: [NO_UNUSED_VARIABLE_NOTICE],
                 },
-                {
-                    ruleName: "no-unused-vars",
-                    ruleArguments: ["off"],
-                },
             ],
         });
     });

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -99,6 +99,7 @@ import { convertNoUnnecessarySemicolons } from "./converters/no-unnecessary-semi
 import { convertNoUnnecessaryTypeAssertion } from "./converters/no-unnecessary-type-assertion";
 import { convertNoUnsafeFinally } from "./converters/no-unsafe-finally";
 import { convertNoUnusedExpression } from "./converters/no-unused-expression";
+import { convertNoUnusedVariable } from "./converters/no-unused-variable";
 import { convertNoUseBeforeDeclare } from "./converters/no-use-before-declare";
 import { convertNoVarKeyword } from "./converters/no-var-keyword";
 import { convertNoVarRequires } from "./converters/no-var-requires";
@@ -240,6 +241,7 @@ export const rulesConverters = new Map([
     ["no-unnecessary-type-assertion", convertNoUnnecessaryTypeAssertion],
     ["no-unsafe-finally", convertNoUnsafeFinally],
     ["no-unused-expression", convertNoUnusedExpression],
+    ["no-unused-variable", convertNoUnusedVariable],
     ["no-use-before-declare", convertNoUseBeforeDeclare],
     ["no-var-keyword", convertNoVarKeyword],
     ["no-var-requires", convertNoVarRequires],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #411 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Add `no-unused-variable` converter which includes a notice to read the article as this rule may change on the short-term.

@JoshuaKGoldberg not sure if it is the proper output but looks like both ESLint rules must be used on this converter.