### PR TITLE
Add codelyzer component-max-inline-declarations converter

### DIFF
--- a/src/rules/converters/codelyzer/component-max-inline-declarations.ts
+++ b/src/rules/converters/codelyzer/component-max-inline-declarations.ts
@@ -1,0 +1,15 @@
+import { RuleConverter } from "../../converter";
+
+export const convertComponentMaxInlineDeclarations: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: [...tslintRule.ruleArguments],
+                }),
+                ruleName: "@angular-eslint/component-max-inline-declarations",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/component-max-inline-declarations.test.ts
+++ b/src/rules/converters/codelyzer/tests/component-max-inline-declarations.test.ts
@@ -1,0 +1,46 @@
+import { convertComponentMaxInlineDeclarations } from "../component-max-inline-declarations";
+
+describe(convertComponentMaxInlineDeclarations, () => {
+    test("conversion without arguments", () => {
+        const result = convertComponentMaxInlineDeclarations({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/component-max-inline-declarations",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+
+    test("conversion with arguments", () => {
+        const result = convertComponentMaxInlineDeclarations({
+            ruleArguments: [
+                {
+                    template: 7,
+                    styles: 2,
+                    animations: 10,
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            template: 7,
+                            styles: 2,
+                            animations: 10,
+                        },
+                    ],
+                    ruleName: "@angular-eslint/component-max-inline-declarations",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -139,6 +139,7 @@ import { convertVariableName } from "./converters/variable-name";
 
 // Codelyzer converters
 import { convertComponentClassSuffix } from "./converters/codelyzer/component-class-suffix";
+import { convertComponentMaxInlineDeclarations } from "./converters/codelyzer/component-max-inline-declarations";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -158,6 +159,7 @@ export const rulesConverters = new Map([
     ["class-name", convertClassName],
     ["comment-format", convertCommentFormat],
     ["component-class-suffix", convertComponentClassSuffix],
+    ["component-max-inline-declarations", convertComponentMaxInlineDeclarations],
     ["curly", convertCurly],
     ["cyclomatic-complexity", convertCyclomaticComplexity],
     ["deprecation", convertDeprecation],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: references #421
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Examples can be found on [angular-eslint/component-max-inline-declarations](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/tests/rules/component-max-inline-declarations.test.ts) test file.

The [TSLint](http://codelyzer.com/rules/component-max-inline-declarations/) rule description is the same as the ESLint one.