### PR TITLE
Added jsx-space-before-trailing-slash converter

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -180,6 +180,7 @@ import { convertJsxBooleanValue } from "./ruleConverters/eslint-plugin-react/jsx
 import { convertJsxCurlySpacing } from "./ruleConverters/eslint-plugin-react/jsx-curly-spacing";
 import { convertJsxEqualsSpacing } from "./ruleConverters/eslint-plugin-react/jsx-equals-spacing";
 import { convertJsxKey } from "./ruleConverters/eslint-plugin-react/jsx-key";
+import { convertJsxSpaceBeforeTrailingSlash } from "./ruleConverters/eslint-plugin-react/jsx-space-before-trailing-slash";
 import { convertJsxNoBind } from "./ruleConverters/eslint-plugin-react/jsx-no-bind";
 import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/jsx-wrap-multiline";
 
@@ -242,6 +243,7 @@ export const ruleConverters = new Map([
     ["jsx-equals-spacing", convertJsxEqualsSpacing],
     ["jsx-key", convertJsxKey],
     ["jsx-no-bind", convertJsxNoBind],
+    ["jsx-space-before-trailing-slash", convertJsxSpaceBeforeTrailingSlash],
     ["jsx-wrap-multiline", convertJsxWrapMultiline],
     ["label-position", convertLabelPosition],
     ["linebreak-style", convertLinebreakStyle],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-space-before-trailing-slash.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-space-before-trailing-slash.ts
@@ -6,7 +6,8 @@ export const convertJsxSpaceBeforeTrailingSlash: RuleConverter = () => {
             {
                 ruleArguments: [
                     {
-                        beforeSelfClosing: "always",
+                        afterOpening: "allow",
+                        closingSlash: "allow",
                     },
                 ],
                 ruleName: "react/jsx-tag-spacing",

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-space-before-trailing-slash.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-space-before-trailing-slash.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertJsxSpaceBeforeTrailingSlash: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "react/jsx-space-before-closing",
+            },
+        ],
+        plugins: ["eslint-plugin-react"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-space-before-trailing-slash.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-space-before-trailing-slash.ts
@@ -4,7 +4,12 @@ export const convertJsxSpaceBeforeTrailingSlash: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "react/jsx-space-before-closing",
+                ruleArguments: [
+                    {
+                        beforeSelfClosing: "always",
+                    },
+                ],
+                ruleName: "react/jsx-tag-spacing",
             },
         ],
         plugins: ["eslint-plugin-react"],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-space-before-trailing-slash.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-space-before-trailing-slash.test.ts
@@ -1,0 +1,18 @@
+import { convertJsxSpaceBeforeTrailingSlash } from "../jsx-space-before-trailing-slash";
+
+describe(convertJsxSpaceBeforeTrailingSlash, () => {
+    test("conversion without arguments", () => {
+        const result = convertJsxSpaceBeforeTrailingSlash({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "react/jsx-space-before-trailing-slash",
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-space-before-trailing-slash.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-space-before-trailing-slash.test.ts
@@ -11,7 +11,8 @@ describe(convertJsxSpaceBeforeTrailingSlash, () => {
                 {
                     ruleArguments: [
                         {
-                            beforeSelfClosing: "always",
+                            afterOpening: "allow",
+                            closingSlash: "allow",
                         },
                     ],
                     ruleName: "react/jsx-tag-spacing",

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-space-before-trailing-slash.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-space-before-trailing-slash.test.ts
@@ -9,7 +9,12 @@ describe(convertJsxSpaceBeforeTrailingSlash, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "react/jsx-space-before-trailing-slash",
+                    ruleArguments: [
+                        {
+                            beforeSelfClosing: "always",
+                        },
+                    ],
+                    ruleName: "react/jsx-tag-spacing",
                 },
             ],
             plugins: ["eslint-plugin-react"],


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #526
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md -> https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md