### PR TITLE
Allowed --comments not to be provided

### DIFF
--- a/src/comments/convertComments.test.ts
+++ b/src/comments/convertComments.test.ts
@@ -10,6 +10,20 @@ const createStubDependencies = (
 });
 
 describe("convertComments", () => {
+    it("returns an empty result when --comment is not provided", async () => {
+        // Arrange
+        const dependencies = createStubDependencies();
+
+        // Act
+        const result = await convertComments(dependencies, undefined);
+
+        // Assert
+        expect(result).toEqual({
+            data: undefined,
+            status: ResultStatus.Succeeded,
+        });
+    });
+
     it("returns an error when --comment is given as a boolean value", async () => {
         // Arrange
         const dependencies = createStubDependencies();

--- a/src/comments/convertComments.ts
+++ b/src/comments/convertComments.ts
@@ -17,7 +17,14 @@ const noGlobsResult: ResultWithDataStatus<string[]> = {
 export const convertComments = async (
     dependencies: ConvertCommentsDependencies,
     filePathGlobs: true | string | string[] | undefined,
-): Promise<ResultWithDataStatus<string[]>> => {
+): Promise<ResultWithDataStatus<string[] | undefined>> => {
+    if (filePathGlobs === undefined) {
+        return {
+            data: undefined,
+            status: ResultStatus.Succeeded,
+        };
+    }
+
     if (filePathGlobs === true) {
         return noGlobsResult;
     }

--- a/src/conversion/convertConfig.ts
+++ b/src/conversion/convertConfig.ts
@@ -65,7 +65,7 @@ export const convertConfig = async (
 
     // 6. A summary of the results is printed to the user's console
     await dependencies.reportConversionResults(settings.config, simplifiedConfiguration);
-    dependencies.reportCommentResults(settings.comments, commentsResult);
+    dependencies.reportCommentResults(commentsResult);
     await dependencies.logMissingPackages(
         simplifiedConfiguration,
         originalConfigurations.data.packages,

--- a/src/reporting/reportCommentResults.test.ts
+++ b/src/reporting/reportCommentResults.test.ts
@@ -3,12 +3,12 @@ import { ResultStatus } from "../types";
 import { reportCommentResults } from "./reportCommentResults";
 
 describe("reportCommentResults", () => {
-    it("logs a suggestion when no comment globs are provided", () => {
+    it("logs a suggestion when no comment globs were requested", () => {
         // Arrange
         const logger = createStubLogger();
 
         // Act
-        reportCommentResults({ logger }, undefined, { data: [], status: ResultStatus.Succeeded });
+        reportCommentResults({ logger }, { data: undefined, status: ResultStatus.Succeeded });
 
         // Assert
         expectEqualWrites(
@@ -23,7 +23,7 @@ describe("reportCommentResults", () => {
         const errors = [new Error("Hello")];
 
         // Act
-        reportCommentResults({ logger }, ["src/index.ts"], { errors, status: ResultStatus.Failed });
+        reportCommentResults({ logger }, { errors, status: ResultStatus.Failed });
 
         // Assert
         expectEqualWrites(
@@ -44,7 +44,7 @@ describe("reportCommentResults", () => {
         const errors = [new Error("Hello"), new Error("World")];
 
         // Act
-        reportCommentResults({ logger }, ["src/index.ts"], { errors, status: ResultStatus.Failed });
+        reportCommentResults({ logger }, { errors, status: ResultStatus.Failed });
 
         // Assert
         expectEqualWrites(
@@ -65,10 +65,13 @@ describe("reportCommentResults", () => {
         const logger = createStubLogger();
 
         // Act
-        reportCommentResults({ logger }, ["src/*.ts"], {
-            data: ["src/index.ts"],
-            status: ResultStatus.Succeeded,
-        });
+        reportCommentResults(
+            { logger },
+            {
+                data: ["src/index.ts"],
+                status: ResultStatus.Succeeded,
+            },
+        );
 
         // Assert
         expectEqualWrites(
@@ -82,10 +85,13 @@ describe("reportCommentResults", () => {
         const logger = createStubLogger();
 
         // Act
-        reportCommentResults({ logger }, ["src/*.ts"], {
-            data: ["src/index.ts", "src/data.ts"],
-            status: ResultStatus.Succeeded,
-        });
+        reportCommentResults(
+            { logger },
+            {
+                data: ["src/index.ts", "src/data.ts"],
+                status: ResultStatus.Succeeded,
+            },
+        );
 
         // Assert
         expectEqualWrites(

--- a/src/reporting/reportCommentResults.ts
+++ b/src/reporting/reportCommentResults.ts
@@ -10,18 +10,8 @@ export type ReportCommentResultsDependencies = {
 
 export const reportCommentResults = (
     dependencies: ReportCommentResultsDependencies,
-    commentGlobs: string | string[] | undefined,
-    commentsResult: ResultWithDataStatus<string[]>,
+    commentsResult: ResultWithDataStatus<string[] | undefined>,
 ) => {
-    if (commentGlobs === undefined) {
-        dependencies.logger.stdout.write(
-            chalk.magentaBright(
-                `${EOL}♻ Consider using --comment to replace TSLint comment directives in your source files. ♻${EOL}`,
-            ),
-        );
-        return;
-    }
-
     if (commentsResult.status === ResultStatus.Failed) {
         const headline = `${commentsResult.errors.length} error${
             commentsResult.errors.length === 1 ? "" : "s"
@@ -37,6 +27,15 @@ export const reportCommentResults = (
             commentsResult.errors.map((error) => `  * ${error.message}${EOL}`).join(""),
         );
         dependencies.logger.info.write(EOL);
+        return;
+    }
+
+    if (commentsResult.data === undefined) {
+        dependencies.logger.stdout.write(
+            chalk.magentaBright(
+                `${EOL}♻ Consider using --comment to replace TSLint comment directives in your source files. ♻${EOL}`,
+            ),
+        );
         return;
     }
 

--- a/src/reporting/reportOutputs.ts
+++ b/src/reporting/reportOutputs.ts
@@ -13,7 +13,7 @@ export const logSuccessfulConversions = (
     converted: Map<string, EditorSetting | ESLintRuleOptions>,
     logger: Logger,
 ) => {
-    logger.stdout.write(chalk.greenBright(`✨ ${converted.size}`));
+    logger.stdout.write(chalk.greenBright(`${EOL} ✨ ${converted.size}`));
     logger.stdout.write(
         converted.size === 1
             ? chalk.green(` ${conversionTypeName} replaced with its ESLint equivalent.`)


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #442
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Changes `convertComments` to return an `data: undefined` success result when no comments were requested. Reporting will now check on that to determine whether to complain.