### PR TITLE
Added Codelyzer template-no-negated-async converter

### DIFF
--- a/src/rules/converters/codelyzer/template-no-negated-async.ts
+++ b/src/rules/converters/codelyzer/template-no-negated-async.ts
@@ -4,9 +4,9 @@ export const convertTemplateNoNegatedAsync: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "@angular-eslint/template-no-negated-async",
+                ruleName: "@angular-eslint/template/no-negated-async",
             },
         ],
-        plugins: ["@angular-eslint/eslint-plugin"],
+        plugins: ["@angular-eslint/eslint-plugin-template"],
     };
 };

--- a/src/rules/converters/codelyzer/template-no-negated-async.ts
+++ b/src/rules/converters/codelyzer/template-no-negated-async.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertTemplateNoNegatedAsync: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/template-no-negated-async",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/template-no-negated-async.test.ts
+++ b/src/rules/converters/codelyzer/tests/template-no-negated-async.test.ts
@@ -9,10 +9,10 @@ describe(convertTemplateNoNegatedAsync, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@angular-eslint/template-no-negated-async",
+                    ruleName: "@angular-eslint/template/no-negated-async",
                 },
             ],
-            plugins: ["@angular-eslint/eslint-plugin"],
+            plugins: ["@angular-eslint/eslint-plugin-template"],
         });
     });
 });

--- a/src/rules/converters/codelyzer/tests/template-no-negated-async.test.ts
+++ b/src/rules/converters/codelyzer/tests/template-no-negated-async.test.ts
@@ -1,0 +1,18 @@
+import { convertTemplateNoNegatedAsync } from "../template-no-negated-async";
+
+describe(convertTemplateNoNegatedAsync, () => {
+    test("conversion without arguments", () => {
+        const result = convertTemplateNoNegatedAsync({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/template-no-negated-async",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -163,6 +163,7 @@ import { convertPreferOutputReadonly } from "./converters/codelyzer/prefer-outpu
 import { convertRelativeUrlPrefix } from "./converters/codelyzer/relative-url-prefix";
 import { convertTemplateBananaInBox } from "./converters/codelyzer/template-banana-in-box";
 import { convertTemplateNoCallExpression } from "./converters/codelyzer/template-no-call-expression";
+import { convertTemplateNoNegatedAsync } from "./converters/codelyzer/template-no-negated-async";
 import { convertUseComponentSelector } from "./converters/codelyzer/use-component-selector";
 import { convertUseComponentViewEncapsulation } from "./converters/codelyzer/use-component-view-encapsulation";
 import { convertUseInjectableProvidedIn } from "./converters/codelyzer/use-injectable-provided-in";
@@ -327,6 +328,7 @@ export const rulesConverters = new Map([
     ["switch-default", convertSwitchDefault],
     ["template-banana-in-box", convertTemplateBananaInBox],
     ["template-no-call-expression", convertTemplateNoCallExpression],
+    ["template-no-negated-async", convertTemplateNoNegatedAsync],
     ["trailing-comma", convertTrailingComma],
     ["triple-equals", convertTripleEquals],
     ["type-literal-delimiter", convertTypeLiteralDelimiter],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #510
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/template-no-negated-async / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin-template/src/rules/no-negated-async.ts