### PR TITLE
Further clarified config converters structure in code

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -4,12 +4,12 @@
 
 1.  CLI usage starts in `bin/tslint-to-eslint-config`, which immediately calls `src/cli/main.ts`.
 2.  CLI settings are parsed and read in `src/cli/runCli.ts`.
-3.  Linter configuration conversion is run by `src/conversion/convertConfig.ts`.
+3.  Linter configuration conversion is run by `src/conversion/convertLintConfig.ts`.
 4.  Editor configuration conversion is run by `src/conversion/convertEditorConfig.ts`.
 
 ## Linter Configuration Conversion
 
-Within `src/conversion/convertConfig.ts`, the following steps occur:
+Within `src/conversion/convertLintConfig.ts`, the following steps occur:
 
 1. Existing configurations are read from disk
 2. TSLint rules are converted into their ESLint configurations

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -11,7 +11,7 @@ import {
     ConvertFileCommentsDependencies,
     convertFileComments,
 } from "../comments/convertFileComments";
-import { convertConfig, ConvertConfigDependencies } from "../conversion/convertConfig";
+import { convertLintConfig, ConvertLintConfigDependencies } from "../conversion/convertLintConfig";
 import {
     convertEditorConfig,
     ConvertEditorConfigDependencies,
@@ -165,7 +165,7 @@ const convertEditorConfigDependencies: ConvertEditorConfigDependencies = {
     ),
 };
 
