### PR TITLE
Corrected NPM_TOKEN setting in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,9 @@ workflows:
                   requires:
                       - build
             - publish:
+                  filters:
+                      branches:
+                          only: master
                   requires:
                       - tsc
             - prettier:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,5 @@
 version: 2.1
 
-references:
-    set_npm_token: &set_npm_token
-        run:
-            name: Add NPM auth token file
-            command: echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-
 jobs:
     build:
         docker:
@@ -58,10 +52,10 @@ jobs:
         steps:
             - checkout
 
-            - *set_npm_token
-
             - attach_workspace:
                   at: "."
+
+            - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
 
             - run: npm publish || exit 0
 
@@ -121,9 +115,6 @@ workflows:
                   requires:
                       - build
             - publish:
-                  filters:
-                      branches:
-                          only: master
                   requires:
                       - tsc
             - prettier:


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #395 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

I think the issue was that the token was getting set _before_ the workspace was attached.