### PR TITLE
Added codelyzer use-component-view-encapsulation converter

### DIFF
--- a/src/rules/converters/codelyzer/tests/use-component-view-encapsulation.test.ts
+++ b/src/rules/converters/codelyzer/tests/use-component-view-encapsulation.test.ts
@@ -1,0 +1,18 @@
+import { convertUseComponentViewEncapsulation } from "../use-component-view-encapsulation";
+
+describe(convertUseComponentViewEncapsulation, () => {
+    test("conversion without arguments", () => {
+        const result = convertUseComponentViewEncapsulation({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/use-component-view-encapsulation",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/converters/codelyzer/use-component-view-encapsulation.ts
+++ b/src/rules/converters/codelyzer/use-component-view-encapsulation.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertUseComponentViewEncapsulation: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/use-component-view-encapsulation",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -152,6 +152,7 @@ import { convertNoInputPrefix } from "./converters/codelyzer/no-input-prefix";
 import { convertNoInputRename } from "./converters/codelyzer/no-input-rename";
 import { convertNoInputsMetadataProperty } from "./converters/codelyzer/no-inputs-metadata-property";
 import { convertNoLifecycleCall } from "./converters/codelyzer/no-lifecycle-call";
+import { convertUseComponentViewEncapsulation } from "./converters/codelyzer/use-component-view-encapsulation";
 import { convertUsePipeDecorator } from "./converters/codelyzer/use-pipe-decorator";
 
 /**
@@ -307,6 +308,7 @@ export const rulesConverters = new Map([
     ["unified-signatures", convertUnifiedSignatures],
     ["unnecessary-bind", convertUnnecessaryBind],
     ["unnecessary-constructor", convertUnnecessaryConstructor],
+    ["use-component-view-encapsulation", convertUseComponentViewEncapsulation],
     ["use-default-type-parameter", convertUseDefaultTypeParameter],
     ["use-isnan", convertUseIsnan],
     ["use-pipe-decorator", convertUsePipeDecorator],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #513
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