### PR TITLE
Used commander's .opts() to parse raw argv

### DIFF
--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -35,7 +35,7 @@ export const runCli = async (
 
     const parsedArgv = {
         config: "./.eslintrc.js",
-        ...(command.parse(rawArgv) as Partial<TSLintToESLintSettings>),
+        ...command.parse(rawArgv).opts(),
     };
 
     const programOptions = command.opts();


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #660
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

As of either the latest Node version or latest commander version (I haven't checked but suspect commander), member variables such as `.prettier` aren't being set on the `command` object. They're now available on `.opts()`.