### PR TITLE
Add codelyzer directive-selector converter

### DIFF
--- a/src/rules/converters/codelyzer/directive-selector.ts
+++ b/src/rules/converters/codelyzer/directive-selector.ts
@@ -1,0 +1,21 @@
+import { RuleConverter } from "../../converter";
+
+export const convertDirectiveSelector: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: [
+                        {
+                            type: tslintRule.ruleArguments[0],
+                            prefix: tslintRule.ruleArguments[1],
+                            style: tslintRule.ruleArguments[2],
+                        },
+                    ],
+                }),
+                ruleName: "@angular-eslint/directive-selector",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/directive-selector.test.ts
+++ b/src/rules/converters/codelyzer/tests/directive-selector.test.ts
@@ -1,0 +1,47 @@
+import { convertDirectiveSelector } from "../directive-selector";
+
+describe(convertDirectiveSelector, () => {
+    test("conversion with arguments of same type", () => {
+        const result = convertDirectiveSelector({
+            ruleArguments: ["attribute", "myPrefix", "camelCase"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            type: "attribute",
+                            prefix: "myPrefix",
+                            style: "camelCase",
+                        },
+                    ],
+                    ruleName: "@angular-eslint/directive-selector",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+
+    test("conversion with arguments of mixed type", () => {
+        const result = convertDirectiveSelector({
+            ruleArguments: ["element", ["ng", "ngx"], "kebab-case"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            type: "element",
+                            prefix: ["ng", "ngx"],
+                            style: "kebab-case",
+                        },
+                    ],
+                    ruleName: "@angular-eslint/directive-selector",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -142,6 +142,7 @@ import { convertComponentClassSuffix } from "./converters/codelyzer/component-cl
 import { convertComponentMaxInlineDeclarations } from "./converters/codelyzer/component-max-inline-declarations";
 import { convertComponentSelector } from "./converters/codelyzer/component-selector";
 import { convertContextualLifecycle } from "./converters/codelyzer/contextual-lifecycle";
+import { convertDirectiveSelector } from "./converters/codelyzer/directive-selector";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -167,6 +168,7 @@ export const rulesConverters = new Map([
     ["curly", convertCurly],
     ["cyclomatic-complexity", convertCyclomaticComplexity],
     ["deprecation", convertDeprecation],
+    ["directive-selector", convertDirectiveSelector],
     ["eofline", convertEofline],
     ["file-name-casing", convertFileNameCasing],
     ["forin", convertForin],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: references #421
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Same story as `component-selector` rule. Examples can be found on [angular-eslint/directive-selector](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/tests/rules/directive-selector.test.ts) test file.

The [TSLint rule](http://codelyzer.com/rules/directive-selector/) takes an array of strings whose indexes are mapped into object fields **type**, **style** and **prefix** on the output ESLint rule.