### PR TITLE
Added converter for jsx-no-lambda

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -181,6 +181,7 @@ import { convertJsxCurlySpacing } from "./ruleConverters/eslint-plugin-react/jsx
 import { convertJsxEqualsSpacing } from "./ruleConverters/eslint-plugin-react/jsx-equals-spacing";
 import { convertJsxKey } from "./ruleConverters/eslint-plugin-react/jsx-key";
 import { convertJsxNoBind } from "./ruleConverters/eslint-plugin-react/jsx-no-bind";
+import { convertJsxNoLambda } from "./ruleConverters/eslint-plugin-react/jsx-no-lambda";
 import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/jsx-wrap-multiline";
 
 // eslint-plugin-rxjs converters
@@ -242,6 +243,7 @@ export const ruleConverters = new Map([
     ["jsx-equals-spacing", convertJsxEqualsSpacing],
     ["jsx-key", convertJsxKey],
     ["jsx-no-bind", convertJsxNoBind],
+    ["jsx-no-lambda", convertJsxNoLambda],
     ["jsx-wrap-multiline", convertJsxWrapMultiline],
     ["label-position", convertLabelPosition],
     ["linebreak-style", convertLinebreakStyle],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-no-lambda.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-no-lambda.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertJsxNoLambda: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                notices: ["ESLint rule 'jsx-no-bind' also checks for Function.bind"],
+                ruleName: "react/jsx-no-bind",
+            },
+        ],
+        plugins: ["eslint-plugin-react"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-no-lambda.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-no-lambda.test.ts
@@ -10,7 +10,7 @@ describe(convertJsxNoLambda, () => {
             rules: [
                 {
                     notices: ["ESLint rule 'jsx-no-bind' also checks for Function.bind"],
-                    ruleName: "react/jsx-key",
+                    ruleName: "react/jsx-no-bind",
                 },
             ],
             plugins: ["eslint-plugin-react"],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-no-lambda.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-no-lambda.test.ts
@@ -1,0 +1,19 @@
+import { convertJsxNoLambda } from "../jsx-no-lambda";
+
+describe(convertJsxNoLambda, () => {
+    test("conversion without arguments", () => {
+        const result = convertJsxNoLambda({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: ["ESLint rule 'jsx-no-bind' also checks for Function.bind"],
+                    ruleName: "react/jsx-key",
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #523
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/yannickcr/eslint-plugin-react/issues/2176