### PR TITLE
Added Codelyzer template-no-autofocus converter

### DIFF
--- a/src/rules/converters/codelyzer/prefer-output-readonly.ts
+++ b/src/rules/converters/codelyzer/prefer-output-readonly.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertPreferOutputReadonly: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/prefer-output-readonly",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/template-no-autofocus.ts
+++ b/src/rules/converters/codelyzer/template-no-autofocus.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertTemplateNoAutofocus: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/template-no-autofocus",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/prefer-output-readonly.test.ts
+++ b/src/rules/converters/codelyzer/tests/prefer-output-readonly.test.ts
@@ -1,0 +1,18 @@
+import { convertPreferOutputReadonly } from "../prefer-output-readonly";
+
+describe(convertPreferOutputReadonly, () => {
+    test("conversion without arguments", () => {
+        const result = convertPreferOutputReadonly({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/prefer-output-readonly",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/converters/codelyzer/tests/template-no-autofocus.test.ts
+++ b/src/rules/converters/codelyzer/tests/template-no-autofocus.test.ts
@@ -1,0 +1,18 @@
+import { convertTemplateNoAutofocus } from "../template-no-autofocus";
+
+describe(convertTemplateNoAutofocus, () => {
+    test("conversion without arguments", () => {
+        const result = convertTemplateNoAutofocus({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/template-no-autofocus",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -156,6 +156,7 @@ import { convertNoOutputNative } from "./converters/codelyzer/no-output-native";
 import { convertNoOutputOnPrefix } from "./converters/codelyzer/no-output-on-prefix";
 import { convertNoOutputsMetadataProperty } from "./converters/codelyzer/no-outputs-metadata-property";
 import { convertPreferOutputReadonly } from "./converters/codelyzer/prefer-output-readonly";
+import { convertTemplateNoAutofocus } from "./converters/codelyzer/template-no-autofocus";
 import { convertUseInjectableProvidedIn } from "./converters/codelyzer/use-injectable-provided-in";
 import { convertUseLifecycleInterface } from "./converters/codelyzer/use-lifecycle-interface";
 import { convertUsePipeDecorator } from "./converters/codelyzer/use-pipe-decorator";
@@ -310,6 +311,7 @@ export const rulesConverters = new Map([
     ["space-within-parens", convertSpaceWithinParens],
     ["strict-boolean-expressions", convertStrictBooleanExpressions],
     ["switch-default", convertSwitchDefault],
+    ["template-no-autofocus", convertTemplateNoAutofocus],
     ["trailing-comma", convertTrailingComma],
     ["triple-equals", convertTripleEquals],
     ["type-literal-delimiter", convertTypeLiteralDelimiter],

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -151,10 +151,11 @@ import { convertNoHostMetadataProperty } from "./converters/codelyzer/no-host-me
 import { convertNoInputPrefix } from "./converters/codelyzer/no-input-prefix";
 import { convertNoInputRename } from "./converters/codelyzer/no-input-rename";
 import { convertNoInputsMetadataProperty } from "./converters/codelyzer/no-inputs-metadata-property";
-import { convertNoOutputNative } from "./converters/codelyzer/no-output-native";
-import { convertNoOutputsMetadataProperty } from "./converters/codelyzer/no-outputs-metadata-property";
 import { convertNoLifecycleCall } from "./converters/codelyzer/no-lifecycle-call";
+import { convertNoOutputNative } from "./converters/codelyzer/no-output-native";
 import { convertNoOutputOnPrefix } from "./converters/codelyzer/no-output-on-prefix";
+import { convertNoOutputsMetadataProperty } from "./converters/codelyzer/no-outputs-metadata-property";
+import { convertPreferOutputReadonly } from "./converters/codelyzer/prefer-output-readonly";
 import { convertUseInjectableProvidedIn } from "./converters/codelyzer/use-injectable-provided-in";
 import { convertUseLifecycleInterface } from "./converters/codelyzer/use-lifecycle-interface";
 import { convertUsePipeDecorator } from "./converters/codelyzer/use-pipe-decorator";
@@ -297,6 +298,7 @@ export const rulesConverters = new Map([
     ["prefer-for-of", convertPreferForOf],
     ["prefer-function-over-method", convertPreferFunctionOverMethod],
     ["prefer-object-spread", convertPreferObjectSpread],
+    ["prefer-output-readonly", convertPreferOutputReadonly],
     ["prefer-readonly", convertPreferReadonly],
     ["prefer-template", convertPreferTemplate],
     ["promise-function-async", convertPromiseFunctionAsync],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #507
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/template-no-autofocus /  https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin-template/src/rules/no-autofocus.ts