### PR TITLE
Added Codelyzer no-output-native converter

### DIFF
--- a/src/rules/converters/codelyzer/no-output-native.ts
+++ b/src/rules/converters/codelyzer/no-output-native.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertNoOutputNative: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/no-output-native",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/no-output-native.test.ts
+++ b/src/rules/converters/codelyzer/tests/no-output-native.test.ts
@@ -1,0 +1,18 @@
+import { convertNoOutputNative } from "../no-output-native";
+
+describe(convertNoOutputNative, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoOutputNative({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/no-output-native",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -151,6 +151,7 @@ import { convertNoHostMetadataProperty } from "./converters/codelyzer/no-host-me
 import { convertNoInputPrefix } from "./converters/codelyzer/no-input-prefix";
 import { convertNoInputRename } from "./converters/codelyzer/no-input-rename";
 import { convertNoInputsMetadataProperty } from "./converters/codelyzer/no-inputs-metadata-property";
+import { convertNoOutputNative } from "./converters/codelyzer/no-output-native";
 import { convertNoLifecycleCall } from "./converters/codelyzer/no-lifecycle-call";
 import { convertUseInjectableProvidedIn } from "./converters/codelyzer/use-injectable-provided-in";
 import { convertUseLifecycleInterface } from "./converters/codelyzer/use-lifecycle-interface";
@@ -250,6 +251,7 @@ export const rulesConverters = new Map([
     ["no-non-null-assertion", convertNoNonNullAssertion],
     ["no-null-keyword", convertNoNullKeyword],
     ["no-object-literal-type-assertion", convertNoObjectLiteralTypeAssertion],
+    ["no-output-native", convertNoOutputNative],
     ["no-octal-literal", convertNoOctalLiteral],
     ["no-parameter-properties", convertNoParameterProperties],
     ["no-parameter-reassignment", convertNoParameterReassignment],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #481 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/no-output-native / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/rules/no-output-native.ts