### PR TITLE
Added jsx-key converter

### DIFF
--- a/src/rules/converters/eslint-plugin-react/jsx-key.ts
+++ b/src/rules/converters/eslint-plugin-react/jsx-key.ts
@@ -5,7 +5,6 @@ export const convertJsxKey: RuleConverter = () => {
         rules: [
             {
                 ruleName: "react/jsx-key",
-                ruleArguments: ["<enabled>"],
             },
         ],
         plugins: ["eslint-plugin-react"],

--- a/src/rules/converters/eslint-plugin-react/jsx-key.ts
+++ b/src/rules/converters/eslint-plugin-react/jsx-key.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../converter";
+
+export const convertJsxKey: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "react/jsx-key",
+                ruleArguments: ["<enabled>"],
+            },
+        ],
+        plugins: ["eslint-plugin-react"],
+    };
+};

--- a/src/rules/converters/eslint-plugin-react/tests/jsx-key.test.ts
+++ b/src/rules/converters/eslint-plugin-react/tests/jsx-key.test.ts
@@ -10,7 +10,6 @@ describe(convertJsxKey, () => {
             rules: [
                 {
                     ruleName: "react/jsx-key",
-                    ruleArguments: ["<enabled>"],
                 },
             ],
             plugins: ["eslint-plugin-react"],

--- a/src/rules/converters/eslint-plugin-react/tests/jsx-key.test.ts
+++ b/src/rules/converters/eslint-plugin-react/tests/jsx-key.test.ts
@@ -1,0 +1,19 @@
+import { convertJsxKey } from "../jsx-key";
+
+describe(convertJsxKey, () => {
+    test("conversion without arguments", () => {
+        const result = convertJsxKey({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "react/jsx-key",
+                    ruleArguments: ["<enabled>"],
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -174,6 +174,7 @@ import { convertUsePipeTransformInterface } from "./converters/codelyzer/use-pip
 
 // ESLint-React converters
 import { convertJsxBooleanValue } from "./converters/eslint-plugin-react/jsx-boolean-value";
+import { convertJsxKey } from "./converters/eslint-plugin-react/jsx-key";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -212,6 +213,7 @@ export const rulesConverters = new Map([
     ["interface-over-type-literal", convertInterfaceOverTypeLiteral],
     ["jsdoc-format", convertJSDocFormat],
     ["jsx-boolean-value", convertJsxBooleanValue],
+    ["jsx-key", convertJsxKey],
     ["label-position", convertLabelPosition],
     ["linebreak-style", convertLinebreakStyle],
     ["max-classes-per-file", convertMaxClassesPerFile],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #521
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Based on [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md), provides the correct converter for this rule.

However, I am not 100% sure about the `<enabled>` rule argument as this doesn't seem to be a string but TS code will mark it as a property if it isn't.