### PR TITLE
Ignore all unknown editor settings in conversion

### DIFF
--- a/src/editorSettings/convertEditorSettings.ts
+++ b/src/editorSettings/convertEditorSettings.ts
@@ -4,7 +4,14 @@ import { convertEditorSetting } from "./convertEditorSetting";
 import { EditorSettingConverter } from "./converter";
 import { EditorSetting } from "./types";
 
-const EDITOR_SETTINGS_PREFIX = "editor.";
+const knownEditorSettings = new Set([
+    "tslint.configFile",
+    "tslint.jsEnable",
+    "tslint.ignoreDefinitionFiles",
+    "tslint.exclude",
+    "tslint.alwaysShowRuleFailuresAsWarnings",
+    "tslint.suppressWhileTypeErrorsPresent",
+]);
 
 export type ConvertEditorSettingsDependencies = {
     converters: Map<string, EditorSettingConverter>;
@@ -30,7 +37,7 @@ export const convertEditorSettings = (
     for (const [configurationName, value] of Object.entries(rawEditorConfiguration)) {
         // Configurations other than editor settings will be ignored.
         // See: https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin#configuration
-        if (!configurationName.startsWith(EDITOR_SETTINGS_PREFIX)) {
+        if (!knownEditorSettings.has(configurationName)) {
             continue;
         }
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #407
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Uses an explicit allowlist for the known editor settings mentioned in the [TSLint extension's docs](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin#configuration) instead of prefix filtering.

FYI @MrCube42 