### PR TITLE
Added Codelyzer template-no-call-expression converter

### DIFF
--- a/src/rules/converters/codelyzer/template-no-call-expression.ts
+++ b/src/rules/converters/codelyzer/template-no-call-expression.ts
@@ -4,9 +4,9 @@ export const convertTemplateNoCallExpression: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "@angular-eslint/template-no-call-expression",
+                ruleName: "@angular-eslint/template/no-call-expression",
             },
         ],
-        plugins: ["@angular-eslint/eslint-plugin"],
+        plugins: ["@angular-eslint/eslint-plugin-template"],
     };
 };

--- a/src/rules/converters/codelyzer/template-no-call-expression.ts
+++ b/src/rules/converters/codelyzer/template-no-call-expression.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertTemplateNoCallExpression: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/template-no-call-expression",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/template-no-call-expression.test.ts
+++ b/src/rules/converters/codelyzer/tests/template-no-call-expression.test.ts
@@ -9,10 +9,10 @@ describe(convertTemplateNoCallExpression, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@angular-eslint/template-no-call-expression",
+                    ruleName: "@angular-eslint/template/no-call-expression",
                 },
             ],
-            plugins: ["@angular-eslint/eslint-plugin"],
+            plugins: ["@angular-eslint/eslint-plugin-template"],
         });
     });
 });

--- a/src/rules/converters/codelyzer/tests/template-no-call-expression.test.ts
+++ b/src/rules/converters/codelyzer/tests/template-no-call-expression.test.ts
@@ -1,0 +1,18 @@
+import { convertTemplateNoCallExpression } from "../template-no-call-expression";
+
+describe(convertTemplateNoCallExpression, () => {
+    test("conversion without arguments", () => {
+        const result = convertTemplateNoCallExpression({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/template-no-call-expression",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -162,6 +162,7 @@ import { convertPreferOnPushComponentChangeDetection } from "./converters/codely
 import { convertPreferOutputReadonly } from "./converters/codelyzer/prefer-output-readonly";
 import { convertRelativeUrlPrefix } from "./converters/codelyzer/relative-url-prefix";
 import { convertTemplateBananaInBox } from "./converters/codelyzer/template-banana-in-box";
+import { convertTemplateNoCallExpression } from "./converters/codelyzer/template-no-call-expression";
 import { convertUseComponentSelector } from "./converters/codelyzer/use-component-selector";
 import { convertUseComponentViewEncapsulation } from "./converters/codelyzer/use-component-view-encapsulation";
 import { convertUseInjectableProvidedIn } from "./converters/codelyzer/use-injectable-provided-in";
@@ -325,6 +326,7 @@ export const rulesConverters = new Map([
     ["strict-boolean-expressions", convertStrictBooleanExpressions],
     ["switch-default", convertSwitchDefault],
     ["template-banana-in-box", convertTemplateBananaInBox],
+    ["template-no-call-expression", convertTemplateNoCallExpression],
     ["trailing-comma", convertTrailingComma],
     ["triple-equals", convertTripleEquals],
     ["type-literal-delimiter", convertTypeLiteralDelimiter],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #508
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/template-no-call-expression / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin-template/src/rules/no-call-expression.ts

