### PR TITLE
Added Codelyzer no-outputs-metadata-property converter

### DIFF
--- a/src/rules/converters/codelyzer/no-outputs-metadata-property.ts
+++ b/src/rules/converters/codelyzer/no-outputs-metadata-property.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertNoOutputsMetadataProperty: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/no-outputs-metadata-property",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/no-outputs-metadata-property.test.ts
+++ b/src/rules/converters/codelyzer/tests/no-outputs-metadata-property.test.ts
@@ -1,0 +1,18 @@
+import { convertNoOutputsMetadataProperty } from "../no-outputs-metadata-property";
+
+describe(convertNoOutputsMetadataProperty, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoOutputsMetadataProperty({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/no-outputs-metadata-property",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -152,6 +152,7 @@ import { convertNoInputPrefix } from "./converters/codelyzer/no-input-prefix";
 import { convertNoInputRename } from "./converters/codelyzer/no-input-rename";
 import { convertNoInputsMetadataProperty } from "./converters/codelyzer/no-inputs-metadata-property";
 import { convertNoOutputNative } from "./converters/codelyzer/no-output-native";
+import { convertNoOutputsMetadataProperty } from "./converters/codelyzer/no-outputs-metadata-property";
 import { convertNoLifecycleCall } from "./converters/codelyzer/no-lifecycle-call";
 import { convertUseInjectableProvidedIn } from "./converters/codelyzer/use-injectable-provided-in";
 import { convertUseLifecycleInterface } from "./converters/codelyzer/use-lifecycle-interface";
@@ -253,6 +254,7 @@ export const rulesConverters = new Map([
     ["no-null-keyword", convertNoNullKeyword],
     ["no-object-literal-type-assertion", convertNoObjectLiteralTypeAssertion],
     ["no-output-native", convertNoOutputNative],
+    ["no-outputs-metadata-property", convertNoOutputsMetadataProperty],
     ["no-octal-literal", convertNoOctalLiteral],
     ["no-parameter-properties", convertNoParameterProperties],
     ["no-parameter-reassignment", convertNoParameterReassignment],


### PR DESCRIPTION

## PR Checklist

-   [x] Addresses an existing issue: fixes #485
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/no-outputs-metadata-property / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/rules/no-outputs-metadata-property.ts