### PR TITLE
Add codelyzer no-forward-ref converter

### DIFF
--- a/src/rules/converters/codelyzer/no-forward-ref.ts
+++ b/src/rules/converters/codelyzer/no-forward-ref.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertNoForwardRef: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/no-forward-ref",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/no-forward-ref.test.ts
+++ b/src/rules/converters/codelyzer/tests/no-forward-ref.test.ts
@@ -1,0 +1,18 @@
+import { convertNoForwardRef } from "../no-forward-ref";
+
+describe(convertNoForwardRef, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoForwardRef({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/no-forward-ref",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -146,6 +146,7 @@ import { convertDirectiveClassSuffix } from "./converters/codelyzer/directive-cl
 import { convertDirectiveSelector } from "./converters/codelyzer/directive-selector";
 import { convertNoAttributeDecorator } from "./converters/codelyzer/no-attribute-decorator";
 import { convertUsePipeDecorator } from "./converters/codelyzer/use-pipe-decorator";
+import { convertNoForwardRef } from "./converters/codelyzer/no-forward-ref";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -218,8 +219,9 @@ export const rulesConverters = new Map([
     ["no-eval", convertNoEval],
     ["no-floating-promises", convertNoFloatingPromises],
     ["no-for-in-array", convertNoForInArray],
-    ["no-implicit-dependencies", convertNoImplicitDependencies],
     ["no-for-in", convertNoForIn],
+    ["no-forward-ref", convertNoForwardRef],
+    ["no-implicit-dependencies", convertNoImplicitDependencies],
     ["no-import-side-effect", convertNoImportSideEffect],
     ["no-inferrable-types", convertNoInferrableTypes],
     ["no-internal-module", convertNoInternalModule],
@@ -238,8 +240,8 @@ export const rulesConverters = new Map([
     ["no-parameter-properties", convertNoParameterProperties],
     ["no-parameter-reassignment", convertNoParameterReassignment],
     ["no-redundant-jsdoc", convertNoRedundantJsdoc],
-    ["no-reference", convertNoReference],
     ["no-reference-import", convertNoReferenceImport],
+    ["no-reference", convertNoReference],
     ["no-regex-spaces", convertNoRegexSpaces],
     ["no-require-imports", convertNoRequireImports],
     ["no-return-await", convertNoReturnAwait],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #475
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

This rule is not configurable, so pretty straightforward converter 🌻 .

Also, don't mind the little sort I did on the converter list, I always get lazy looking for the correct placement while looking at all `no-*` converters.