### PR TITLE
Added explicit error for TSLint not being found

### DIFF
--- a/src/input/findTSLintConfiguration.ts
+++ b/src/input/findTSLintConfiguration.ts
@@ -20,6 +20,13 @@ export type FindTSLintConfigurationDependencies = {
 
 const knownErrors = [
     [
+        "command not found",
+        () =>
+            new Error(
+                "The 'tslint' command was not found. Either install it globally or add it as a devDependency of this repository.",
+            ),
+    ],
+    [
         "unknown option `--print-config",
         () => new Error("TSLint v5.18 required. Please update your version."),
     ],

--- a/src/input/findTslintConfiguration.test.ts
+++ b/src/input/findTslintConfiguration.test.ts
@@ -49,6 +49,25 @@ describe("findTSLintConfiguration", () => {
         );
     });
 
+    it("replaces an error with a v5.18 request when the tslint command is not found", async () => {
+        // Arrange
+        const stderr = "/bin/sh tslint: command not found";
+        const dependencies = createStubDependencies({
+            exec: createStubThrowingExec({ stderr }),
+        });
+
+        // Act
+        const result = await findTSLintConfiguration(dependencies, undefined);
+
+        // Assert
+        expect(result).toEqual(
+            expect.objectContaining({
+                message:
+                    "The 'tslint' command was not found. Either install it globally or add it as a devDependency of this repository.",
+            }),
+        );
+    });
+
     it("replaces an error with a v5.18 request when the --print-config option is unsupported", async () => {
         // Arrange
         const stderr = "unknown option `--print-config";


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #836
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Continues #827 but adding another hardcoded error for the _"command not found"_ case.