### PR TITLE
Added explicit error for a missing TSLint configuration file

### DIFF
--- a/src/input/findTslintConfiguration.test.ts
+++ b/src/input/findTslintConfiguration.test.ts
@@ -67,6 +67,24 @@ describe("findTSLintConfiguration", () => {
         );
     });
 
+    it("replaces an error with a file-not-found complaint when the file path is not found", async () => {
+        // Arrange
+        const stderr = "Could not find configuration path.";
+        const dependencies = createStubDependencies({
+            exec: createStubThrowingExec({ stderr }),
+        });
+
+        // Act
+        const result = await findTSLintConfiguration(dependencies, undefined);
+
+        // Assert
+        expect(result).toEqual(
+            expect.objectContaining({
+                message: `Could not find your TSLint configuration file at './tslint.json'. Try providing a different --tslint path.`,
+            }),
+        );
+    });
+
     it("defaults the configuration file when one isn't provided", async () => {
         // Arrange
         const dependencies = createStubDependencies({


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #823
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Adds a second hardcoded error message override for the TSLint configuration finder. If the requested path is not found, a better error message is printed.