### PR TITLE
fix: Convert options for no-inferrable-types

### DIFF
--- a/src/rules/converters/no-inferrable-types.ts
+++ b/src/rules/converters/no-inferrable-types.ts
@@ -1,10 +1,25 @@
 import { RuleConverter } from "../converter";
 
-export const convertNoInferrableTypes: RuleConverter = () => {
+export const convertNoInferrableTypes: RuleConverter = (tslintRule) => {
     return {
         rules: [
             {
                 ruleName: "@typescript-eslint/no-inferrable-types",
+                ruleArguments: tslintRule.ruleArguments.length
+                    ? tslintRule.ruleArguments.reduce(
+                          (acc: any, arg: string) => {
+                              switch (arg) {
+                                  case "ignore-params":
+                                      acc[0].ignoreParameters = true;
+                                      return acc;
+                                  case "ignore-properties":
+                                      acc[0].ignoreProperties = true;
+                                      return acc;
+                              }
+                          },
+                          [{}],
+                      )
+                    : undefined,
             },
         ],
     };

--- a/src/rules/converters/tests/no-inferrable-types.test.ts
+++ b/src/rules/converters/tests/no-inferrable-types.test.ts
@@ -14,4 +14,34 @@ describe(convertNoInferrableTypes, () => {
             ],
         });
     });
+
+    test("conversion with an argument", () => {
+        const result = convertNoInferrableTypes({
+            ruleArguments: ["ignore-params"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/no-inferrable-types",
+                    ruleArguments: [{ ignoreParameters: true }],
+                },
+            ],
+        });
+    });
+
+    test("conversion with arguments", () => {
+        const result = convertNoInferrableTypes({
+            ruleArguments: ["ignore-params", "ignore-properties"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/no-inferrable-types",
+                    ruleArguments: [{ ignoreParameters: true, ignoreProperties: true }],
+                },
+            ],
+        });
+    });
 });


### PR DESCRIPTION
## PR Checklist

-   [X] Addresses an existing issue: fixes #668
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
Inserted codes to convert rule arguments.

References:
https://palantir.github.io/tslint/rules/no-inferrable-types/
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-inferrable-types.md