### PR TITLE
Corrected --comment/--comments spelling

### DIFF
--- a/src/comments/convertComments.test.ts
+++ b/src/comments/convertComments.test.ts
@@ -10,7 +10,7 @@ const createStubDependencies = (
 });
 
 describe("convertComments", () => {
-    it("returns an empty result when --comment is not provided", async () => {
+    it("returns an empty result when --comments is not provided", async () => {
         // Arrange
         const dependencies = createStubDependencies();
 
@@ -24,7 +24,7 @@ describe("convertComments", () => {
         });
     });
 
-    it("returns an error when --comment is given as a boolean value", async () => {
+    it("returns an error when --comments is given as a boolean value", async () => {
         // Arrange
         const dependencies = createStubDependencies();
 

--- a/src/comments/convertComments.ts
+++ b/src/comments/convertComments.ts
@@ -10,7 +10,7 @@ export type ConvertCommentsDependencies = {
 };
 
 const noGlobsResult: ResultWithDataStatus<string[]> = {
-    errors: [new Error("--comment requires file path globs to be passed.")],
+    errors: [new Error("--comments requires file path globs to be passed.")],
     status: ResultStatus.Failed,
 };
 

--- a/src/reporting/reportCommentResults.test.ts
+++ b/src/reporting/reportCommentResults.test.ts
@@ -13,7 +13,7 @@ describe("reportCommentResults", () => {
         // Assert
         expectEqualWrites(
             logger.stdout.write,
-            `♻ Consider using --comment to replace TSLint comment directives in your source files. ♻`,
+            `♻ Consider using --comments to replace TSLint comment directives in your source files. ♻`,
         );
     });
 
@@ -28,12 +28,12 @@ describe("reportCommentResults", () => {
         // Assert
         expectEqualWrites(
             logger.stderr.write,
-            `❌ 1 error converting TSLint comment directives in --comment files. ❌`,
+            `❌ 1 error converting TSLint comment directives in --comments files. ❌`,
             `  Check ${logger.debugFileName} for details.`,
         );
         expectEqualWrites(
             logger.info.write,
-            `1 error converting TSLint comment directives in --comment files:`,
+            `1 error converting TSLint comment directives in --comments files:`,
             `  * Hello`,
         );
     });
@@ -49,12 +49,12 @@ describe("reportCommentResults", () => {
         // Assert
         expectEqualWrites(
             logger.stderr.write,
-            `❌ 2 errors converting TSLint comment directives in --comment files. ❌`,
+            `❌ 2 errors converting TSLint comment directives in --comments files. ❌`,
             `  Check ${logger.debugFileName} for details.`,
         );
         expectEqualWrites(
             logger.info.write,
-            `2 errors converting TSLint comment directives in --comment files:`,
+            `2 errors converting TSLint comment directives in --comments files:`,
             `  * Hello`,
             `  * World`,
         );

--- a/src/reporting/reportCommentResults.ts
+++ b/src/reporting/reportCommentResults.ts
@@ -15,7 +15,7 @@ export const reportCommentResults = (
     if (commentsResult.status === ResultStatus.Failed) {
         const headline = `${commentsResult.errors.length} error${
             commentsResult.errors.length === 1 ? "" : "s"
-        } converting TSLint comment directives in --comment files`;
+        } converting TSLint comment directives in --comments files`;
 
         dependencies.logger.stderr.write(chalk.magentaBright(`${EOL}❌ ${headline}. ❌${EOL}`));
         dependencies.logger.stderr.write(
@@ -33,7 +33,7 @@ export const reportCommentResults = (
     if (commentsResult.data === undefined) {
         dependencies.logger.stdout.write(
             chalk.magentaBright(
-                `${EOL}♻ Consider using --comment to replace TSLint comment directives in your source files. ♻${EOL}`,
+                `${EOL}♻ Consider using --comments to replace TSLint comment directives in your source files. ♻${EOL}`,
             ),
         );
         return;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #535
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

I can spell.