### PR TITLE
Used typescript-eslint's no-shadow in conversion

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/no-shadowed-variable.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/no-shadowed-variable.ts
@@ -40,7 +40,7 @@ export const convertNoShadowedVariable: RuleConverter = (tslintRule) => {
             {
                 ...(notices.length !== 0 && { notices }),
                 ...(ruleArguments.length !== 0 && { ruleArguments }),
-                ruleName: "no-shadow",
+                ruleName: "@typescript-eslint/no-shadow",
             },
         ],
     };

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-shadowed-variable.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-shadowed-variable.test.ts
@@ -10,7 +10,7 @@ describe(convertNoShadowedVariable, () => {
             rules: [
                 {
                     ruleArguments: [{ hoist: "all" }],
-                    ruleName: "no-shadow",
+                    ruleName: "@typescript-eslint/no-shadow",
                 },
             ],
         });
@@ -25,7 +25,7 @@ describe(convertNoShadowedVariable, () => {
             rules: [
                 {
                     ruleArguments: [{ hoist: "all" }],
-                    ruleName: "no-shadow",
+                    ruleName: "@typescript-eslint/no-shadow",
                 },
             ],
         });
@@ -40,7 +40,7 @@ describe(convertNoShadowedVariable, () => {
             rules: [
                 {
                     ruleArguments: [{ hoist: "all" }],
-                    ruleName: "no-shadow",
+                    ruleName: "@typescript-eslint/no-shadow",
                 },
             ],
         });
@@ -55,7 +55,7 @@ describe(convertNoShadowedVariable, () => {
             rules: [
                 {
                     ruleArguments: [{ hoist: "never" }],
-                    ruleName: "no-shadow",
+                    ruleName: "@typescript-eslint/no-shadow",
                 },
             ],
         });
@@ -77,7 +77,7 @@ describe(convertNoShadowedVariable, () => {
                             "depending on the type of declaration, so all kinds of declarations are checked.",
                     ],
                     ruleArguments: [{ hoist: "all" }],
-                    ruleName: "no-shadow",
+                    ruleName: "@typescript-eslint/no-shadow",
                 },
             ],
         });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #856
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

`@typescript-eslint/no-shadow` is the right rule to convert to, as stated in the issue. It was added after our converter was originally written in https://github.com/typescript-eslint/typescript-eslint/pull/2039.