### PR TITLE
Added converter for jsx-self-close rule

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -181,6 +181,7 @@ import { convertJsxCurlySpacing } from "./ruleConverters/eslint-plugin-react/jsx
 import { convertJsxEqualsSpacing } from "./ruleConverters/eslint-plugin-react/jsx-equals-spacing";
 import { convertJsxKey } from "./ruleConverters/eslint-plugin-react/jsx-key";
 import { convertJsxNoBind } from "./ruleConverters/eslint-plugin-react/jsx-no-bind";
+import { convertJsxSelfClose } from "./ruleConverters/eslint-plugin-react/jsx-self-close";
 import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/jsx-wrap-multiline";
 
 // eslint-plugin-rxjs converters
@@ -242,6 +243,7 @@ export const ruleConverters = new Map([
     ["jsx-equals-spacing", convertJsxEqualsSpacing],
     ["jsx-key", convertJsxKey],
     ["jsx-no-bind", convertJsxNoBind],
+    ["jsx-self-close", convertJsxSelfClose],
     ["jsx-wrap-multiline", convertJsxWrapMultiline],
     ["label-position", convertLabelPosition],
     ["linebreak-style", convertLinebreakStyle],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-self-close.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-self-close.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertJsxSelfClose: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "react/self-closing-comp",
+            },
+        ],
+        plugins: ["eslint-plugin-react"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-self-close.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-self-close.test.ts
@@ -1,0 +1,18 @@
+import { convertJsxSelfClose } from "../jsx-self-close";
+
+describe(convertJsxSelfClose, () => {
+    test("conversion without arguments", () => {
+        const result = convertJsxSelfClose({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "react/self-closing-comp",
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+});


### PR DESCRIPTION

## PR Checklist

-   [x] Addresses an existing issue: fixes #525
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md