### PR TITLE
Added Codelyzer contextual-decorator converter

### DIFF
--- a/src/rules/converters/codelyzer/contextual-decorator.ts
+++ b/src/rules/converters/codelyzer/contextual-decorator.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertContextualDecorator: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/contextual-decorator",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/contextual-decorator.test.ts
+++ b/src/rules/converters/codelyzer/tests/contextual-decorator.test.ts
@@ -1,0 +1,18 @@
+import { convertContextualDecorator } from "../contextual-decorator";
+
+describe(convertContextualDecorator, () => {
+    test("conversion without arguments", () => {
+        const result = convertContextualDecorator({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/contextual-decorator",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -141,6 +141,7 @@ import { convertVariableName } from "./converters/variable-name";
 import { convertComponentClassSuffix } from "./converters/codelyzer/component-class-suffix";
 import { convertComponentMaxInlineDeclarations } from "./converters/codelyzer/component-max-inline-declarations";
 import { convertComponentSelector } from "./converters/codelyzer/component-selector";
+import { convertContextualDecorator } from "./converters/codelyzer/contextual-decorator";
 import { convertContextualLifecycle } from "./converters/codelyzer/contextual-lifecycle";
 import { convertDirectiveClassSuffix } from "./converters/codelyzer/directive-class-suffix";
 import { convertDirectiveSelector } from "./converters/codelyzer/directive-selector";
@@ -176,6 +177,7 @@ export const rulesConverters = new Map([
     ["component-class-suffix", convertComponentClassSuffix],
     ["component-max-inline-declarations", convertComponentMaxInlineDeclarations],
     ["component-selector", convertComponentSelector],
+    ["contextual-decorator", convertContextualDecorator],
     ["contextual-lifecycle", convertContextualLifecycle],
     ["curly", convertCurly],
     ["cyclomatic-complexity", convertCyclomaticComplexity],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #468 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/contextual-decorator / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/rules/contextual-decorator.ts