### PR TITLE
Adding the rule converter for jsx-wrap-multiline

### DIFF
--- a/src/rules/converters/eslint-plugin-react/jsx-wrap-multiline.ts
+++ b/src/rules/converters/eslint-plugin-react/jsx-wrap-multiline.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertJsxWrapMultiline: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "react/jsx-wrap-multilines",
+            },
+        ],
+        plugins: ["eslint-plugin-react"],
+    };
+};

--- a/src/rules/converters/eslint-plugin-react/tests/jsx-wrap-multiline.test.ts
+++ b/src/rules/converters/eslint-plugin-react/tests/jsx-wrap-multiline.test.ts
@@ -1,0 +1,18 @@
+import { convertJsxWrapMultiline } from "../jsx-wrap-multiline";
+
+describe(convertJsxWrapMultiline, () => {
+    test("conversion without arguments", () => {
+        const result = convertJsxWrapMultiline({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "react/jsx-wrap-multilines",
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -178,6 +178,7 @@ import { convertJsxCurlySpacing } from "./converters/eslint-plugin-react/jsx-cur
 import { convertJsxEqualsSpacing } from "./converters/eslint-plugin-react/jsx-equals-spacing";
 import { convertJsxKey } from "./converters/eslint-plugin-react/jsx-key";
 import { convertJsxNoBind } from "./converters/eslint-plugin-react/jsx-no-bind";
+import { convertJsxWrapMultiline } from "./converters/eslint-plugin-react/jsx-wrap-multiline";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -220,6 +221,7 @@ export const rulesConverters = new Map([
     ["jsx-equals-spacing", convertJsxEqualsSpacing],
     ["jsx-key", convertJsxKey],
     ["jsx-no-bind", convertJsxNoBind],
+    ["jsx-wrap-multiline", convertJsxWrapMultiline],
     ["label-position", convertLabelPosition],
     ["linebreak-style", convertLinebreakStyle],
     ["max-classes-per-file", convertMaxClassesPerFile],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #527
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
1. Adding a rule converter for tslint rule jsx-wrap-multiline, Equivalent eslint rule is react/jsx-wrap-multilines (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)
react/jsx-wrap-multilines- "_This rule optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, all the syntax listed below will be checked except the conditions out of declaration or assignment, logical expressions and JSX attributes, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior displayed below._" 
Since tslint rule jsx-wrap-multiline does not provide any options, I have not provided the second optional argument to the eslint rule react/jsx-wrap-multiline, so it is the default.
2. Added the required tests.
