### PR TITLE
Fixed crash when ESLint rule has multiple rule arguments

### DIFF
--- a/src/creation/summarization/normalizeESLintRules.test.ts
+++ b/src/creation/summarization/normalizeESLintRules.test.ts
@@ -15,30 +15,6 @@ describe("normalizeESLintRules", () => {
         expect(result).toEqual(new Map());
     });
 
-    it("converts a rule when given as an array", () => {
-        // Arrange
-        const userRules: ESLintConfigurationRules = {
-            [ruleName]: ["error", {}],
-        };
-
-        // Act
-        const result = normalizeESLintRules(userRules);
-
-        // Assert
-        expect(result).toEqual(
-            new Map([
-                [
-                    ruleName,
-                    {
-                        ruleArguments: {},
-                        ruleName: "rule-a",
-                        ruleSeverity: "error",
-                    },
-                ],
-            ]),
-        );
-    });
-
     it("converts a rule when given as a severity level", () => {
         // Arrange
         const userRules: ESLintConfigurationRules = {
@@ -54,7 +30,55 @@ describe("normalizeESLintRules", () => {
                 [
                     ruleName,
                     {
-                        ruleArguments: {},
+                        ruleArguments: [{}],
+                        ruleName: "rule-a",
+                        ruleSeverity: "error",
+                    },
+                ],
+            ]),
+        );
+    });
+
+    it("converts a rule when given as an array", () => {
+        // Arrange
+        const userRules: ESLintConfigurationRules = {
+            [ruleName]: ["error", {}],
+        };
+
+        // Act
+        const result = normalizeESLintRules(userRules);
+
+        // Assert
+        expect(result).toEqual(
+            new Map([
+                [
+                    ruleName,
+                    {
+                        ruleArguments: [{}],
+                        ruleName: "rule-a",
+                        ruleSeverity: "error",
+                    },
+                ],
+            ]),
+        );
+    });
+
+    it("converts a rule when given as an array with multiple arguments", () => {
+        // Arrange
+        const userRules: ESLintConfigurationRules = {
+            [ruleName]: ["error", 4, { value: true }],
+        };
+
+        // Act
+        const result = normalizeESLintRules(userRules);
+
+        // Assert
+        expect(result).toEqual(
+            new Map([
+                [
+                    ruleName,
+                    {
+                        ruleArguments: [4, { value: true }],
                         ruleName: "rule-a",
                         ruleSeverity: "error",
                     },

--- a/src/creation/summarization/normalizeESLintRules.ts
+++ b/src/creation/summarization/normalizeESLintRules.ts
@@ -1,5 +1,8 @@
-import { ESLintConfigurationRules } from "../../input/findESLintConfiguration";
-import { ESLintRuleOptions } from "../../rules/types";
+import {
+    ESLintConfigurationRules,
+    ESLintConfigurationRuleValue,
+} from "../../input/findESLintConfiguration";
+import { ESLintRuleOptions, RawESLintRuleSeverity } from "../../rules/types";
 import { normalizeRawESLintRuleSeverity } from "../pruning/normalizeRawESLintRuleSeverity";
 
 /**
@@ -8,13 +11,20 @@ import { normalizeRawESLintRuleSeverity } from "../pruning/normalizeRawESLintRul
 export const normalizeESLintRules = (userRules: ESLintConfigurationRules | undefined) => {
     const output: Map<string, ESLintRuleOptions> = new Map();
 
-    for (const [ruleName, configuration] of Object.entries(userRules ?? {})) {
-        const [rawRuleSeverity, ruleArguments] =
-            configuration instanceof Array ? configuration : [configuration, {}];
+    for (const [ruleName, rawRuleValue] of Object.entries(userRules ?? {})) {
+        const [rawRuleSeverity, ruleArguments] = parseRawRuleValue(rawRuleValue);
         const ruleSeverity = normalizeRawESLintRuleSeverity(rawRuleSeverity);
 
         output.set(ruleName, { ruleArguments, ruleName, ruleSeverity });
     }
 
     return output;
+};
+
+const parseRawRuleValue = (
+    configuration: ESLintConfigurationRuleValue,
+): [RawESLintRuleSeverity, any[]] => {
+    return configuration instanceof Array
+        ? [configuration[0], configuration.slice(1)]
+        : [configuration, [{}]];
 };

--- a/src/creation/writeConversionResults.ts
+++ b/src/creation/writeConversionResults.ts
@@ -34,10 +34,7 @@ export const writeConversionResults = async (
             sourceType: "module",
         },
         plugins,
-        rules: {
-            // ...trimESLintRules(eslint?.full.rules, summarizedResults.extensionRules),
-            ...formatConvertedRules(summarizedResults, tslint.full),
-        },
+        rules: formatConvertedRules(summarizedResults, tslint.full),
     });
 
     return await dependencies.fileSystem.writeFile(outputPath, formatOutput(outputPath, output));

--- a/src/input/findESLintConfiguration.ts
+++ b/src/input/findESLintConfiguration.ts
@@ -21,8 +21,7 @@ export type ESLintConfigurationRules = {
 
 export type ESLintConfigurationRuleValue =
     | RawESLintRuleSeverity
-    | [RawESLintRuleSeverity]
-    | [RawESLintRuleSeverity, any];
+    | [RawESLintRuleSeverity, ...any[]];
 
 const defaultESLintConfiguration = {
     env: {},


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #581
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

I could only reproduce #581's crash for an existing `.eslintrc.js` containing a rule specifying multiple arguments:

```json
"@typescript-eslint/indent": [
    "error",
    4,
    {
        "ignoreComments": false
    }
],
```

The root issue was that `normalizeESLintRules` was converting the raw rules into an object with a single value in `ruleArguments`, not an array:

```ts
const [rawRuleSeverity, ruleArguments] =
    configuration instanceof Array ? configuration : [configuration, {}];
const ruleSeverity = normalizeRawESLintRuleSeverity(rawRuleSeverity);
```

```js
{
  ruleArguments: 4,
  ruleName: '@typescript-eslint/indent',
  ruleSeverity: 'error'
}
```

If `configuration` is an array, it should be `[configuration[0], configuration.slice(1)]` to capture the rule arguments as an array.