### PR TITLE
Quote wildcards for shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Each of these flags is optional:
 #### `comments`
 
 ```shell
-npx tslint-to-eslint-config --comments src/**/*.ts
+npx tslint-to-eslint-config --comments 'src/**/*.ts'
 ```
 
 _Default: none_


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

No existing issues, but I did run into one when running the command from the README:

```
$ npx tslint-to-eslint-config --prettier --comments **/*.ts[x]
npx: installed 56 in 4.615s

✨ 77 rules replaced with their ESLint equivalents. ✨

...

♻ 1 file of TSLint comment directives converted to ESLint. ♻
```

Whoops! My shell is eating up the glob. Really it should be quoted:

```
npx tslint-to-eslint-config --prettier --comments '**/*.tsx'
npx: installed 56 in 4.219s

✨ 77 rules replaced with their ESLint equivalents. ✨

...

♻ 144 files of TSLint comment directives converted to ESLint. ♻
```