### PR TITLE
Add codelyzer no-attribute-decorator converter

### DIFF
--- a/src/rules/converters/codelyzer/no-attribute-decorator.ts
+++ b/src/rules/converters/codelyzer/no-attribute-decorator.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertNoAttributeDecorator: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/no-attribute-decorator",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/no-attribute-decorator.test.ts
+++ b/src/rules/converters/codelyzer/tests/no-attribute-decorator.test.ts
@@ -1,0 +1,18 @@
+import { convertNoAttributeDecorator } from "../no-attribute-decorator";
+
+describe(convertNoAttributeDecorator, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoAttributeDecorator({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/no-attribute-decorator",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -142,6 +142,7 @@ import { convertComponentClassSuffix } from "./converters/codelyzer/component-cl
 import { convertComponentMaxInlineDeclarations } from "./converters/codelyzer/component-max-inline-declarations";
 import { convertComponentSelector } from "./converters/codelyzer/component-selector";
 import { convertContextualLifecycle } from "./converters/codelyzer/contextual-lifecycle";
+import { convertNoAttributeDecorator } from "./converters/codelyzer/no-attribute-decorator";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -191,6 +192,7 @@ export const rulesConverters = new Map([
     ["no-any", convertNoExplicitAny],
     ["no-arg", convertNoArg],
     ["no-async-without-await", convertNoAsyncWithoutAwait],
+    ["no-attribute-decorator", convertNoAttributeDecorator],
     ["no-banned-terms", convertNoBannedTerms],
     ["no-bitwise", convertNoBitwise],
     ["no-boolean-literal-compare", convertNoBooleanLiteralCompare],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: references #421
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Examples can be found on [angular-eslint/no-attribute-decorator](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/tests/rules/no-attribute-decorator.test.ts) test file.

The [TSLint rule](http://codelyzer.com/rules/no-attribute-decorator/) has no schema, hence it is not configurable 😎 