### PR TITLE
Add codelyzer no-input-prefix converter

### DIFF
--- a/src/rules/converters/codelyzer/no-input-prefix.ts
+++ b/src/rules/converters/codelyzer/no-input-prefix.ts
@@ -1,0 +1,19 @@
+import { RuleConverter } from "../../converter";
+
+export const convertNoInputPrefix: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: [
+                        {
+                            prefixes: tslintRule.ruleArguments,
+                        },
+                    ],
+                }),
+                ruleName: "@angular-eslint/no-input-prefix",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/no-input-prefix.test.ts
+++ b/src/rules/converters/codelyzer/tests/no-input-prefix.test.ts
@@ -1,0 +1,38 @@
+import { convertNoInputPrefix } from "../no-input-prefix";
+
+describe(convertNoInputPrefix, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoInputPrefix({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/no-input-prefix",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+
+    test("conversion with arguments", () => {
+        const result = convertNoInputPrefix({
+            ruleArguments: ["can", "is", "should"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            prefixes: ["can", "is", "should"],
+                        },
+                    ],
+                    ruleName: "@angular-eslint/no-input-prefix",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -148,6 +148,7 @@ import { convertNoAttributeDecorator } from "./converters/codelyzer/no-attribute
 import { convertUsePipeDecorator } from "./converters/codelyzer/use-pipe-decorator";
 import { convertNoForwardRef } from "./converters/codelyzer/no-forward-ref";
 import { convertNoHostMetadataProperty } from "./converters/codelyzer/no-host-metadata-property";
+import { convertNoInputPrefix } from "./converters/codelyzer/no-input-prefix";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -226,6 +227,7 @@ export const rulesConverters = new Map([
     ["no-implicit-dependencies", convertNoImplicitDependencies],
     ["no-import-side-effect", convertNoImportSideEffect],
     ["no-inferrable-types", convertNoInferrableTypes],
+    ["no-input-prefix", convertNoInputPrefix],
     ["no-internal-module", convertNoInternalModule],
     ["no-invalid-regexp", convertNoInvalidRegexp],
     ["no-invalid-template-strings", convertNoInvalidTemplateStrings],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #477
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
The TSLint rule takes a list of strings which are mapped into the ESLint ule output as the value of `prefixes` property.