### PR TITLE
Corrected Prettier plugin inclusion in config files

### DIFF
--- a/src/creation/simplification/retrieveExtendsValues.ts
+++ b/src/creation/simplification/retrieveExtendsValues.ts
@@ -18,7 +18,12 @@ const builtInExtensions = new Map([
     ["eslint:recommended", "eslint/conf/eslint-recommended"],
 ]);
 
-const typescriptPluginExtensions = new Map([
+const pluginExtensions = new Map([
+    ["eslint-plugin-prettier", "node_modules/eslint-config-prettier/index.js"],
+    [
+        "eslint-plugin-prettier/@typescript-eslint",
+        "node_modules/eslint-config-prettier/@typescript-eslint.js",
+    ],
     [
         "plugin:@typescript-eslint/all",
         "node_modules/@typescript-eslint/eslint-plugin/dist/configs/all.json",
@@ -54,10 +59,10 @@ export const retrieveExtendsValues = async (
                 return;
             }
 
-            const typescriptPluginExtension = typescriptPluginExtensions.get(extensionName);
-            if (typescriptPluginExtension !== undefined) {
+            const pluginExtension = pluginExtensions.get(extensionName);
+            if (pluginExtension !== undefined) {
                 const importedTypeScriptPlugin = (await dependencies.importer(
-                    typescriptPluginExtension,
+                    pluginExtension,
                 )) as ESLintConfiguration;
                 importedExtensions.push({
                     rules: importedTypeScriptPlugin.rules,

--- a/src/creation/simplification/simplifyPackageRules.test.ts
+++ b/src/creation/simplification/simplifyPackageRules.test.ts
@@ -68,10 +68,7 @@ describe("simplifyPackageRules", () => {
         expect(simplifiedResults).toEqual({
             ...ruleConversionResults,
             converted: undefined,
-            extends: [
-                "plugin:eslint-config-prettier",
-                "plugin:eslint-config-prettier/@typescript-eslint",
-            ],
+            extends: ["prettier", "prettier/@typescript-eslint"],
         });
     });
 

--- a/src/creation/simplification/simplifyPackageRules.ts
+++ b/src/creation/simplification/simplifyPackageRules.ts
@@ -55,7 +55,7 @@ export const simplifyPackageRules = async (
     return {
         ...ruleConversionResults,
         converted,
-        extends: allExtensions,
+        extends: uniqueFromSources(allExtensions),
         failed: [...ruleConversionResults.failed, ...configurationErrors],
     };
 };

--- a/src/creation/simplification/simplifyPackageRules.ts
+++ b/src/creation/simplification/simplifyPackageRules.ts
@@ -36,10 +36,7 @@ export const simplifyPackageRules = async (
 
     // 3a. If no output rules conflict with `eslint-config-prettier`, it's added in
     if (await dependencies.addPrettierExtensions(ruleConversionResults, prettierRequested)) {
-        allExtensions.push(
-            "plugin:eslint-config-prettier",
-            "plugin:eslint-config-prettier/@typescript-eslint",
-        );
+        allExtensions.push("prettier", "prettier/@typescript-eslint");
     }
 
     if (allExtensions.length === 0) {

--- a/src/reporting/packages/logMissingPackages.test.ts
+++ b/src/reporting/packages/logMissingPackages.test.ts
@@ -71,7 +71,7 @@ describe("logMissingPackages", () => {
         // Arrange
         const { choosePackageManager, logger } = createStubDependencies();
         const ruleConversionResults = createEmptyConversionResults({
-            extends: ["plugin:eslint-config-prettier"],
+            extends: ["prettier"],
         });
 
         // Act

--- a/src/reporting/packages/logMissingPackages.ts
+++ b/src/reporting/packages/logMissingPackages.ts
@@ -29,8 +29,7 @@ export const logMissingPackages = async (
     const requiredPackageNames = [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
-        ruleConversionResults.extends?.join("").includes("eslint-config-prettier") &&
-            "eslint-config-prettier",
+        ruleConversionResults.extends?.join("").includes("prettier") && "eslint-config-prettier",
         ruleConversionResults.missing.length !== 0 && "@typescript-eslint/eslint-plugin-tslint",
         "eslint",
         ...Array.from(ruleConversionResults.plugins),

--- a/src/reporting/reportConversionResults.test.ts
+++ b/src/reporting/reportConversionResults.test.ts
@@ -5,10 +5,7 @@ import { createEmptyConversionResults } from "../conversion/conversionResults.st
 import { ESLintRuleOptions } from "../rules/types";
 import { reportConversionResults } from "./reportConversionResults";
 
-const basicExtends = [
-    "plugin:eslint-config-prettier",
-    "plugin:eslint-config-prettier/@typescript-eslint",
-];
+const basicExtends = ["prettier", "prettier/@typescript-eslint"];
 
 describe("reportConversionResults", () => {
     it("logs a successful conversion without notices when there is one converted rule without notices", async () => {

--- a/src/reporting/reportConversionResults.ts
+++ b/src/reporting/reportConversionResults.ts
@@ -42,7 +42,7 @@ export const reportConversionResults = async (
         );
     }
 
-    if (!ruleConversionResults.extends?.join("").includes("eslint-config-prettier")) {
+    if (!ruleConversionResults.extends?.join("").includes("prettier")) {
         logPrettierExtension(dependencies.logger);
     }
 };

--- a/src/reporting/reportOutputs.ts
+++ b/src/reporting/reportOutputs.ts
@@ -13,7 +13,7 @@ export const logSuccessfulConversions = (
     converted: Map<string, EditorSetting | ESLintRuleOptions>,
     logger: Logger,
 ) => {
-    logger.stdout.write(chalk.greenBright(`${EOL} ✨ ${converted.size}`));
+    logger.stdout.write(chalk.greenBright(`${EOL}✨ ${converted.size}`));
     logger.stdout.write(
         converted.size === 1
             ? chalk.green(` ${conversionTypeName} replaced with its ESLint equivalent.`)


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #439
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Removes the apparently unnecessary `plugin:eslint-config-` from `extends` and gives it the correct alias in extended config imports.