### PR TITLE
Add codelyzer component-selector converter

### DIFF
--- a/src/rules/converters/codelyzer/component-selector.ts
+++ b/src/rules/converters/codelyzer/component-selector.ts
@@ -1,0 +1,21 @@
+import { RuleConverter } from "../../converter";
+
+export const convertComponentSelector: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: [
+                        {
+                            type: tslintRule.ruleArguments[0],
+                            prefix: tslintRule.ruleArguments[1],
+                            style: tslintRule.ruleArguments[2],
+                        },
+                    ],
+                }),
+                ruleName: "@angular-eslint/component-selector",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/component-selector.test.ts
+++ b/src/rules/converters/codelyzer/tests/component-selector.test.ts
@@ -1,0 +1,47 @@
+import { convertComponentSelector } from "../component-selector";
+
+describe(convertComponentSelector, () => {
+    test("conversion with arguments of same type", () => {
+        const result = convertComponentSelector({
+            ruleArguments: ["attribute", "myPrefix", "camelCase"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            type: "attribute",
+                            prefix: "myPrefix",
+                            style: "camelCase",
+                        },
+                    ],
+                    ruleName: "@angular-eslint/component-selector",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+
+    test("conversion with arguments of mixed type", () => {
+        const result = convertComponentSelector({
+            ruleArguments: ["element", ["ng", "ngx"], "kebab-case"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            type: "element",
+                            prefix: ["ng", "ngx"],
+                            style: "kebab-case",
+                        },
+                    ],
+                    ruleName: "@angular-eslint/component-selector",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -139,6 +139,7 @@ import { convertVariableName } from "./converters/variable-name";
 
 // Codelyzer converters
 import { convertComponentClassSuffix } from "./converters/codelyzer/component-class-suffix";
+import { convertComponentSelector } from "./converters/codelyzer/component-selector";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -158,6 +159,7 @@ export const rulesConverters = new Map([
     ["class-name", convertClassName],
     ["comment-format", convertCommentFormat],
     ["component-class-suffix", convertComponentClassSuffix],
+    ["component-selector", convertComponentSelector],
     ["curly", convertCurly],
     ["cyclomatic-complexity", convertCyclomaticComplexity],
     ["deprecation", convertDeprecation],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: references #421
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
Examples can be found on [angular-eslint/component-selector](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/tests/rules/component-selector.test.ts) test file.

The [TSLint](http://codelyzer.com/rules/component-selector/) rule takes an array of strings whose indexes are mapped into object fields `type`, `style` and `prefix` on the output ESLint rule.