### PR TITLE
Exported lint rule types for Node APIs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     plugins: ["@typescript-eslint"],
     rules: {
         "@typescript-eslint/require-array-sort-compare": "off",
+        "@typescript-eslint/comma-dangle": "off",
         "@typescript-eslint/consistent-type-definitions": ["error", "type"],
         "@typescript-eslint/consistent-type-imports": "off",
         "@typescript-eslint/explicit-function-return-type": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ module.exports = {
     plugins: ["@typescript-eslint"],
     rules: {
         "@typescript-eslint/require-array-sort-compare": "off",
-        "@typescript-eslint/comma-dangle": "off",
         "@typescript-eslint/consistent-type-definitions": ["error", "type"],
         "@typescript-eslint/consistent-type-imports": "off",
         "@typescript-eslint/explicit-function-return-type": "off",

--- a/src/converters/lintConfigs/rules/types.ts
+++ b/src/converters/lintConfigs/rules/types.ts
@@ -1,15 +1,36 @@
+/**
+ * Severity level for an individual TSLint rule in a TSLint configuration file.
+ *
+ * @see https://palantir.github.io/tslint/usage/configuration
+ */
 export type TSLintRuleSeverity = "warning" | "error" | "off";
 
+/**
+ * Rich descriptor and options for an individual TSLint rule.
+ */
 export type TSLintRuleOptions = {
     ruleArguments: any[];
     ruleName: string;
     ruleSeverity: TSLintRuleSeverity;
 };
 
+/**
+ * Possible reported severities for an ESLint rule's configuration.
+ *
+ * @see https://eslint.org/docs/user-guide/configuring#configuring-rules
+ */
 export type ESLintRuleSeverity = "warn" | "error" | "off";
 
+/**
+ * Permitted severities for an ESLint rule's configuration.
+ *
+ * @see https://eslint.org/docs/user-guide/configuring#configuring-rules
+ */
 export type RawESLintRuleSeverity = ESLintRuleSeverity | 0 | 1 | 2;
 
+/**
+ * Output descriptor and options for a converted ESLint rule.
+ */
 export type ESLintRuleOptions = {
     notices?: any[];
     ruleArguments?: any[];
@@ -17,6 +38,9 @@ export type ESLintRuleOptions = {
     ruleSeverity: ESLintRuleSeverity;
 };
 
+/**
+ * Output descriptor and options for a converted ESLint rule, including arguments.
+ */
 export type ESLintRuleOptionsWithArguments = ESLintRuleOptions & {
     ruleArguments: any[];
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,12 @@ export { findOriginalConfigurationsStandalone as findOriginalConfigurations } fr
 export { findReportedConfigurationStandalone as findReportedConfiguration } from "./api/findReportedConfigurationStandalone";
 export { formatOutput } from "./converters/lintConfigs/formatting/formatOutput";
 export { joinConfigConversionResults } from "./converters/lintConfigs/joinConfigConversionResults";
+export {
+    ESLintRuleOptions,
+    ESLintRuleOptionsWithArguments,
+    ESLintRuleSeverity,
+    RawESLintRuleSeverity,
+    TSLintRuleOptions,
+    TSLintRuleSeverity,
+} from "./converters/lintConfigs/rules/types";
 export * from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,5 @@ export { findOriginalConfigurationsStandalone as findOriginalConfigurations } fr
 export { findReportedConfigurationStandalone as findReportedConfiguration } from "./api/findReportedConfigurationStandalone";
 export { formatOutput } from "./converters/lintConfigs/formatting/formatOutput";
 export { joinConfigConversionResults } from "./converters/lintConfigs/joinConfigConversionResults";
-export {
-    ESLintRuleOptions,
-    ESLintRuleOptionsWithArguments,
-    ESLintRuleSeverity,
-    RawESLintRuleSeverity,
-    TSLintRuleOptions,
-    TSLintRuleSeverity,
-} from "./converters/lintConfigs/rules/types";
+export * from "./converters/lintConfigs/rules/types";
 export * from "./types";


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #814
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Adds comments to and exports all the types in `src/lintConfigs/types.ts` referring to raw and reported lint rule configurations/options.