### PR TITLE
fix: converters now uses naming-convention

### DIFF
--- a/src/rules/converters/class-name.ts
+++ b/src/rules/converters/class-name.ts
@@ -4,7 +4,7 @@ export const convertClassName: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "@typescript-eslint/class-name-casing",
+                ruleName: "@typescript-eslint/naming-convention",
             },
         ],
     };

--- a/src/rules/converters/interface-name.ts
+++ b/src/rules/converters/interface-name.ts
@@ -1,10 +1,23 @@
 import { RuleConverter } from "../converter";
 
-export const convertInterfaceName: RuleConverter = () => {
+export const convertInterfaceName: RuleConverter = (tslintRule) => {
     return {
         rules: [
             {
                 ruleName: "@typescript-eslint/naming-convention",
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    rules: [
+                        {
+                            selector: "interface",
+                            format: ["PascalCase"],
+                            custom: {
+                                regex: "^I[A-Z]",
+                                match:
+                                    tslintRule.ruleArguments[0] === "always-prefix" ? true : false,
+                            },
+                        },
+                    ],
+                }),
             },
         ],
     };

--- a/src/rules/converters/interface-name.ts
+++ b/src/rules/converters/interface-name.ts
@@ -4,7 +4,7 @@ export const convertInterfaceName: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "@typescript-eslint/interface-name-prefix",
+                ruleName: "@typescript-eslint/naming-convention",
             },
         ],
     };

--- a/src/rules/converters/tests/class-name.test.ts
+++ b/src/rules/converters/tests/class-name.test.ts
@@ -9,7 +9,7 @@ describe(convertClassName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@typescript-eslint/class-name-casing",
+                    ruleName: "@typescript-eslint/naming-convention",
                 },
             ],
         });

--- a/src/rules/converters/tests/interface-name.test.ts
+++ b/src/rules/converters/tests/interface-name.test.ts
@@ -9,7 +9,7 @@ describe(convertInterfaceName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@typescript-eslint/interface-name-prefix",
+                    ruleName: "@typescript-eslint/naming-convention",
                 },
             ],
         });

--- a/src/rules/converters/tests/interface-name.test.ts
+++ b/src/rules/converters/tests/interface-name.test.ts
@@ -14,4 +14,52 @@ describe(convertInterfaceName, () => {
             ],
         });
     });
