### PR TITLE
Added missing output plugins to configuration file

### DIFF
--- a/src/creation/writeConversionResults.test.ts
+++ b/src/creation/writeConversionResults.test.ts
@@ -60,6 +60,7 @@ describe("writeConversionResults", () => {
                     ruleSeverity: "error",
                 },
             ],
+            plugins: new Set(["eslint-plugin-example"]),
         });
         const fileSystem = { writeFile: jest.fn().mockReturnValue(Promise.resolve()) };
 
@@ -85,7 +86,11 @@ describe("writeConversionResults", () => {
                     project: "tsconfig.json",
                     sourceType: "module",
                 },
-                plugins: ["@typescript-eslint", "@typescript-eslint/tslint"],
+                plugins: [
+                    "eslint-plugin-example",
+                    "@typescript-eslint",
+                    "@typescript-eslint/tslint",
+                ],
                 rules: {
                     "@typescript-eslint/tslint/config": [
                         "error",

--- a/src/creation/writeConversionResults.ts
+++ b/src/creation/writeConversionResults.ts
@@ -16,11 +16,11 @@ export const writeConversionResults = async (
     summarizedResults: SummarizedResultsConfiguration,
     originalConfigurations: AllOriginalConfigurations,
 ) => {
-    const plugins = ["@typescript-eslint"];
+    const plugins = new Set([...summarizedResults.plugins, "@typescript-eslint"]);
     const { eslint, tslint } = originalConfigurations;
 
     if (summarizedResults.missing.length !== 0) {
-        plugins.push("@typescript-eslint/tslint");
+        plugins.add("@typescript-eslint/tslint");
     }
 
     const output = removeEmptyMembers({
@@ -33,7 +33,7 @@ export const writeConversionResults = async (
             project: "tsconfig.json",
             sourceType: "module",
         },
-        plugins,
+        plugins: Array.from(plugins),
         rules: formatConvertedRules(summarizedResults, tslint.full),
     });
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #612
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

For some reason, `writeConversionResults` was ignoring the output plugins listed in the summarized results from converting rules. I can't think of why; we would want to include those plugins in the generated ESLint configuration file.