### PR TITLE
Stopped logging package notice when none are missing

### DIFF
--- a/src/reporting/packages/logMissingPackages.test.ts
+++ b/src/reporting/packages/logMissingPackages.test.ts
@@ -9,6 +9,25 @@ const createStubDependencies = (packageManager = PackageManager.npm) => ({
 });
 
 describe("logMissingPackages", () => {
+    it("does nothing when no package are missing", async () => {
+        // Arrange
+        const { choosePackageManager, logger } = createStubDependencies(PackageManager.npm);
+        const ruleConversionResults = createEmptyConversionResults();
+
+        // Act
+        await logMissingPackages({ choosePackageManager, logger }, ruleConversionResults, {
+            dependencies: {
+                "@typescript-eslint/eslint-plugin": "*",
+                "@typescript-eslint/parser": "*",
+                eslint: "*",
+            },
+            devDependencies: {},
+        });
+
+        // Assert
+        expectEqualWrites(logger.stdout.write);
+    });
+
     it("reports a singular message when one package is missing", async () => {
         // Arrange
         const { choosePackageManager, logger } = createStubDependencies(PackageManager.npm);

--- a/src/reporting/packages/logMissingPackages.ts
+++ b/src/reporting/packages/logMissingPackages.ts
@@ -39,6 +39,10 @@ export const logMissingPackages = async (
         .filter((packageName) => !existingPackageNames.has(packageName))
         .sort();
 
+    if (missingPackageNames.length === 0) {
+        return;
+    }
+
     dependencies.logger.stdout.write(chalk.cyanBright(`${EOL}⚡ ${missingPackageNames.length}`));
     dependencies.logger.stdout.write(
         chalk.cyan(


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #445
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

This worked out nicely.