### PR TITLE
Allowed passing a tsconfig.json to --comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We **strongly** advise reading [docs/FAQs.md](./docs/FAQs.md) before planning yo
 
 Each of these flags is optional:
 
--   **[`comments`](#comments)**: File glob path(s) to convert TSLint rule flags to ESLint within.
+-   **[`comments`](#comments)**: TypeScript configuration or file glob path(s) to convert TSLint rule flags to ESLint within.
 -   **[`config`](#config)**: Path to print the generated ESLint configuration file to.
 -   **[`editor`](#editor)**: Path to an editor configuration file to convert linter settings within.
 -   **[`eslint`](#eslint)**: Path to an ESLint configuration file to read settings from.
@@ -64,7 +64,13 @@ Comments such as `// tslint:disable: tslint-rule-name` will be converted to equi
 
 If passed without arguments, respects the `excludes`, `files`, and `includes` in your TypeScript configuration.
 
-Alternately, you can specify which files to convert comments in as globs:
+If passed a single file path ending with `.json`, that is treated as a TypeScript configuration file describing with files to convert.
+
+```shell
+npx tslint-to-eslint-config --comments tsconfig.json
+```
+
+If passed any other arguments, those are treated as glob paths for file paths to convert:
 
 ```shell
 npx tslint-to-eslint-config --comments 'src/**/*.ts'

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,10 @@ import { globAsync } from "../adapters/globAsync";
 import { nativeImporter } from "../adapters/nativeImporter";
 import { processLogger } from "../adapters/processLogger";
 import { bind } from "../binding";
+import {
+    collectCommentFileNames,
+    CollectCommentFileNamesDependencies,
+} from "../comments/collectCommentFileNames";
 import { convertComments, ConvertCommentsDependencies } from "../comments/convertComments";
 import {
     ConvertFileCommentsDependencies,
@@ -72,16 +76,6 @@ import { mergers } from "../rules/mergers";
 import { rulesConverters } from "../rules/rulesConverters";
 import { runCli, RunCliDependencies } from "./runCli";
 
-const convertFileCommentsDependencies: ConvertFileCommentsDependencies = {
-    converters: rulesConverters,
-    fileSystem: fsFileSystem,
-};
-
-const convertCommentsDependencies: ConvertCommentsDependencies = {
-    convertFileComments: bind(convertFileComments, convertFileCommentsDependencies),
-    globAsync,
-};
-
 const convertRulesDependencies: ConvertRulesDependencies = {
     converters: rulesConverters,
     mergers,
@@ -115,6 +109,21 @@ const findOriginalConfigurationsDependencies: FindOriginalConfigurationsDependen
     findTypeScriptConfiguration: bind(findTypeScriptConfiguration, findConfigurationDependencies),
     findTSLintConfiguration: bind(findTSLintConfiguration, findConfigurationDependencies),
     mergeLintConfigurations,
+};
+
+const convertFileCommentsDependencies: ConvertFileCommentsDependencies = {
+    converters: rulesConverters,
+    fileSystem: fsFileSystem,
+};
+
+const collectCommentFileNamesDependencies: CollectCommentFileNamesDependencies = {
+    findTypeScriptConfiguration: bind(findTypeScriptConfiguration, findConfigurationDependencies),
+};
+
+const convertCommentsDependencies: ConvertCommentsDependencies = {
+    convertFileComments: bind(convertFileComments, convertFileCommentsDependencies),
+    collectCommentFileNames: bind(collectCommentFileNames, collectCommentFileNamesDependencies),
+    globAsync,
 };
 
 const reportCommentResultsDependencies: ReportCommentResultsDependencies = {

--- a/src/comments/collectCommentFileNames.test.ts
+++ b/src/comments/collectCommentFileNames.test.ts
@@ -1,0 +1,81 @@
+import { collectCommentFileNames } from "./collectCommentFileNames";
+
+describe("collectCommentFileNames", () => {
+    it("returns an error result when filePathGlobs is true and typescriptConfiguration is undefined", async () => {
+        const findTypeScriptConfiguration = jest.fn();
+
+        const result = await collectCommentFileNames({ findTypeScriptConfiguration }, true);
+
+        expect(result).toEqual(expect.any(Error));
+    });
+
+    it("returns the typescript configuration when filePathGlobs is true and typescriptConfiguration exists", async () => {
+        const findTypeScriptConfiguration = jest.fn();
+        const typescriptConfiguration = {
+            include: ["a.ts"],
+        };
+
+        const result = await collectCommentFileNames(
+            { findTypeScriptConfiguration },
+            true,
+            typescriptConfiguration,
+        );
+
+        expect(result).toEqual(typescriptConfiguration);
+    });
+
+    it("returns the input file paths when filePathGlobs is an array", async () => {
+        const findTypeScriptConfiguration = jest.fn();
+        const filePathGlobs = ["a.ts"];
+
+        const result = await collectCommentFileNames(
+            { findTypeScriptConfiguration },
+            filePathGlobs,
+        );
+
+        expect(result).toEqual({
+            include: filePathGlobs,
+        });
+    });
+
+    it("returns the input file path when filePathGlobs is a source file path string", async () => {
+        const findTypeScriptConfiguration = jest.fn();
+        const filePathGlobs = "a.ts";
+
+        const result = await collectCommentFileNames(
+            { findTypeScriptConfiguration },
+            filePathGlobs,
+        );
+
+        expect(result).toEqual({
+            include: [filePathGlobs],
+        });
+    });
+
+    it("returns the failure when filePathGlobs is a config file path string and reading it fails", async () => {
+        const error = new Error("Failure!");
+        const findTypeScriptConfiguration = jest.fn().mockResolvedValue(error);
+
+        const result = await collectCommentFileNames(
+            { findTypeScriptConfiguration },
+            "tsconfig.json",
+        );
+
+        expect(result).toEqual(error);
+    });
+
+    it("returns the typescript configuration from disk when filePathGlobs is a config path string and reading it succeeds", async () => {
+        const findTypeScriptConfiguration = jest.fn().mockResolvedValue({
+            include: ["a.ts"],
+        });
+
+        const result = await collectCommentFileNames(
+            { findTypeScriptConfiguration },
+            "tsconfig.json",
+        );
+
+        expect(result).toEqual({
+            include: ["a.ts"],
+        });
+    });
+});

--- a/src/comments/collectCommentFileNames.ts
+++ b/src/comments/collectCommentFileNames.ts
@@ -1,0 +1,50 @@
+import { SansDependencies } from "../binding";
+import {
+    findTypeScriptConfiguration,
+    TypeScriptConfiguration,
+} from "../input/findTypeScriptConfiguration";
+import { uniqueFromSources } from "../utils";
+
+export type CollectCommentFileNamesDependencies = {
+    findTypeScriptConfiguration: SansDependencies<typeof findTypeScriptConfiguration>;
+};
+
+export type CommentFileNames = {
+    exclude?: string[];
+    include: string[];
+};
+
+export const collectCommentFileNames = async (
+    dependencies: CollectCommentFileNamesDependencies,
+    filePathGlobs: true | string | string[],
+    typescriptConfiguration?: TypeScriptConfiguration,
+): Promise<CommentFileNames | Error> => {
+    if (filePathGlobs === true) {
+        if (!typescriptConfiguration) {
+            return new Error(
+                "--comments indicated to convert files listed in a tsconfig.json, but one was not found on disk or specified by with --typescript.",
+            );
+        }
+
+        return {
+            exclude: typescriptConfiguration.exclude,
+            include: uniqueFromSources(
+                typescriptConfiguration.files,
+                typescriptConfiguration.include,
+            ),
+        };
+    }
+
+    if (typeof filePathGlobs === "string" && filePathGlobs.endsWith(".json")) {
+        const findResult = await dependencies.findTypeScriptConfiguration(filePathGlobs);
+        if (findResult instanceof Error) {
+            return findResult;
+        }
+
+        return await collectCommentFileNames(dependencies, true, findResult);
+    }
+
+    return {
+        include: uniqueFromSources(filePathGlobs),
+    };
+};

--- a/src/comments/convertComments.ts
+++ b/src/comments/convertComments.ts
@@ -5,11 +5,13 @@ import { SansDependencies } from "../binding";
 import { TypeScriptConfiguration } from "../input/findTypeScriptConfiguration";
 import { ResultStatus, ResultWithDataStatus } from "../types";
 import { separateErrors, uniqueFromSources, isError } from "../utils";
+import { collectCommentFileNames } from "./collectCommentFileNames";
 import { convertFileComments } from "./convertFileComments";
 
 export type ConvertCommentsDependencies = {
     convertFileComments: SansDependencies<typeof convertFileComments>;
     globAsync: GlobAsync;
+    collectCommentFileNames: SansDependencies<typeof collectCommentFileNames>;
 };
 
 export const convertComments = async (
@@ -17,35 +19,38 @@ export const convertComments = async (
     filePathGlobs: true | string | string[] | undefined,
     typescriptConfiguration?: TypeScriptConfiguration,
 ): Promise<ResultWithDataStatus<string[] | undefined>> => {
-    let fromTypeScriptConfiguration: TypeScriptConfiguration | undefined;
-
-    if (filePathGlobs === true) {
-        if (!typescriptConfiguration) {
-            return {
-                errors: [
-                    new Error(
-                        "--comments indicated to convert files listed in a tsconfig.json, but one was not found on disk or specified by with --typescript.",
-                    ),
-                ],
-                status: ResultStatus.Failed,
-            };
-        }
-
-        filePathGlobs = [
-            ...(typescriptConfiguration.files ?? []),
-            ...(typescriptConfiguration.include ?? []),
-        ];
-        fromTypeScriptConfiguration = typescriptConfiguration;
-    }
-
     if (filePathGlobs === undefined) {
         return {
             data: undefined,
             status: ResultStatus.Succeeded,
         };
     }
-    const uniqueFilePathGlobs = uniqueFromSources(filePathGlobs);
-    if (uniqueFilePathGlobs.join("") === "") {
+
+    const commentFileNames = await dependencies.collectCommentFileNames(
+        filePathGlobs,
+        typescriptConfiguration,
+    );
+
+    if (commentFileNames instanceof Error) {
+        return {
+            errors: [commentFileNames],
+            status: ResultStatus.Failed,
+        };
+    }
+
+    const { exclude, include } = commentFileNames;
+    const [fileGlobErrors, globbedFilePaths] = separateErrors(
+        await Promise.all(include.map(dependencies.globAsync)),
+    );
+
+    if (fileGlobErrors.length !== 0) {
+        return {
+            errors: fileGlobErrors,
+            status: ResultStatus.Failed,
+        };
+    }
+
+    if (globbedFilePaths.join("") === "") {
         return {
             errors: [
                 new Error(
@@ -56,24 +61,22 @@ export const convertComments = async (
         };
     }
 
-    const [fileGlobErrors, globbedFilePaths] = separateErrors(
-        await Promise.all(uniqueFilePathGlobs.map(dependencies.globAsync)),
+    const uniqueGlobbedFilePaths = uniqueFromSources(...globbedFilePaths).filter(
+        (filePathGlob) => !exclude?.some((exclusion) => minimatch(filePathGlob, exclusion)),
     );
-    if (fileGlobErrors.length !== 0) {
+
+    if (uniqueGlobbedFilePaths.join("") === "") {
         return {
-            errors: fileGlobErrors,
+            errors: [
+                new Error(
+                    `All files passed to --comments were excluded. Consider removing 'exclude' from your TypeScript configuration.`,
+                ),
+            ],
             status: ResultStatus.Failed,
         };
     }
 
     const ruleConversionCache = new Map<string, string | undefined>();
-    const uniqueGlobbedFilePaths = uniqueFromSources(...globbedFilePaths).filter(
-        (filePathGlob) =>
-            !fromTypeScriptConfiguration?.exclude?.some((exclude) =>
-                minimatch(filePathGlob, exclude),
-            ),
-    );
-
     const fileFailures = (
         await Promise.all(
             uniqueGlobbedFilePaths.map(async (filePath) =>


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #709
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

As described by the issue, allows a string that ends with `.json` to be counted as a new TypeScript configuration to read from disk. In theory we could reuse the existing configuration if it's the same as `--typescript`, but that seems like both a rare case and not a significant performance penalty.

Extracts the logic to take `--comments` globs & existing TS config into a new injected function. This wasn't strictly necessary but they were getting pretty chunky.