### PR TITLE
Added Codelyzer prefer-on-push-component-change-detection converter

### DIFF
--- a/src/rules/converters/codelyzer/prefer-on-push-component-change-detection.ts
+++ b/src/rules/converters/codelyzer/prefer-on-push-component-change-detection.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertPreferOnPushComponentChangeDetection: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/prefer-on-push-component-change-detection",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin"],
+    };
+};

--- a/src/rules/converters/codelyzer/tests/prefer-on-push-component-change-detection.test.ts
+++ b/src/rules/converters/codelyzer/tests/prefer-on-push-component-change-detection.test.ts
@@ -1,0 +1,18 @@
+import { convertPreferOnPushComponentChangeDetection } from "../prefer-on-push-component-change-detection";
+
+describe(convertPreferOnPushComponentChangeDetection, () => {
+    test("conversion without arguments", () => {
+        const result = convertPreferOnPushComponentChangeDetection({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/prefer-on-push-component-change-detection",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -158,6 +158,7 @@ import { convertNoOutputRename } from "./converters/codelyzer/no-output-rename";
 import { convertNoOutputsMetadataProperty } from "./converters/codelyzer/no-outputs-metadata-property";
 import { convertNoPipeImpure } from "./converters/codelyzer/no-pipe-impure";
 import { convertNoQueriesMetadataProperty } from "./converters/codelyzer/no-queries-metadata-property";
+import { convertPreferOnPushComponentChangeDetection } from "./converters/codelyzer/prefer-on-push-component-change-detection";
 import { convertPreferOutputReadonly } from "./converters/codelyzer/prefer-output-readonly";
 import { convertRelativeUrlPrefix } from "./converters/codelyzer/relative-url-prefix";
 import { convertUseComponentSelector } from "./converters/codelyzer/use-component-selector";
@@ -308,6 +309,7 @@ export const rulesConverters = new Map([
     ["prefer-for-of", convertPreferForOf],
     ["prefer-function-over-method", convertPreferFunctionOverMethod],
     ["prefer-object-spread", convertPreferObjectSpread],
+    ["prefer-on-push-component-change-detection", convertPreferOnPushComponentChangeDetection],
     ["prefer-output-readonly", convertPreferOutputReadonly],
     ["prefer-readonly", convertPreferReadonly],
     ["prefer-template", convertPreferTemplate],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #491
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Another non-configurable rule. ⚡

http://codelyzer.com/rules/prefer-on-push-component-change-detection / https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin/src/rules/prefer-on-push-component-change-detection.ts