### PR TITLE
Add codelyzer component-class-suffix converter

### DIFF
--- a/src/rules/converters/codelyzer/component-class-suffix.ts
+++ b/src/rules/converters/codelyzer/component-class-suffix.ts
@@ -5,7 +5,11 @@ export const convertComponentClassSuffix: RuleConverter = (tslintRule) => {
         rules: [
             {
                 ...(tslintRule.ruleArguments.length !== 0 && {
-                    ruleArguments: tslintRule.ruleArguments,
+                    ruleArguments: [
+                        {
+                            suffixes: tslintRule.ruleArguments,
+                        },
+                    ],
                 }),
                 ruleName: "@angular-eslint/component-class-suffix",
             },

--- a/src/rules/converters/codelyzer/component-class-suffix.ts
+++ b/src/rules/converters/codelyzer/component-class-suffix.ts
@@ -1,0 +1,15 @@
+import { RuleConverter } from "../../converter";
+
+export const convertComponentClassSuffix: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: tslintRule.ruleArguments,
+                }),
+                ruleName: "@angular-eslint/component-class-suffix",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/component-class-suffix.test.ts
+++ b/src/rules/converters/codelyzer/tests/component-class-suffix.test.ts
@@ -1,0 +1,34 @@
+import { convertComponentClassSuffix } from "../component-class-suffix";
+
+describe(convertComponentClassSuffix, () => {
+    test("conversion without arguments", () => {
+        const result = convertComponentClassSuffix({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/component-class-suffix",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+
+    test("conversion with arguments", () => {
+        const result = convertComponentClassSuffix({
+            ruleArguments: ["Component", "View"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: ["Component", "View"],
+                    ruleName: "@angular-eslint/component-class-suffix",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/converters/codelyzer/tests/component-class-suffix.test.ts
+++ b/src/rules/converters/codelyzer/tests/component-class-suffix.test.ts
@@ -24,7 +24,11 @@ describe(convertComponentClassSuffix, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: ["Component", "View"],
+                    ruleArguments: [
+                        {
+                            suffixes: ["Component", "View"],
+                        },
+                    ],
                     ruleName: "@angular-eslint/component-class-suffix",
                 },
             ],

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -137,6 +137,9 @@ import { convertUseDefaultTypeParameter } from "./converters/use-default-type-pa
 import { convertUseIsnan } from "./converters/use-isnan";
 import { convertVariableName } from "./converters/variable-name";
 
+// Codelyzer converters
+import { convertComponentClassSuffix } from "./converters/codelyzer/component-class-suffix";
+
 /**
  * Keys TSLint rule names to their ESLint rule converters.
  */
@@ -154,6 +157,7 @@ export const rulesConverters = new Map([
     ["callable-types", convertCallableTypes],
     ["class-name", convertClassName],
     ["comment-format", convertCommentFormat],
+    ["component-class-suffix", convertComponentClassSuffix],
     ["curly", convertCurly],
     ["cyclomatic-complexity", convertCyclomaticComplexity],
     ["deprecation", convertDeprecation],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: references #421
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

This is more like a example of how **codelyzer** rules should be placed inside their own folder so any contributor knows where find those converters.

This rule is pretty simple and examples can be found on [angular-eslint/component-class-suffix test](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/tests/rules/component-class-suffix.test.ts) file.

The [TSLint rule](http://codelyzer.com/rules/component-class-suffix/) is pretty much the same as the ESLint one, a set of rule arguments will be the suffix to match for any class decorated with `@Component`.