### PR TITLE
Added Codelyzer template-no-distracting-elements converter

### DIFF
--- a/src/rules/converters/codelyzer/template-no-distracting-elements.ts
+++ b/src/rules/converters/codelyzer/template-no-distracting-elements.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertTemplateNoDistractingElements: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/template-no-distracting-elements",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/template-no-distracting-elements.test.ts
+++ b/src/rules/converters/codelyzer/tests/template-no-distracting-elements.test.ts
@@ -1,0 +1,18 @@
+import { convertTemplateNoDistractingElements } from "../template-no-distracting-elements";
+
+describe(convertTemplateNoDistractingElements, () => {
+    test("conversion without arguments", () => {
+        const result = convertTemplateNoDistractingElements({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/template-no-distracting-elements",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -156,6 +156,7 @@ import { convertNoOutputNative } from "./converters/codelyzer/no-output-native";
 import { convertNoOutputOnPrefix } from "./converters/codelyzer/no-output-on-prefix";
 import { convertNoOutputsMetadataProperty } from "./converters/codelyzer/no-outputs-metadata-property";
 import { convertPreferOutputReadonly } from "./converters/codelyzer/prefer-output-readonly";
+import { convertTemplateNoDistractingElements } from "./converters/codelyzer/template-no-distracting-elements";
 import { convertUseInjectableProvidedIn } from "./converters/codelyzer/use-injectable-provided-in";
 import { convertUseLifecycleInterface } from "./converters/codelyzer/use-lifecycle-interface";
 import { convertUsePipeDecorator } from "./converters/codelyzer/use-pipe-decorator";
@@ -310,6 +311,7 @@ export const rulesConverters = new Map([
     ["space-within-parens", convertSpaceWithinParens],
     ["strict-boolean-expressions", convertStrictBooleanExpressions],
     ["switch-default", convertSwitchDefault],
+    ["template-no-distracting-elements", convertTemplateNoDistractingElements],
     ["trailing-comma", convertTrailingComma],
     ["triple-equals", convertTripleEquals],
     ["type-literal-delimiter", convertTypeLiteralDelimiter],


### PR DESCRIPTION

## PR Checklist

-   [x] Addresses an existing issue: fixes #509
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/template-no-distracting-elements / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/rules/template-no-distracting-elements.ts
