### PR TITLE
Fix invalid indent rule when using tabs

### DIFF
--- a/src/rules/converters/indent.ts
+++ b/src/rules/converters/indent.ts
@@ -4,7 +4,7 @@ export const convertIndent: RuleConverter = (tslintRule) => {
     let indentSize: number | string = 4; // @typescript-eslint/indent default
 
     if (tslintRule.ruleArguments[0] === "tabs") {
-        indentSize = "tabs";
+        indentSize = "tab";
     } else if (tslintRule.ruleArguments[1] === 2) {
         indentSize = 2;
     }

--- a/src/rules/converters/tests/indent.test.ts
+++ b/src/rules/converters/tests/indent.test.ts
@@ -53,7 +53,7 @@ describe(convertIndent, () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/indent",
-                    ruleArguments: ["tabs"],
+                    ruleArguments: ["tab"],
                 },
             ],
         });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #711
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Fixes the ESLint converter when using the `"tabs"` option in the `indent` rule as [stated here](https://github.com/typescript-eslint/tslint-to-eslint-config/issues/711#issuecomment-694315355)
