### PR TITLE
Switched build job to node:latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
     build:
         docker:
-            - image: circleci/node:10
+            - image: circleci/node:latest
 
         working_directory: ~/repo
 


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #815
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Switches the one `circleci/node:10` to `circleci/node:latest` to match up with the other jobs.