### PR TITLE
improve type safety with regards to  config files

### DIFF
--- a/src/creation/eslint/createEnv.test.ts
+++ b/src/creation/eslint/createEnv.test.ts
@@ -63,6 +63,20 @@ describe("createEnv", () => {
         });
     });
 
+    it("handles an environment where typescript configuration files are mostly undefined", () => {
+        // Arrange
+        const packages = undefined;
+        const typescript = {};
+
+        // Act
+        const env = createEnv({ packages, typescript });
+
+        // Assert
+        expect(env).not.toContain({
+            browser: expect.any(Boolean),
+        });
+    });
+
     it("returns browser as true if a typescript lib is dom", () => {
         // Arrange
         const packages = undefined;

--- a/src/creation/eslint/createEnv.ts
+++ b/src/creation/eslint/createEnv.ts
@@ -6,12 +6,12 @@ export const createEnv = ({
 }: Pick<AllOriginalConfigurations, "packages" | "typescript">) => {
     const browser =
         typescript === undefined ||
-        typescript.compilerOptions.lib === undefined ||
+        typescript.compilerOptions?.lib === undefined ||
         typescript.compilerOptions.lib.includes("dom");
 
     const es6 =
         typescript === undefined ||
-        !["es3", "es5"].includes(typescript.compilerOptions.target.toLowerCase());
+        !["es3", "es5"].includes(typescript.compilerOptions?.target?.toLowerCase() ?? "");
 
     const node =
         packages === undefined ||

--- a/src/input/findESLintConfiguration.ts
+++ b/src/input/findESLintConfiguration.ts
@@ -9,10 +9,10 @@ import { OriginalConfigurations } from "./findOriginalConfigurations";
 import { importer } from "./importer";
 
 export type ESLintConfiguration = {
-    env: Record<string, boolean>;
-    extends: string | string[];
-    globals?: Record<string, boolean>;
-    rules: ESLintConfigurationRules;
+    env?: Record<string, boolean | undefined>;
+    extends?: string | string[];
+    globals?: Record<string, boolean | undefined>;
+    rules?: ESLintConfigurationRules;
 };
 
 export type ESLintConfigurationRules = {
@@ -43,7 +43,7 @@ export const findESLintConfiguration = async (
         findRawConfiguration<ESLintConfiguration>(dependencies.importer, filePath, {
             extends: [],
         }),
-        findReportedConfiguration<Partial<ESLintConfiguration>>(
+        findReportedConfiguration<ESLintConfiguration>(
             dependencies.exec,
             "eslint --print-config",
             filePath,

--- a/src/input/findOriginalConfigurations.ts
+++ b/src/input/findOriginalConfigurations.ts
@@ -14,6 +14,7 @@ import {
 } from "./findTypeScriptConfiguration";
 import { findTSLintConfiguration, TSLintConfiguration } from "./findTSLintConfiguration";
 import { mergeLintConfigurations } from "./mergeLintConfigurations";
+import { DeepPartial } from "./findReportedConfiguration";
 
 export type FindOriginalConfigurationsDependencies = {
     findESLintConfiguration: SansDependencies<typeof findESLintConfiguration>;
@@ -35,7 +36,7 @@ export type OriginalConfigurations<Configuration> = {
     /**
      * Raw import results from `import`ing the configuration file.
      */
-    raw: Partial<Configuration>;
+    raw: DeepPartial<Configuration>;
 };
 
 export type AllOriginalConfigurations = {

--- a/src/input/findPackagesConfiguration.ts
+++ b/src/input/findPackagesConfiguration.ts
@@ -4,8 +4,8 @@ import {
 } from "./findReportedConfiguration";
 
 export type PackagesConfiguration = {
-    dependencies: Record<string, string>;
-    devDependencies: Record<string, string>;
+    dependencies: Record<string, string | undefined>;
+    devDependencies: Record<string, string | undefined>;
 };
 
 export const findPackagesConfiguration = async (

--- a/src/input/findReportedConfiguration.test.ts
+++ b/src/input/findReportedConfiguration.test.ts
@@ -1,5 +1,5 @@
 import { createStubExec, createStubThrowingExec } from "../adapters/exec.stubs";
-import { findReportedConfiguration, DeepPartial } from "./findReportedConfiguration";
+import { findReportedConfiguration } from "./findReportedConfiguration";
 
 describe("findReportedConfiguration", () => {
     it("returns stderr as an error when the command fails with a zero exit code", async () => {
@@ -55,24 +55,5 @@ describe("findReportedConfiguration", () => {
         expect(result).toEqual({
             rules,
         });
-    });
-
-    it("declares a correct DeepPartial type", () => {
-        type RulesType = {
-            "rule-a": boolean;
-            "rule-b": { component: string; deeper: { key: boolean } };
-        };
-        type PartialRules = DeepPartial<RulesType>;
-
-        type Expected = {
-            "rule-a"?: boolean;
-            "rule-b"?: { component?: string; deeper?: { key?: boolean } };
-        };
-
-        type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
-            ? true
-            : false;
-        const assertion: Equals<PartialRules, Expected> = true;
-        expect(assertion).toBeTruthy();
     });
 });

--- a/src/input/findReportedConfiguration.test.ts
+++ b/src/input/findReportedConfiguration.test.ts
@@ -1,5 +1,5 @@
 import { createStubExec, createStubThrowingExec } from "../adapters/exec.stubs";
-import { findReportedConfiguration } from "./findReportedConfiguration";
+import { findReportedConfiguration, DeepPartial } from "./findReportedConfiguration";
 
 describe("findReportedConfiguration", () => {
     it("returns stderr as an error when the command fails with a zero exit code", async () => {
@@ -55,5 +55,24 @@ describe("findReportedConfiguration", () => {
         expect(result).toEqual({
             rules,
         });
+    });
+
+    it("declares a correct DeepPartial type", () => {
+        type RulesType = {
+            "rule-a": boolean;
+            "rule-b": { component: string; deeper: { key: boolean } };
+        };
+        type PartialRules = DeepPartial<RulesType>;
+
+        type Expected = {
+            "rule-a"?: boolean;
+            "rule-b"?: { component?: string; deeper?: { key?: boolean } };
+        };
+
+        type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+            ? true
+            : false;
+        const assertion: Equals<PartialRules, Expected> = true;
+        expect(assertion).toBeTruthy();
     });
 });

--- a/src/input/findReportedConfiguration.ts
+++ b/src/input/findReportedConfiguration.ts
@@ -1,7 +1,7 @@
 import { Exec } from "../adapters/exec";
 
 export type DeepPartial<T> = {
-    [P in keyof T]?: T[P] extends Record<P, T[P]> ? DeepPartial<T[P]> : T[P];
+    [P in keyof T]?: T[P] extends Record<string, unknown> ? DeepPartial<T[P]> : T[P];
 };
 
 export type FindReportedConfigurationDependencies = {

--- a/src/input/findTSLintConfiguration.ts
+++ b/src/input/findTSLintConfiguration.ts
@@ -8,7 +8,7 @@ import { importer } from "./importer";
 export type TSLintConfiguration = {
     extends?: string[];
     rulesDirectory?: string[];
-    rules: TSLintConfigurationRules;
+    rules?: TSLintConfigurationRules;
 };
 
 export type TSLintConfigurationRules = Record<string, any>;

--- a/src/input/findTypeScriptConfiguration.ts
+++ b/src/input/findTypeScriptConfiguration.ts
@@ -4,9 +4,9 @@ import {
 } from "./findReportedConfiguration";
 
 export type TypeScriptConfiguration = {
-    compilerOptions: {
+    compilerOptions?: {
         lib?: string[];
-        target: string;
+        target?: string;
     };
 };
 

--- a/src/input/mergeLintConfigurations.ts
+++ b/src/input/mergeLintConfigurations.ts
@@ -10,7 +10,7 @@ export const mergeLintConfigurations = (
         return tslint;
     }
 
-    const mappedConfig = eslint.full.rules["@typescript-eslint/tslint/config"];
+    const mappedConfig = eslint.full.rules?.["@typescript-eslint/tslint/config"];
     if (!(mappedConfig instanceof Array) || mappedConfig[0] === "off") {
         return tslint;
     }

--- a/src/rules/convertRules.test.ts
+++ b/src/rules/convertRules.test.ts
@@ -5,7 +5,7 @@ import { RuleConverter, ConversionResult } from "./converter";
 import { RuleMerger } from "./merger";
 
 describe("convertRules", () => {
-    it("doesn't crash with a type error when passed undefined configuration", () => {
+    it("doesn't crash when passed an undefined configuration", () => {
         // Arrange
         const { converters, mergers } = setupConversionEnvironment({
             ruleSeverity: "off",

--- a/src/rules/convertRules.test.ts
+++ b/src/rules/convertRules.test.ts
@@ -5,6 +5,19 @@ import { RuleConverter, ConversionResult } from "./converter";
 import { RuleMerger } from "./merger";
 
 describe("convertRules", () => {
+    it("doesn't crash with a type error when passed undefined configuration", () => {
+        // Arrange
+        const { converters, mergers } = setupConversionEnvironment({
+            ruleSeverity: "off",
+        });
+
+        // Act
+        const { missing } = convertRules({ converters, mergers }, undefined);
+
+        // Assert
+        expect(missing).toEqual([]);
+    });
+
     it("doesn't marks a disabled rule as missing when its converter returns undefined", () => {
         // Arrange
         const { tslintRule, converters, mergers } = setupConversionEnvironment({


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
Last week I said I would look deeper at the poor `DeepPartial<T>` type in https://github.com/typescript-eslint/tslint-to-eslint-config/pull/589

It seems that this type needs to touch a number of config related places and there are several places where incomplete configurations might have slipped through but were fine according to tsc. 