### PR TITLE
Added Codelyzer template-accessibility-table-scope converter

### DIFF
--- a/src/rules/converters/codelyzer/template-accessibility-table-scope.ts
+++ b/src/rules/converters/codelyzer/template-accessibility-table-scope.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertTemplateAccessibilityTableScope: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/template-accessibility-table-scope",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/template-accessibility-table-scope.test.ts
+++ b/src/rules/converters/codelyzer/tests/template-accessibility-table-scope.test.ts
@@ -1,0 +1,18 @@
+import { convertTemplateAccessibilityTableScope } from "../template-accessibility-table-scope";
+
+describe(convertTemplateAccessibilityTableScope, () => {
+    test("conversion without arguments", () => {
+        const result = convertTemplateAccessibilityTableScope({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/template-accessibility-table-scope",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -156,6 +156,7 @@ import { convertNoOutputNative } from "./converters/codelyzer/no-output-native";
 import { convertNoOutputOnPrefix } from "./converters/codelyzer/no-output-on-prefix";
 import { convertNoOutputsMetadataProperty } from "./converters/codelyzer/no-outputs-metadata-property";
 import { convertPreferOutputReadonly } from "./converters/codelyzer/prefer-output-readonly";
+import { convertTemplateAccessibilityTableScope } from "./converters/codelyzer/template-accessibility-table-scope";
 import { convertUseInjectableProvidedIn } from "./converters/codelyzer/use-injectable-provided-in";
 import { convertUseLifecycleInterface } from "./converters/codelyzer/use-lifecycle-interface";
 import { convertUsePipeDecorator } from "./converters/codelyzer/use-pipe-decorator";
@@ -310,6 +311,7 @@ export const rulesConverters = new Map([
     ["space-within-parens", convertSpaceWithinParens],
     ["strict-boolean-expressions", convertStrictBooleanExpressions],
     ["switch-default", convertSwitchDefault],
+    ["template-accessibility-table-scope", convertTemplateAccessibilityTableScope],
     ["trailing-comma", convertTrailingComma],
     ["triple-equals", convertTripleEquals],
     ["type-literal-delimiter", convertTypeLiteralDelimiter],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #498
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/template-accessibility-table-scope / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/rules/template-accessibility-table-scope.ts