### PR TITLE
Prefer @typescript-eslint/no-unused-expression

### DIFF
--- a/src/rules/converters/no-unused-expression.ts
+++ b/src/rules/converters/no-unused-expression.ts
@@ -4,7 +4,7 @@ export const convertNoUnusedExpression: RuleConverter = (tslintRule) => {
     return {
         rules: [
             {
-                ruleName: "no-unused-expressions",
+                ruleName: "@typescript-eslint/no-unused-expressions",
                 ...collectNoticesAndArguments(tslintRule.ruleArguments),
             },
         ],

--- a/src/rules/converters/tests/no-unused-expression.test.ts
+++ b/src/rules/converters/tests/no-unused-expression.test.ts
@@ -12,7 +12,7 @@ describe(convertNoUnusedExpression, () => {
                     notices: [
                         `The TSLint optional config "allow-new" is the default ESLint behavior and will no longer be ignored.`,
                     ],
-                    ruleName: "no-unused-expressions",
+                    ruleName: "@typescript-eslint/no-unused-expressions",
                 },
             ],
         });
@@ -30,7 +30,7 @@ describe(convertNoUnusedExpression, () => {
                         `The TSLint optional config "allow-new" is the default ESLint behavior and will no longer be ignored.`,
                     ],
                     ruleArguments: [{ allowShortCircuit: true }],
-                    ruleName: "no-unused-expressions",
+                    ruleName: "@typescript-eslint/no-unused-expressions",
                 },
             ],
         });
@@ -45,7 +45,7 @@ describe(convertNoUnusedExpression, () => {
             rules: [
                 {
                     ruleArguments: [{ allowTaggedTemplates: true }],
-                    ruleName: "no-unused-expressions",
+                    ruleName: "@typescript-eslint/no-unused-expressions",
                 },
             ],
         });
@@ -60,7 +60,7 @@ describe(convertNoUnusedExpression, () => {
             rules: [
                 {
                     ruleArguments: [{ allowShortCircuit: true }],
-                    ruleName: "no-unused-expressions",
+                    ruleName: "@typescript-eslint/no-unused-expressions",
                 },
             ],
         });
@@ -75,7 +75,7 @@ describe(convertNoUnusedExpression, () => {
             rules: [
                 {
                     ruleArguments: [{ allowTaggedTemplates: true, allowShortCircuit: true }],
-                    ruleName: "no-unused-expressions",
+                    ruleName: "@typescript-eslint/no-unused-expressions",
                 },
             ],
         });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)
-  [X] Neither :grimacing: If this gets sent to the back of the queue, that's OK :slightly_smiling_face: 

## Overview

This PR largely builds off of the work in #205. It updates the converter to use [@typescript-eslint/no-unused-expressions](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-expressions.md) over ESLint's [no-unused-expressions](https://github.com/eslint/eslint/blob/master/docs/rules/no-unused-expressions.md) rule (the `@typescript-eslint` version seems to have come along after #205 was landed).  

Looking at the rule [source](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/rules/no-unused-expressions.ts), the only thing that the new rule seems to add is support for optional call expressions (thanks TS 3.7 :heart:) and [directives in modules ](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/tests/rules/no-unused-expressions.test.ts#L50).  I didn't see any additional flags added to the new rule that would need to be added to the existing tests (I think :wink:)
