### PR TITLE
Add jsx-no-bind rule

### DIFF
--- a/src/rules/converters/eslint-plugin-react/jsx-no-bind.ts
+++ b/src/rules/converters/eslint-plugin-react/jsx-no-bind.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertJsxNoBind: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "react/jsx-no-bind",
+            },
+        ],
+        plugins: ["eslint-plugin-react"],
+    };
+};

--- a/src/rules/converters/eslint-plugin-react/jsx-no-bind.ts
+++ b/src/rules/converters/eslint-plugin-react/jsx-no-bind.ts
@@ -5,6 +5,7 @@ export const convertJsxNoBind: RuleConverter = () => {
         rules: [
             {
                 ruleName: "react/jsx-no-bind",
+                notices: ["ESLint rule 'jsx-no-bind' also checks for arrow functions"],
             },
         ],
         plugins: ["eslint-plugin-react"],

--- a/src/rules/converters/eslint-plugin-react/tests/jsx-no-bind.test.ts
+++ b/src/rules/converters/eslint-plugin-react/tests/jsx-no-bind.test.ts
@@ -1,0 +1,18 @@
+import { convertJsxNoBind } from "../jsx-no-bind";
+
+describe(convertJsxNoBind, () => {
+    test("conversion without arguments", () => {
+        const result = convertJsxNoBind({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "react/jsx-no-bind",
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+});

--- a/src/rules/converters/eslint-plugin-react/tests/jsx-no-bind.test.ts
+++ b/src/rules/converters/eslint-plugin-react/tests/jsx-no-bind.test.ts
@@ -10,6 +10,7 @@ describe(convertJsxNoBind, () => {
             rules: [
                 {
                     ruleName: "react/jsx-no-bind",
+                    notices: ["ESLint rule 'jsx-no-bind' also checks for arrow functions"],
                 },
             ],
             plugins: ["eslint-plugin-react"],

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -177,6 +177,7 @@ import { convertJsxBooleanValue } from "./converters/eslint-plugin-react/jsx-boo
 import { convertJsxCurlySpacing } from "./converters/eslint-plugin-react/jsx-curly-spacing";
 import { convertJsxEqualsSpacing } from "./converters/eslint-plugin-react/jsx-equals-spacing";
 import { convertJsxKey } from "./converters/eslint-plugin-react/jsx-key";
+import { convertJsxNoBind } from "./converters/eslint-plugin-react/jsx-no-bind";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -218,6 +219,7 @@ export const rulesConverters = new Map([
     ["jsx-curly-spacing", convertJsxCurlySpacing],
     ["jsx-equals-spacing", convertJsxEqualsSpacing],
     ["jsx-key", convertJsxKey],
+    ["jsx-no-bind", convertJsxNoBind],
     ["label-position", convertLabelPosition],
     ["linebreak-style", convertLinebreakStyle],
     ["max-classes-per-file", convertMaxClassesPerFile],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #522 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
Currently the tslint-to-eslint-config doesn't support the rule "jsx-no-bind". This PR has a rule converter that addresses the issue

<!-- Brief description of what is changed and how the code change does that. -->
