### PR TITLE
rxjs-no-unsafe-subject-next

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -181,8 +181,9 @@ import { convertJsxKey } from "./ruleConverters/eslint-plugin-react/jsx-key";
 import { convertJsxNoBind } from "./ruleConverters/eslint-plugin-react/jsx-no-bind";
 import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/jsx-wrap-multiline";
 
-//eslint-plugin-rxjs converters
+// eslint-plugin-rxjs converters
 import { convertNoAsyncSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-async-subscribe";
+import { convertNoUnsafeSubjectNext } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-subject-next";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -368,6 +369,7 @@ export const ruleConverters = new Map([
     ["use-pipe-transform-interface", convertUsePipeTransformInterface],
     ["variable-name", convertVariableName],
     ["rxjs-no-async-subscribe", convertNoAsyncSubscribe],
+    ["rxjs-no-unsafe-subject-next", convertNoUnsafeSubjectNext],
 
     // These converters are all for rules that need more complex option conversions.
     // Some of them will likely need to have notices about changed lint behaviors...

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-subject-next.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-subject-next.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoUnsafeSubjectNext: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-unsafe-subject-next",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-subject-next.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-subject-next.test.ts
@@ -1,0 +1,18 @@
+import { convertNoUnsafeSubjectNext } from "../no-unsafe-subject-next";
+
+describe(convertNoUnsafeSubjectNext, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoUnsafeSubjectNext({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-unsafe-subject-next",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #789
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

rxjs-no-unsafe-subject-next => rxjs/no-unsafe-subject-next