### PR TITLE
Recognize tslint-react as an extended ruleset

### DIFF
--- a/src/creation/summarization/collectTSLintRulesets.test.ts
+++ b/src/creation/summarization/collectTSLintRulesets.test.ts
@@ -33,6 +33,19 @@ describe("collectTSLintRulesets", () => {
         ]);
     });
 
+    it("includes mapped ESLint extension for a raw TSLint-React extension when it exists", () => {
+        const tslint = {
+            full: {},
+            raw: {
+                extends: ["tslint-react"],
+            },
+        };
+
+        const extensions = collectTSLintRulesets(tslint);
+
+        expect(extensions).toEqual(["plugin:react/recommended"]);
+    });
+
     it("ignores a TSLint extension when it has no mapped ESLint extensions", () => {
         const tslint = {
             full: {

--- a/src/creation/summarization/collectTSLintRulesets.ts
+++ b/src/creation/summarization/collectTSLintRulesets.ts
@@ -11,6 +11,7 @@ const nativeExtensions = new Map([
             "plugin:@typescript-eslint/recommended-requiring-type-checking",
         ],
     ],
+    ["tslint-react", ["plugin:react/recommended"]],
 ]);
 
 export const collectTSLintRulesets = (

--- a/src/creation/summarization/retrieveExtendsValues.ts
+++ b/src/creation/summarization/retrieveExtendsValues.ts
@@ -36,6 +36,7 @@ const pluginExtensions = new Map([
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
         "node_modules/@typescript-eslint/eslint-plugin/dist/configs/recommended-requiring-type-checking.json",
     ],
+    ["plugin:react/recommended", "node_modules/eslint-plugin-react/index.js"],
 ]);
 
 /**


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #528
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
### Recognize tslint-react as a extended ruleset.

[Github Issue](https://github.com/typescript-eslint/tslint-to-eslint-config/issues/528)

If a rule extends from tslint-react , we will now add `react/recommended` to the configuration.

Recommendation from `eslint-plugin-react` are present [Here](https://github.com/yannickcr/eslint-plugin-react#recommended). I have left out `eslint:recommended` not sure if that would be required.

Have added unit tests and verified if the coverage remains at 100%.

<!-- Brief description of what is changed and how the code change does that. -->
