### PR TITLE
Add codelyzer directive-class-suffix converter

### DIFF
--- a/src/rules/converters/codelyzer/directive-class-suffix.ts
+++ b/src/rules/converters/codelyzer/directive-class-suffix.ts
@@ -1,0 +1,19 @@
+import { RuleConverter } from "../../converter";
+
+export const convertDirectiveClassSuffix: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: [
+                        {
+                            suffixes: tslintRule.ruleArguments,
+                        },
+                    ],
+                }),
+                ruleName: "@angular-eslint/directive-class-suffix",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/directive-class-suffix.test.ts
+++ b/src/rules/converters/codelyzer/tests/directive-class-suffix.test.ts
@@ -1,0 +1,38 @@
+import { convertDirectiveClassSuffix } from "../directive-class-suffix";
+
+describe(convertDirectiveClassSuffix, () => {
+    test("conversion without arguments", () => {
+        const result = convertDirectiveClassSuffix({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/directive-class-suffix",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+
+    test("conversion with arguments", () => {
+        const result = convertDirectiveClassSuffix({
+            ruleArguments: ["Directive", "View"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            suffixes: ["Directive", "View"],
+                        },
+                    ],
+                    ruleName: "@angular-eslint/directive-class-suffix",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -142,6 +142,7 @@ import { convertComponentClassSuffix } from "./converters/codelyzer/component-cl
 import { convertComponentMaxInlineDeclarations } from "./converters/codelyzer/component-max-inline-declarations";
 import { convertComponentSelector } from "./converters/codelyzer/component-selector";
 import { convertContextualLifecycle } from "./converters/codelyzer/contextual-lifecycle";
+import { convertDirectiveClassSuffix } from "./converters/codelyzer/directive-class-suffix";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -167,6 +168,7 @@ export const rulesConverters = new Map([
     ["curly", convertCurly],
     ["cyclomatic-complexity", convertCyclomaticComplexity],
     ["deprecation", convertDeprecation],
+    ["directive-class-suffix", convertDirectiveClassSuffix],
     ["eofline", convertEofline],
     ["file-name-casing", convertFileNameCasing],
     ["forin", convertForin],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: references #421 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

This rule is pretty simple and examples can be found on [angular-eslint/directive-class-suffix](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/tests/rules/directive-class-suffix.test.ts) test file.

The [TSLint rule](http://codelyzer.com/rules/directive-class-suffix/) is pretty much the same as the ESLint one, a set of rule arguments will be the suffix to match for any class decorated with `@Directive`, similar to how `component-class-suffix` rule works for any class decorated with `@Component`.