### PR TITLE
Added Codelyzer import-destructuring-spacing converter

### DIFF
--- a/src/rules/converters/codelyzer/import-destructuring-spacing.ts
+++ b/src/rules/converters/codelyzer/import-destructuring-spacing.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertImportDestructuringSpacing: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/import-destructuring-spacing",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/import-destructuring-spacing.test.ts
+++ b/src/rules/converters/codelyzer/tests/import-destructuring-spacing.test.ts
@@ -1,0 +1,18 @@
+import { convertImportDestructuringSpacing } from "../import-destructuring-spacing";
+
+describe(convertImportDestructuringSpacing, () => {
+    test("conversion without arguments", () => {
+        const result = convertImportDestructuringSpacing({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/import-destructuring-spacing",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -144,6 +144,7 @@ import { convertComponentSelector } from "./converters/codelyzer/component-selec
 import { convertContextualLifecycle } from "./converters/codelyzer/contextual-lifecycle";
 import { convertDirectiveClassSuffix } from "./converters/codelyzer/directive-class-suffix";
 import { convertDirectiveSelector } from "./converters/codelyzer/directive-selector";
+import { convertImportDestructuringSpacing } from "./converters/codelyzer/import-destructuring-spacing";
 import { convertNoAttributeDecorator } from "./converters/codelyzer/no-attribute-decorator";
 import { convertNoConflictingLifecycle } from "./converters/codelyzer/no-conflicting-lifecycle";
 import { convertNoForwardRef } from "./converters/codelyzer/no-forward-ref";
@@ -187,6 +188,7 @@ export const rulesConverters = new Map([
     ["forin", convertForin],
     ["function-constructor", convertFunctionConstructor],
     ["import-blacklist", convertImportBlacklist],
+    ["import-destructuring-spacing", convertImportDestructuringSpacing],
     ["increment-decrement", convertIncrementDecrement],
     ["indent", convertIndent],
     ["interface-name", convertInterfaceName],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #472 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/import-destructuring-spacing / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/rules/import-destructuring-spacing.ts