### PR TITLE
rxjs-no-async-subscribe

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -180,6 +180,8 @@ import { convertJsxEqualsSpacing } from "./ruleConverters/eslint-plugin-react/js
 import { convertJsxKey } from "./ruleConverters/eslint-plugin-react/jsx-key";
 import { convertJsxNoBind } from "./ruleConverters/eslint-plugin-react/jsx-no-bind";
 import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/jsx-wrap-multiline";
+
+//eslint-plugin-rxjs converters
 import { convertNoAsyncSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-async-subscribe";
 
 /**

--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -367,7 +367,7 @@ export const ruleConverters = new Map([
     ["use-pipe-decorator", convertUsePipeDecorator],
     ["use-pipe-transform-interface", convertUsePipeTransformInterface],
     ["variable-name", convertVariableName],
-    ["rxjs/no-async-subscribe", convertNoAsyncSubscribe],
+    ["rxjs-no-async-subscribe", convertNoAsyncSubscribe],
 
     // These converters are all for rules that need more complex option conversions.
     // Some of them will likely need to have notices about changed lint behaviors...

--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -180,6 +180,7 @@ import { convertJsxEqualsSpacing } from "./ruleConverters/eslint-plugin-react/js
 import { convertJsxKey } from "./ruleConverters/eslint-plugin-react/jsx-key";
 import { convertJsxNoBind } from "./ruleConverters/eslint-plugin-react/jsx-no-bind";
 import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/jsx-wrap-multiline";
+import { convertNoAsyncSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-async-subscribe";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -364,6 +365,7 @@ export const ruleConverters = new Map([
     ["use-pipe-decorator", convertUsePipeDecorator],
     ["use-pipe-transform-interface", convertUsePipeTransformInterface],
     ["variable-name", convertVariableName],
+    ["rxjs/no-async-subscribe", convertNoAsyncSubscribe],
 
     // These converters are all for rules that need more complex option conversions.
     // Some of them will likely need to have notices about changed lint behaviors...

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-async-subscribe.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-async-subscribe.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoAsyncSubscribe: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "no-async-subscribe",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-async-subscribe.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-async-subscribe.test.ts
@@ -1,0 +1,18 @@
+import { convertNoAsyncSubscribe } from "../no-async-subscribe";
+
+describe(convertNoAsyncSubscribe, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoAsyncSubscribe({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "no-async-subscribe",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #774
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

first of many converters to convert rules from cartant/rxjs-tslint-rules to cartant/eslint-plugin-rxjs