### PR TITLE
Stopped writing empty root members in output configurations

### DIFF
--- a/src/creation/writeConversionResults.test.ts
+++ b/src/creation/writeConversionResults.test.ts
@@ -46,7 +46,6 @@ describe("writeConversionResults", () => {
                     sourceType: "module",
                 },
                 plugins: ["@typescript-eslint"],
-                rules: {},
             }),
         );
     });
@@ -137,8 +136,6 @@ describe("writeConversionResults", () => {
                     es6: true,
                     node: true,
                 },
-                extends: [],
-                rules: {},
                 parser: "@typescript-eslint/parser",
                 parserOptions: {
                     project: "tsconfig.json",
@@ -182,7 +179,6 @@ describe("writeConversionResults", () => {
                     sourceType: "module",
                 },
                 plugins: ["@typescript-eslint"],
-                rules: {},
             }),
         );
     });
@@ -224,8 +220,6 @@ describe("writeConversionResults", () => {
                     es6: true,
                     node: true,
                 },
-                extends: [],
-                rules: {},
                 globals: {
                     Promise: true,
                 },

--- a/src/creation/writeConversionResults.ts
+++ b/src/creation/writeConversionResults.ts
@@ -1,5 +1,6 @@
 import { FileSystem } from "../adapters/fileSystem";
 import { AllOriginalConfigurations } from "../input/findOriginalConfigurations";
+import { removeEmptyMembers } from "../utils";
 import { createEnv } from "./eslint/createEnv";
 import { formatConvertedRules } from "./formatConvertedRules";
 import { formatOutput } from "./formatting/formatOutput";
@@ -22,11 +23,11 @@ export const writeConversionResults = async (
         plugins.push("@typescript-eslint/tslint");
     }
 
-    const output = {
+    const output = removeEmptyMembers({
         ...eslint?.full,
         env: createEnv(originalConfigurations),
         ...(eslint && { globals: eslint.raw.globals }),
-        ...(summarizedResults.extends?.length !== 0 && { extends: summarizedResults.extends }),
+        ...(summarizedResults.extends && { extends: summarizedResults.extends }),
         parser: "@typescript-eslint/parser",
         parserOptions: {
             project: "tsconfig.json",
@@ -37,7 +38,7 @@ export const writeConversionResults = async (
             // ...trimESLintRules(eslint?.full.rules, summarizedResults.extensionRules),
             ...formatConvertedRules(summarizedResults, tslint.full),
         },
-    };
+    });
 
     return await dependencies.fileSystem.writeFile(outputPath, formatOutput(outputPath, output));
 };

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { isDefined, isError, uniqueFromSources, separateErrors } from "./utils";
+import { isDefined, isError, uniqueFromSources, separateErrors, removeEmptyMembers } from "./utils";
 
 describe("isDefined", () => {
     it("returns true when the item is defined", () => {
@@ -45,6 +45,41 @@ describe("isError", () => {
 
         // Assert
         expect(result).toBe(false);
+    });
+});
+
+describe("removeEmptyMembers", () => {
+    it("remove an object member when it is empty", () => {
+        // Arrange
+        const items = { kept: { value: true }, removed: {} };
+
+        // Act
+        const result = removeEmptyMembers(items);
+
+        // Assert
+        expect(result).toEqual({ kept: { value: true } });
+    });
+
+    it("removes an array member when it is empty", () => {
+        // Arrange
+        const items = { kept: [true], removed: [] };
+
+        // Act
+        const result = removeEmptyMembers(items);
+
+        // Assert
+        expect(result).toEqual({ kept: [true] });
+    });
+
+    it("keeps a member when it isn't an array or object", () => {
+        // Arrange
+        const items = { kept: true };
+
+        // Act
+        const result = removeEmptyMembers(items);
+
+        // Assert
+        expect(result).toEqual({ kept: true });
     });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,21 @@ export const isError = <Item>(item: Item | Error): item is Error => item instanc
 
 export const isTruthy = <Item>(item: Item | false | undefined | null | 0): item is Item => !!item;
 
+export const removeEmptyMembers = <Item>(items: Item): Item => {
+    const result: any = {};
+
+    for (const [key, value] of Object.entries(items)) {
+        if (
+            !(value instanceof Array && value.length === 0) &&
+            !(value instanceof Object && Object.keys(value).length === 0)
+        ) {
+            result[key] = value;
+        }
+    }
+
+    return result;
+};
+
 export const separateErrors = <Item>(mixed: (Error | Item)[]): [Error[], Item[]] => {
     const errors: Error[] = [];
     const items: Item[] = [];


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #537
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Cleans up the output configuration format a little bit to not redundantly print empty objects. Just a little cleanup 🧹 