### PR TITLE
Prefer @typescript-eslint/dot-notation to native ESLint version

### DIFF
--- a/src/rules/converters/no-string-literal.ts
+++ b/src/rules/converters/no-string-literal.ts
@@ -4,7 +4,7 @@ export const convertNoStringLiteral: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "dot-notation",
+                ruleName: "@typescript-eslint/dot-notation",
             },
         ],
     };

--- a/src/rules/converters/tests/no-string-literal.test.ts
+++ b/src/rules/converters/tests/no-string-literal.test.ts
@@ -9,7 +9,7 @@ describe(convertNoStringLiteral, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "dot-notation",
+                    ruleName: "@typescript-eslint/dot-notation",
                 },
             ],
         });


### PR DESCRIPTION
## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

This PR updates the converter for [no-string-literal](https://palantir.github.io/tslint/rules/no-string-literal/) to use [@typescript-eslint/dot-notation](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/dot-notation.md) (introduced in [this PR](https://github.com/typescript-eslint/typescript-eslint/pull/1867)) over ESLint's native [dot-notation](https://eslint.org/docs/rules/dot-notation)

The `@typescript-eslint` variant does introduce a new optional flag, `allowPrivateClassPropertyAccess`, which isn't added in this converter in this PR.  But if it's something y'all feel like it should be added (even if added with a `false` value) I'm happy to add it :slightly_smiling_face: 
