### PR TITLE
Changed async addPrettierExtensions to synchronous checkPrettierExtension

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -68,7 +68,7 @@ import {
 import { runCli, RunCliDependencies } from "./runCli";
 import { ruleMergers } from "../converters/lintConfigs/rules/ruleMergers";
 import { writeEditorConfigConversionResults } from "../converters/lintConfigs/writeEditorConfigConversionResults";
-import { addPrettierExtensions } from "../converters/lintConfigs/summarization/prettier/addPrettierExtensions";
+import { checkPrettierExtension } from "../converters/lintConfigs/summarization/prettier/checkPrettierExtension";
 import { removeExtendsDuplicatedRules } from "../converters/lintConfigs/pruning/removeExtendsDuplicatedRules";
 import {
     ExtractGlobPathsDependencies,
@@ -166,7 +166,7 @@ const retrieveExtendsValuesDependencies: RetrieveExtendsValuesDependencies = {
 };
 
 const summarizePackageRulesDependencies: SummarizePackageRulesDependencies = {
-    addPrettierExtensions,
+    checkPrettierExtension,
     removeExtendsDuplicatedRules,
     retrieveExtendsValues: bind(retrieveExtendsValues, retrieveExtendsValuesDependencies),
 };

--- a/src/converters/lintConfigs/summarization/prettier/checkPrettierExtension.test.ts
+++ b/src/converters/lintConfigs/summarization/prettier/checkPrettierExtension.test.ts
@@ -1,57 +1,57 @@
 import { createEmptyConfigConversionResults } from "../../configConversionResults.stubs";
-import { addPrettierExtensions } from "./addPrettierExtensions";
+import { checkPrettierExtension } from "./checkPrettierExtension";
 
 const createStubRuleConversions = (ruleName: string, ruleSeverity: "error" | "off") =>
     new Map([[ruleName, { ruleName, ruleSeverity }]]);
 
-describe("addPrettierExtensions", () => {
-    it("returns false when a matching converted rule is enabled", async () => {
+describe("checkPrettierExtension", () => {
+    it("returns false when a matching converted rule is enabled", () => {
         // Arrange
         const ruleConversionResults = createEmptyConfigConversionResults({
             converted: createStubRuleConversions("max-len", "error"),
         });
 
         // Act
-        const result = await addPrettierExtensions(ruleConversionResults);
+        const result = checkPrettierExtension(ruleConversionResults);
 
         // Assert
         expect(result).toEqual(false);
     });
 
-    it("returns true when a matching converted rule is disabled", async () => {
+    it("returns true when a matching converted rule is disabled", () => {
         // Arrange
         const ruleConversionResults = createEmptyConfigConversionResults({
             converted: createStubRuleConversions("max-len", "off"),
         });
 
         // Act
-        const result = await addPrettierExtensions(ruleConversionResults);
+        const result = checkPrettierExtension(ruleConversionResults);
 
         // Assert
         expect(result).toEqual(true);
     });
 
-    it("returns true when there are no matching converted rules", async () => {
+    it("returns true when there are no matching converted rules", () => {
         // Arrange
         const ruleConversionResults = createEmptyConfigConversionResults({
             converted: createStubRuleConversions("unknown", "error"),
         });
 
         // Act
-        const result = await addPrettierExtensions(ruleConversionResults);
+        const result = checkPrettierExtension(ruleConversionResults);
 
         // Assert
         expect(result).toEqual(true);
     });
 
-    it("returns true when prettier is requested", async () => {
+    it("returns true when prettier is requested", () => {
         // Arrange
         const ruleConversionResults = createEmptyConfigConversionResults({
             converted: createStubRuleConversions("max-len", "off"),
         });
 
         // Act
-        const result = await addPrettierExtensions(ruleConversionResults, true);
+        const result = checkPrettierExtension(ruleConversionResults, true);
 
         // Assert
         expect(result).toEqual(true);

--- a/src/converters/lintConfigs/summarization/prettier/checkPrettierExtension.ts
+++ b/src/converters/lintConfigs/summarization/prettier/checkPrettierExtension.ts
@@ -2,7 +2,7 @@ import prettierRuleSettings from "eslint-config-prettier";
 
 import { RuleConversionResults } from "../../rules/convertRules";
 
-export const addPrettierExtensions = async (
+export const checkPrettierExtension = (
     ruleConversionResults: Pick<RuleConversionResults, "converted">,
     prettierRequested?: boolean,
 ) => {

--- a/src/converters/lintConfigs/summarization/summarizePackageRules.test.ts
+++ b/src/converters/lintConfigs/summarization/summarizePackageRules.test.ts
@@ -4,7 +4,7 @@ import { ESLintRuleOptionsWithArguments } from "../rules/types";
 import { summarizePackageRules, SummarizePackageRulesDependencies } from "./summarizePackageRules";
 
 const createStubDependencies = (overrides: Partial<SummarizePackageRulesDependencies> = {}) => ({
-    addPrettierExtensions: jest.fn(),
+    checkPrettierExtension: jest.fn(),
     removeExtendsDuplicatedRules: () => ({
         differentRules: new Map(),
         extensionRules: new Map(),
@@ -49,10 +49,10 @@ describe("summarizePackageRules", () => {
         expect(summarizedResults).toEqual(ruleConversionResults);
     });
 
-    it("adds Prettier extensions when addPrettierExtensions returns true", async () => {
+    it("adds Prettier extensions when checkPrettierExtension returns true", async () => {
         // Arrange
         const dependencies = createStubDependencies({
-            addPrettierExtensions: async () => true,
+            checkPrettierExtension: () => true,
         });
         const eslint = undefined;
         const tslint = createStubTSLintConfiguration();

--- a/src/converters/lintConfigs/summarization/summarizePackageRules.ts
+++ b/src/converters/lintConfigs/summarization/summarizePackageRules.ts
@@ -8,12 +8,12 @@ import { normalizeExtensions } from "../pruning/normalizeExtensions";
 import { RuleConversionResults } from "../rules/convertRules";
 import { collectTSLintRulesets } from "./collectTSLintRulesets";
 import { normalizeESLintRules } from "./normalizeESLintRules";
-import { addPrettierExtensions } from "./prettier/addPrettierExtensions";
+import { checkPrettierExtension } from "./prettier/checkPrettierExtension";
 import { retrieveExtendsValues } from "./retrieveExtendsValues";
 import { SummarizedConfigResultsConfiguration } from "./types";
 
 export type SummarizePackageRulesDependencies = {
-    addPrettierExtensions: typeof addPrettierExtensions;
+    checkPrettierExtension: typeof checkPrettierExtension;
     removeExtendsDuplicatedRules: typeof removeExtendsDuplicatedRules;
     retrieveExtendsValues: SansDependencies<typeof retrieveExtendsValues>;
 };
@@ -34,7 +34,7 @@ export const summarizePackageRules = async (
     const allExtensions = uniqueFromSources(extendedESLintRulesets, extendedTSLintRulesets);
 
     // 3a. If no output rules conflict with `eslint-config-prettier`, it's added in
-    if (await dependencies.addPrettierExtensions(ruleConversionResults, prettierRequested)) {
+    if (dependencies.checkPrettierExtension(ruleConversionResults, prettierRequested)) {
         allExtensions.push("prettier", "prettier/@typescript-eslint");
     }
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #730
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Does exactly what the issue suggested.