+
+    test("conversion with 'always-prefix' argument", () => {
+        const result = convertInterfaceName({
+            ruleArguments: ["always-prefix"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "interface",
+                            format: ["PascalCase"],
+                            custom: {
+                                regex: "^I[A-Z]",
+                                match: true,
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    test("conversion with 'never-prefix' argument", () => {
+        const result = convertInterfaceName({
+            ruleArguments: ["never-prefix"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "interface",
+                            format: ["PascalCase"],
+                            custom: {
+                                regex: "^I[A-Z]",
+                                match: false,
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
 });

--- a/src/rules/converters/tests/variable-name.test.ts
+++ b/src/rules/converters/tests/variable-name.test.ts
@@ -1,12 +1,8 @@
 import {
     convertVariableName,
-    IgnoreLeadingTrailingUnderscoreMsg,
+    ConstRequiredForAllCapsMsg,
     ForbiddenLeadingTrailingIdentifierMsg,
     IgnoreLeadingTrailingIdentifierMsg,
-    ForbiddenPascalSnakeMsg,
-    ConstRequiredForAllCapsMsg,
-    IgnoreOnlyLeadingUnderscoreMsg,
-    IgnoreOnlyTrailingUnderscoreMsg,
 } from "../variable-name";
 
 describe(convertVariableName, () => {
@@ -18,8 +14,15 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: [IgnoreLeadingTrailingUnderscoreMsg],
-                    ruleName: "camelcase",
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
                 },
                 {
                     notices: [ForbiddenLeadingTrailingIdentifierMsg],
@@ -35,7 +38,7 @@ describe(convertVariableName, () => {
         });
     });
 
-    test("conversion with require-const-for-all-caps argument", () => {
+    test("conversion with require-const-for-all-caps argument without check-format argument", () => {
         const result = convertVariableName({
             ruleArguments: ["require-const-for-all-caps"],
         });
@@ -43,8 +46,15 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: [IgnoreLeadingTrailingUnderscoreMsg, ConstRequiredForAllCapsMsg],
-                    ruleName: "camelcase",
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
                 },
                 {
                     notices: [ForbiddenLeadingTrailingIdentifierMsg],
@@ -60,7 +70,7 @@ describe(convertVariableName, () => {
         });
     });
 
-    test("conversion with allow-pascal-case argument", () => {
+    test("conversion with allow-pascal-case argument without check-format argument", () => {
         const result = convertVariableName({
             ruleArguments: ["allow-pascal-case"],
         });
@@ -68,8 +78,15 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: [IgnoreLeadingTrailingUnderscoreMsg, ForbiddenPascalSnakeMsg],
-                    ruleName: "camelcase",
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
                 },
                 {
                     notices: [ForbiddenLeadingTrailingIdentifierMsg],
@@ -85,7 +102,7 @@ describe(convertVariableName, () => {
         });
     });
 
-    test("conversion with allow-snake-case argument", () => {
+    test("conversion with allow-snake-case argument without check-format argument", () => {
         const result = convertVariableName({
             ruleArguments: ["allow-snake-case"],
         });
@@ -93,8 +110,15 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "camelcase",
-                    notices: [IgnoreLeadingTrailingUnderscoreMsg, ForbiddenPascalSnakeMsg],
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
                 },
                 {
                     notices: [ForbiddenLeadingTrailingIdentifierMsg],
@@ -118,8 +142,15 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "camelcase",
-                    notices: [IgnoreLeadingTrailingUnderscoreMsg],
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
                 },
                 {
                     ruleName: "no-underscore-dangle",
@@ -143,8 +174,15 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: [IgnoreLeadingTrailingUnderscoreMsg],
-                    ruleName: "camelcase",
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
                 },
                 {
                     notices: [ForbiddenLeadingTrailingIdentifierMsg],
@@ -168,8 +206,48 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: [IgnoreLeadingTrailingUnderscoreMsg],
-                    ruleName: "camelcase",
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
+                },
+                {
+                    notices: [ForbiddenLeadingTrailingIdentifierMsg],
+                    ruleName: "no-underscore-dangle",
+                },
+                {
+                    ruleName: "id-blacklist",
+                },
+                {
+                    ruleName: "id-match",
+                },
+            ],
+        });
+    });
+
+    test("conversion with require-const-for-all-caps argument and check-format argument", () => {
+        const result = convertVariableName({
+            ruleArguments: ["check-format", "require-const-for-all-caps"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [ConstRequiredForAllCapsMsg],
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
                 },
                 {
                     notices: [ForbiddenLeadingTrailingIdentifierMsg],
@@ -193,8 +271,15 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: [IgnoreOnlyLeadingUnderscoreMsg],
-                    ruleName: "camelcase",
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "allow",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
                 },
                 {
                     notices: [IgnoreLeadingTrailingIdentifierMsg],
@@ -219,8 +304,15 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: [IgnoreOnlyTrailingUnderscoreMsg],
-                    ruleName: "camelcase",
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "allow",
+                        },
+                    ],
                 },
                 {
                     notices: [IgnoreLeadingTrailingIdentifierMsg],
@@ -249,8 +341,15 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: [],
-                    ruleName: "camelcase",
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "allow",
+                            trailingUnderscore: "allow",
+                        },
+                    ],
                 },
                 {
                     notices: [IgnoreLeadingTrailingIdentifierMsg],
@@ -283,8 +382,16 @@ describe(convertVariableName, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "camelcase",
-                    notices: [ConstRequiredForAllCapsMsg, ForbiddenPascalSnakeMsg],
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "allow",
+                            trailingUnderscore: "allow",
+                        },
+                    ],
+                    notices: [ConstRequiredForAllCapsMsg],
                 },
                 {
                     ruleName: "no-underscore-dangle",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #596
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

This should bring the latest changes from typescript-eslint (the rule removals section) as requested but not sure if I have to provide a merger for these converters @JoshuaKGoldberg 