### PR TITLE
Added editor settings converter for tslint.configFile, with full settings access

### DIFF
--- a/src/conversion/convertEditorConfig.test.ts
+++ b/src/conversion/convertEditorConfig.test.ts
@@ -92,7 +92,7 @@ describe("convertEditorConfig", () => {
         // Assert
         expect(dependencies.convertEditorSettings).toHaveBeenCalledWith(
             originalConfig,
-            createStubTSLintToESLintSettings(),
+            stubSettings,
         );
     });
 

--- a/src/conversion/convertEditorConfig.test.ts
+++ b/src/conversion/convertEditorConfig.test.ts
@@ -1,4 +1,5 @@
 import { EditorSetting } from "../editorSettings/types";
+import { createStubTSLintToESLintSettings } from "../settings.stubs";
 import { FailedResult, ResultStatus } from "../types";
 import { createEmptySettingConversionResults } from "./conversionResults.stubs";
 import { convertEditorConfig, ConvertEditorConfigDependencies } from "./convertEditorConfig";
@@ -89,7 +90,10 @@ describe("convertEditorConfig", () => {
         await convertEditorConfig(dependencies, stubSettings);
 
         // Assert
-        expect(dependencies.convertEditorSettings).toHaveBeenCalledWith(originalConfig);
+        expect(dependencies.convertEditorSettings).toHaveBeenCalledWith(
+            originalConfig,
+            createStubTSLintToESLintSettings(),
+        );
     });
 
     it("reports conversion results when settings are converted successfully", async () => {

--- a/src/conversion/convertEditorConfig.test.ts
+++ b/src/conversion/convertEditorConfig.test.ts
@@ -1,5 +1,4 @@
 import { EditorSetting } from "../editorSettings/types";
-import { createStubTSLintToESLintSettings } from "../settings.stubs";
 import { FailedResult, ResultStatus } from "../types";
 import { createEmptySettingConversionResults } from "./conversionResults.stubs";
 import { convertEditorConfig, ConvertEditorConfigDependencies } from "./convertEditorConfig";

--- a/src/conversion/convertEditorConfig.ts
+++ b/src/conversion/convertEditorConfig.ts
@@ -33,7 +33,10 @@ export const convertEditorConfig = async (
         };
     }
 
-    const settingConversionResults = dependencies.convertEditorSettings(conversion.result);
+    const settingConversionResults = dependencies.convertEditorSettings(
+        conversion.result,
+        settings,
+    );
 
     const fileWriteError = await dependencies.writeConversionResults(
         conversion.configPath,

--- a/src/editorSettings/convertEditorSetting.test.ts
+++ b/src/editorSettings/convertEditorSetting.test.ts
@@ -2,6 +2,7 @@ import { ConversionError } from "../errors/conversionError";
 import { convertEditorSetting } from "./convertEditorSetting";
 import { EditorSettingConverter } from "./converter";
 import { EditorSetting } from "./types";
+import { createStubTSLintToESLintSettings } from "../settings.stubs";
 
 describe("convertEditorSetting", () => {
     it("returns undefined when no converter exists for a setting", () => {
@@ -15,6 +16,7 @@ describe("convertEditorSetting", () => {
                 value: "any value",
             },
             converters,
+            createStubTSLintToESLintSettings(),
         );
 
         // Assert
@@ -42,6 +44,7 @@ describe("convertEditorSetting", () => {
                 value: "existing value",
             },
             converters,
+            createStubTSLintToESLintSettings(),
         );
 
         // Assert
@@ -65,7 +68,11 @@ describe("convertEditorSetting", () => {
         };
 
         // Act
-        const result = convertEditorSetting(tsLintSetting, converters);
+        const result = convertEditorSetting(
+            tsLintSetting,
+            converters,
+            createStubTSLintToESLintSettings(),
+        );
 
         // Assert
         expect(result).toEqual(ConversionError.forSettingError(error, tsLintSetting));

--- a/src/editorSettings/convertEditorSetting.ts
+++ b/src/editorSettings/convertEditorSetting.ts
@@ -1,10 +1,12 @@
 import { ConversionError } from "../errors/conversionError";
+import { TSLintToESLintSettings } from "../types";
 import { EditorSettingConverter } from "./converter";
 import { EditorSetting } from "./types";
 
 export const convertEditorSetting = (
     editorSetting: EditorSetting,
     converters: Map<string, EditorSettingConverter>,
+    settings: TSLintToESLintSettings,
 ) => {
     const converter = converters.get(editorSetting.editorSettingName);
     if (converter === undefined) {
@@ -12,7 +14,7 @@ export const convertEditorSetting = (
     }
 
     try {
-        return converter(editorSetting);
+        return converter(editorSetting, settings);
     } catch (error) {
         return ConversionError.forSettingError(error, editorSetting);
     }

--- a/src/editorSettings/convertEditorSettings.test.ts
+++ b/src/editorSettings/convertEditorSettings.test.ts
@@ -1,4 +1,5 @@
 import { ConversionError } from "../errors/conversionError";
+import { createStubTSLintToESLintSettings } from "../settings.stubs";
 import { convertEditorSettings } from "./convertEditorSettings";
 import { EditorSettingConversionResult, EditorSettingConverter } from "./converter";
 import { EditorSetting } from "./types";
@@ -13,7 +14,11 @@ describe("convertEditorSettings", () => {
         };
 
         // Act
-        const result = convertEditorSettings({ converters }, editorConfiguration);
+        const result = convertEditorSettings(
+            { converters },
+            editorConfiguration,
+            createStubTSLintToESLintSettings(),
+        );
 
         // Assert
         expect(result).toEqual({
@@ -41,7 +46,11 @@ describe("convertEditorSettings", () => {
         };
 
         // Act
-        const result = convertEditorSettings({ converters }, editorConfiguration);
+        const result = convertEditorSettings(
+            { converters },
+            editorConfiguration,
+            createStubTSLintToESLintSettings(),
+        );
 
         // Assert
         expect(result).toEqual({
@@ -67,6 +76,7 @@ describe("convertEditorSettings", () => {
         const result = convertEditorSettings(
             { converters },
             { [editorSetting.editorSettingName]: editorSetting },
+            createStubTSLintToESLintSettings(),
         );
 
         // Assert
@@ -87,6 +97,7 @@ describe("convertEditorSettings", () => {
         const result = convertEditorSettings(
             { converters },
             { [editorSetting.editorSettingName]: editorSetting },
+            createStubTSLintToESLintSettings(),
         );
 
         // Assert
@@ -112,6 +123,7 @@ describe("convertEditorSettings", () => {
         const result = convertEditorSettings(
             { converters },
             { [editorSetting.editorSettingName]: editorSetting.value },
+            createStubTSLintToESLintSettings(),
         );
 
         // Assert

--- a/src/editorSettings/convertEditorSettings.ts
+++ b/src/editorSettings/convertEditorSettings.ts
@@ -1,5 +1,6 @@
 import { ConversionError } from "../errors/conversionError";
 import { ErrorSummary } from "../errors/errorSummary";
+import { TSLintToESLintSettings } from "../types";
 import { convertEditorSetting } from "./convertEditorSetting";
 import { EditorSettingConverter } from "./converter";
 import { EditorSetting } from "./types";
@@ -29,6 +30,7 @@ export type EditorConfiguration = Record<string, any>;
 export const convertEditorSettings = (
     dependencies: ConvertEditorSettingsDependencies,
     rawEditorConfiguration: EditorConfiguration,
+    settings: TSLintToESLintSettings,
 ): EditorSettingConversionResults => {
     const converted = new Map<string, EditorSetting>();
     const failed: ConversionError[] = [];
@@ -42,7 +44,7 @@ export const convertEditorSettings = (
         }
 
         const editorSetting = { editorSettingName: configurationName, value };
-        const conversion = convertEditorSetting(editorSetting, dependencies.converters);
+        const conversion = convertEditorSetting(editorSetting, dependencies.converters, settings);
 
         if (conversion === undefined) {
             const { editorSettingName } = editorSetting;

--- a/src/editorSettings/convertEditorSettings.ts
+++ b/src/editorSettings/convertEditorSettings.ts
@@ -4,7 +4,14 @@ import { convertEditorSetting } from "./convertEditorSetting";
 import { EditorSettingConverter } from "./converter";
 import { EditorSetting } from "./types";
 
-const EDITOR_SETTINGS_PREFIX = "editor.";
+const knownEditorSettings = new Set([
+    "tslint.configFile",
+    "tslint.jsEnable",
+    "tslint.ignoreDefinitionFiles",
+    "tslint.exclude",
+    "tslint.alwaysShowRuleFailuresAsWarnings",
+    "tslint.suppressWhileTypeErrorsPresent",
+]);
 
 export type ConvertEditorSettingsDependencies = {
     converters: Map<string, EditorSettingConverter>;
@@ -30,7 +37,7 @@ export const convertEditorSettings = (
     for (const [configurationName, value] of Object.entries(rawEditorConfiguration)) {
         // Configurations other than editor settings will be ignored.
         // See: https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin#configuration
-        if (!configurationName.startsWith(EDITOR_SETTINGS_PREFIX)) {
+        if (!knownEditorSettings.has(configurationName)) {
             continue;
         }
 

--- a/src/editorSettings/converter.ts
+++ b/src/editorSettings/converter.ts
@@ -1,4 +1,5 @@
 import { ConversionError } from "../errors/conversionError";
+import { TSLintToESLintSettings } from "../types";
 import { EditorSetting } from "./types";
 
 /**
@@ -6,7 +7,8 @@ import { EditorSetting } from "./types";
  */
 export type EditorSettingConverter = (
     tslintEditorSetting: EditorSetting,
-) => ConversionError | EditorSettingConversionResult;
+    settings: TSLintToESLintSettings,
+) => ConversionError | EditorSettingConversionResult | undefined;
 
 /**
  * Successful result from converting a TSLint editor setting to its ESLint equivalents.

--- a/src/editorSettings/converters/tests/editor-code-actions-on-save.test.ts
+++ b/src/editorSettings/converters/tests/editor-code-actions-on-save.test.ts
@@ -1,13 +1,17 @@
+import { createStubTSLintToESLintSettings } from "../../../settings.stubs";
 import { convertEditorCodeActionsOnSave } from "../editor-code-actions-on-save";
 
 describe(convertEditorCodeActionsOnSave, () => {
     test("conversion of 'source.fixAll.tslint' when value is true", () => {
-        const result = convertEditorCodeActionsOnSave({
-            editorSettingName: "editor.codeActionsOnSave",
-            value: {
-                "source.fixAll.tslint": true,
+        const result = convertEditorCodeActionsOnSave(
+            {
+                editorSettingName: "editor.codeActionsOnSave",
+                value: {
+                    "source.fixAll.tslint": true,
+                },
             },
-        });
+            createStubTSLintToESLintSettings(),
+        );
 
         expect(result).toEqual({
             settings: [
@@ -24,12 +28,15 @@ describe(convertEditorCodeActionsOnSave, () => {
     });
 
     test("conversion of 'source.fixAll.tslint' when value is false", () => {
-        const result = convertEditorCodeActionsOnSave({
-            editorSettingName: "editor.codeActionsOnSave",
-            value: {
-                "source.fixAll.tslint": false,
+        const result = convertEditorCodeActionsOnSave(
+            {
+                editorSettingName: "editor.codeActionsOnSave",
+                value: {
+                    "source.fixAll.tslint": false,
+                },
             },
-        });
+            createStubTSLintToESLintSettings(),
+        );
 
         expect(result).toEqual({
             settings: [
@@ -46,14 +53,17 @@ describe(convertEditorCodeActionsOnSave, () => {
     });
 
     test("conversion of 'source.fixAll.tslint' without touching any other 'editor.codeActionsOnSave'", () => {
-        const result = convertEditorCodeActionsOnSave({
-            editorSettingName: "editor.codeActionsOnSave",
-            value: {
-                "one-property": 42,
-                "source.fixAll.tslint": true,
-                "another-property": "foo",
+        const result = convertEditorCodeActionsOnSave(
+            {
+                editorSettingName: "editor.codeActionsOnSave",
+                value: {
+                    "one-property": 42,
+                    "source.fixAll.tslint": true,
+                    "another-property": "foo",
+                },
             },
-        });
+            createStubTSLintToESLintSettings(),
+        );
 
         expect(result).toEqual({
             settings: [

--- a/src/editorSettings/converters/tests/tslint-config-file.test.ts
+++ b/src/editorSettings/converters/tests/tslint-config-file.test.ts
@@ -1,0 +1,34 @@
+import { convertTSLintConfigFile } from "../tslint-config-file";
+
+describe(convertTSLintConfigFile, () => {
+    test("conversion of 'tslint.configFile' when it roughly equals the ESLint file", () => {
+        const result = convertTSLintConfigFile(
+            {
+                editorSettingName: "tslint.configFile",
+                value: "./custom/tslint.json",
+            },
+            { config: "./custom/eslintrc.js" },
+        );
+
+        expect(result).toEqual({
+            settings: [
+                {
+                    editorSettingName: "eslint.options",
+                    value: { configFile: "./custom/eslintrc.js" },
+                },
+            ],
+        });
+    });
+
+    test("conversion of 'tslint.configFile' when it does not roughly equal the ESLint file", () => {
+        const result = convertTSLintConfigFile(
+            {
+                editorSettingName: "tslint.configFile",
+                value: "./custom/tslint.json",
+            },
+            { config: "./eslintrc.js" },
+        );
+
+        expect(result).toEqual(undefined);
+    });
+});

--- a/src/editorSettings/converters/tslint-config-file.ts
+++ b/src/editorSettings/converters/tslint-config-file.ts
@@ -1,0 +1,24 @@
+import * as path from "path";
+
+import { EditorSettingConverter } from "../converter";
+
+export const convertTSLintConfigFile: EditorSettingConverter = (
+    originalTSLintConfigFile,
+    settings,
+) => {
+    // If the output ESLint config path doesn't roughly match the original TSLint path, skip this.
+    const tslintPath = originalTSLintConfigFile.value;
+    const eslintPath = settings.config;
+    if (path.relative(path.dirname(tslintPath), path.dirname(eslintPath))) {
+        return undefined;
+    }
+
+    return {
+        settings: [
+            {
+                editorSettingName: "eslint.options",
+                value: { configFile: settings.config },
+            },
+        ],
+    };
+};

--- a/src/editorSettings/editorSettingsConverters.ts
+++ b/src/editorSettings/editorSettingsConverters.ts
@@ -1,8 +1,10 @@
 import { convertEditorCodeActionsOnSave } from "./converters/editor-code-actions-on-save";
+import { convertTSLintConfigFile } from "./converters/tslint-config-file";
 
 /**
  * Keys TSLint property names in editor settings to their ESLint editor settings converters.
  */
 export const editorSettingsConverters = new Map([
     ["editor.codeActionsOnSave", convertEditorCodeActionsOnSave],
+    ["tslint.configFile", convertTSLintConfigFile],
 ]);

--- a/src/settings.stubs.ts
+++ b/src/settings.stubs.ts
@@ -1,0 +1,3 @@
+export const createStubTSLintToESLintSettings = () => ({
+    config: "./eslintrc.js",
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #651
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

The VS Code TSLint extension allow for a custom configuration path other than `tslint.json` via `tslint.configFile`. Now, if that exists in the original editor settings _and_ matches the directory name of the output ESLint file path, the new ESLint editor settings will include the output ESLint file path.

This logic necessitated adding `settings: TSLintToESLintSettings` as an argument to `EditorSettingConverter`s.  Otherwise the file diff is actually not that big 😉. 