-const convertConfigDependencies: ConvertConfigDependencies = {
+const convertLintConfigDependencies: ConvertLintConfigDependencies = {
     convertComments: bind(convertComments, convertCommentsDependencies),
     convertRules: bind(convertRules, convertRulesDependencies),
     findOriginalConfigurations: bind(
@@ -180,8 +180,8 @@ const convertConfigDependencies: ConvertConfigDependencies = {
 };
 
 const runCliDependencies: RunCliDependencies = {
-    convertConfigs: [
-        bind(convertConfig, convertConfigDependencies),
+    configConverters: [
+        bind(convertLintConfig, convertLintConfigDependencies),
         bind(convertEditorConfig, convertEditorConfigDependencies),
     ],
     logger: processLogger,

--- a/src/cli/runCli.test.ts
+++ b/src/cli/runCli.test.ts
@@ -8,9 +8,9 @@ import { runCli, RunCliDependencies } from "./runCli";
 const createStubArgv = (argv: string[] = []) => ["node", "some/path/bin/file", ...argv];
 
 const createStubRunCliDependencies = (
-    overrides: Partial<Pick<RunCliDependencies, "convertConfigs">> = {},
+    overrides: Partial<Pick<RunCliDependencies, "configConverters">> = {},
 ) => ({
-    convertConfigs: [
+    configConverters: [
         async (): Promise<TSLintToESLintResult> => ({ status: ResultStatus.Succeeded }),
     ],
     logger: createStubLogger(),
@@ -34,7 +34,7 @@ describe("runCli", () => {
         // Arrange
         const message = "Oh no";
         const dependencies = createStubRunCliDependencies({
-            convertConfigs: [() => Promise.reject(new Error(message))],
+            configConverters: [() => Promise.reject(new Error(message))],
         });
 
         // Act
@@ -51,7 +51,7 @@ describe("runCli", () => {
         // Arrange
         const complaint = "too much unit testing coverage";
         const dependencies = createStubRunCliDependencies({
-            convertConfigs: [
+            configConverters: [
                 () =>
                     Promise.resolve({
                         complaints: [complaint],
@@ -76,7 +76,7 @@ describe("runCli", () => {
         // Arrange
         const error = new Error("too much unit testing coverage");
         const dependencies = createStubRunCliDependencies({
-            convertConfigs: [
+            configConverters: [
                 () =>
                     Promise.resolve({
                         errors: [error],
@@ -104,7 +104,7 @@ describe("runCli", () => {
             new Error("too much branch coverage"),
         ];
         const dependencies = createStubRunCliDependencies({
-            convertConfigs: [
+            configConverters: [
                 () =>
                     Promise.resolve({
                         errors,
@@ -141,7 +141,7 @@ describe("runCli", () => {
     it("default output should be .eslintrc.js", async () => {
         let defaultConfig;
         const dependencies = createStubRunCliDependencies({
-            convertConfigs: [
+            configConverters: [
                 (parsedArgs) => {
                     defaultConfig = parsedArgs.config;
                     return Promise.resolve({

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -4,12 +4,11 @@ import { EOL } from "os";
 
 import { version } from "../../package.json";
 import { Logger } from "../adapters/logger";
-import { SansDependencies } from "../binding";
-import { convertConfig } from "../conversion/convertConfig";
+import { ConfigConverter } from "../conversion/configConverter";
 import { ResultStatus, ResultWithStatus, TSLintToESLintSettings } from "../types";
 
 export type RunCliDependencies = {
-    convertConfigs: SansDependencies<typeof convertConfig>[];
+    configConverters: ConfigConverter[];
     logger: Logger;
 };
 
@@ -44,7 +43,7 @@ export const runCli = async (
         return ResultStatus.Succeeded;
     }
 
-    for (const configConverter of dependencies.convertConfigs) {
+    for (const configConverter of dependencies.configConverters) {
         const result = await tryConvertConfig(configConverter, parsedArgv);
         if (result.status !== ResultStatus.Succeeded) {
             logErrorResult(result, dependencies);
@@ -57,7 +56,7 @@ export const runCli = async (
 };
 
 const tryConvertConfig = async (
-    configConverter: SansDependencies<typeof convertConfig>,
+    configConverter: ConfigConverter,
     argv: Partial<TSLintToESLintSettings>,
 ): Promise<ResultWithStatus> => {
     let result: ResultWithStatus;

--- a/src/conversion/configConverter.ts
+++ b/src/conversion/configConverter.ts
@@ -1,4 +1,5 @@
 import { ResultWithStatus, TSLintToESLintSettings } from "../types";
+
 /**
  * Standalone (sans dependencies) type for a converter to run in the CLI.
  */

--- a/src/conversion/configConverter.ts
+++ b/src/conversion/configConverter.ts
@@ -1,0 +1,5 @@
+import { ResultWithStatus, TSLintToESLintSettings } from "../types";
+/**
+ * Standalone (sans dependencies) type for a converter to run in the CLI.
+ */
+export type ConfigConverter = (settings: TSLintToESLintSettings) => Promise<ResultWithStatus>;

--- a/src/conversion/convertLintConfig.test.ts
+++ b/src/conversion/convertLintConfig.test.ts
@@ -1,13 +1,13 @@
 import { ResultStatus, FailedResult } from "../types";
-import { convertConfig, ConvertConfigDependencies } from "./convertConfig";
+import { convertLintConfig, ConvertLintConfigDependencies } from "./convertLintConfig";
 
 const stubSettings = {
     config: "./eslintrc.js",
 };
 
 const createStubDependencies = (
-    overrides: Partial<ConvertConfigDependencies> = {},
-): ConvertConfigDependencies => ({
+    overrides: Partial<ConvertLintConfigDependencies> = {},
+): ConvertLintConfigDependencies => ({
     convertComments: jest.fn(),
     convertRules: jest.fn(),
     findOriginalConfigurations: jest.fn().mockResolvedValue({
@@ -40,7 +40,7 @@ const createStubOriginalConfigurationsData = () => ({
     },
 });
 
-describe("convertConfig", () => {
+describe("convertLintConfig", () => {
     it("returns the failure result when finding the original configurations fails", async () => {
         // Arrange
         const findError: FailedResult = {
@@ -52,7 +52,7 @@ describe("convertConfig", () => {
         });
 
         // Act
-        const result = await convertConfig(dependencies, stubSettings);
+        const result = await convertLintConfig(dependencies, stubSettings);
 
         // Assert
         expect(result).toEqual(findError);
@@ -66,7 +66,7 @@ describe("convertConfig", () => {
         });
 
         // Act
-        const result = await convertConfig(dependencies, stubSettings);
+        const result = await convertLintConfig(dependencies, stubSettings);
 
         // Assert
         expect(result).toEqual({
@@ -86,7 +86,7 @@ describe("convertConfig", () => {
         });
 
         // Act
-        const result = await convertConfig(dependencies, stubSettings);
+        const result = await convertLintConfig(dependencies, stubSettings);
 
         // Assert
         expect(result).toEqual(convertCommentsResult);
@@ -102,7 +102,7 @@ describe("convertConfig", () => {
         });
 
         // Act
-        const result = await convertConfig(dependencies, stubSettings);
+        const result = await convertLintConfig(dependencies, stubSettings);
 
         // Assert
         expect(result).toEqual(convertCommentsResult);

--- a/src/conversion/convertLintConfig.ts
+++ b/src/conversion/convertLintConfig.ts
@@ -9,7 +9,7 @@ import { reportCommentResults } from "../reporting/reportCommentResults";
 import { convertRules } from "../rules/convertRules";
 import { ResultStatus, ResultWithStatus, TSLintToESLintSettings } from "../types";
 
-export type ConvertConfigDependencies = {
+export type ConvertLintConfigDependencies = {
     convertComments: SansDependencies<typeof convertComments>;
     convertRules: SansDependencies<typeof convertRules>;
     findOriginalConfigurations: SansDependencies<typeof findOriginalConfigurations>;
@@ -24,8 +24,8 @@ export type ConvertConfigDependencies = {
  * Root-level driver to convert a TSLint configuration to ESLint.
  * @see `Architecture.md` for documentation.
  */
-export const convertConfig = async (
-    dependencies: ConvertConfigDependencies,
+export const convertLintConfig = async (
+    dependencies: ConvertLintConfigDependencies,
     settings: TSLintToESLintSettings,
 ): Promise<ResultWithStatus> => {
     // 1. Existing configurations are read


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: starts on #274
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Before we jump into the really meaty parts of the proposed refactor, there are a couple of small improvements that would help improve ease of code comprehension on their own:

* Standalone `ConfigConverter` type to use when referring to the array of functions passed to `runCli` that each do some kind of conversion
* Rename `convertConfig` to the more precise `convertLintConfig`, as it's used alongside `convertEditorConfig`

FYI @MrCube42 if you're interested 😊 