### PR TITLE
Added Codelyzer no-output-on-prefix converter

### DIFF
--- a/src/rules/converters/codelyzer/no-output-on-prefix.ts
+++ b/src/rules/converters/codelyzer/no-output-on-prefix.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertNoOutputOnPrefix: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/no-output-on-prefix",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/no-output-on-prefix.test.ts
+++ b/src/rules/converters/codelyzer/tests/no-output-on-prefix.test.ts
@@ -1,0 +1,18 @@
+import { convertNoOutputOnPrefix } from "../no-output-on-prefix";
+
+describe(convertNoOutputOnPrefix, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoOutputOnPrefix({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/no-output-on-prefix",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -152,6 +152,7 @@ import { convertNoInputPrefix } from "./converters/codelyzer/no-input-prefix";
 import { convertNoInputRename } from "./converters/codelyzer/no-input-rename";
 import { convertNoInputsMetadataProperty } from "./converters/codelyzer/no-inputs-metadata-property";
 import { convertNoLifecycleCall } from "./converters/codelyzer/no-lifecycle-call";
+import { convertNoOutputOnPrefix } from "./converters/codelyzer/no-output-on-prefix";
 import { convertUseInjectableProvidedIn } from "./converters/codelyzer/use-injectable-provided-in";
 import { convertUseLifecycleInterface } from "./converters/codelyzer/use-lifecycle-interface";
 import { convertUsePipeDecorator } from "./converters/codelyzer/use-pipe-decorator";
@@ -252,6 +253,7 @@ export const rulesConverters = new Map([
     ["no-null-keyword", convertNoNullKeyword],
     ["no-object-literal-type-assertion", convertNoObjectLiteralTypeAssertion],
     ["no-octal-literal", convertNoOctalLiteral],
+    ["no-output-on-prefix", convertNoOutputOnPrefix],
     ["no-parameter-properties", convertNoParameterProperties],
     ["no-parameter-reassignment", convertNoParameterReassignment],
     ["no-redundant-jsdoc", convertNoRedundantJsdoc],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #482 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/no-output-on-prefix / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/rules/no-output-on-prefix.ts