### PR TITLE
Added converter for jsx-ban-props

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -176,6 +176,7 @@ import { convertUsePipeDecorator } from "./ruleConverters/codelyzer/use-pipe-dec
 import { convertUsePipeTransformInterface } from "./ruleConverters/codelyzer/use-pipe-transform-interface";
 
 // ESLint-React converters
+import { convertJsxBanProps } from "./ruleConverters/eslint-plugin-react/jsx-ban-props";
 import { convertJsxBooleanValue } from "./ruleConverters/eslint-plugin-react/jsx-boolean-value";
 import { convertJsxCurlySpacing } from "./ruleConverters/eslint-plugin-react/jsx-curly-spacing";
 import { convertJsxEqualsSpacing } from "./ruleConverters/eslint-plugin-react/jsx-equals-spacing";
@@ -237,6 +238,7 @@ export const ruleConverters = new Map([
     ["interface-name", convertInterfaceName],
     ["interface-over-type-literal", convertInterfaceOverTypeLiteral],
     ["jsdoc-format", convertJSDocFormat],
+    ["jsx-ban-props", convertJsxBanProps],
     ["jsx-boolean-value", convertJsxBooleanValue],
     ["jsx-curly-spacing", convertJsxCurlySpacing],
     ["jsx-equals-spacing", convertJsxEqualsSpacing],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-ban-props.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-ban-props.ts
@@ -6,8 +6,13 @@ export const convertJsxBanProps: RuleConverter = (tslintRule) => {
             {
                 ...(tslintRule.ruleArguments.length !== 0 && {
                     ruleArguments: tslintRule.ruleArguments.map((ruleArgument) => ({
-                        ...(ruleArgument.length === 2 && { message: ruleArgument[1] }),
-                        propName: ruleArgument[0],
+                        forbid:
+                            ruleArgument.length === 1
+                                ? ruleArgument[0]
+                                : {
+                                      message: ruleArgument[1],
+                                      propName: ruleArgument[0],
+                                  },
                     })),
                 }),
                 ruleName: "react/forbid-component-props",

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-ban-props.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/jsx-ban-props.ts
@@ -1,0 +1,18 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertJsxBanProps: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: tslintRule.ruleArguments.map((ruleArgument) => ({
+                        ...(ruleArgument.length === 2 && { message: ruleArgument[1] }),
+                        propName: ruleArgument[0],
+                    })),
+                }),
+                ruleName: "react/forbid-component-props",
+            },
+        ],
+        plugins: ["eslint-plugin-react"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-ban-props.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-ban-props.test.ts
@@ -1,0 +1,62 @@
+import { convertJsxBanProps } from "../jsx-ban-props";
+
+describe(convertJsxBanProps, () => {
+    test("conversion without arguments", () => {
+        const result = convertJsxBanProps({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "react/forbid-component-props",
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+
+    test("conversion with a single prop", () => {
+        const result = convertJsxBanProps({
+            ruleArguments: [["someProp"]],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            propName: "someProp",
+                        },
+                    ],
+                    ruleName: "react/forbid-component-props",
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+
+    test("conversion with a message", () => {
+        const result = convertJsxBanProps({
+            ruleArguments: [["someProp"], ["anotherProp", "Optional explanation"]],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            propName: "someProp",
+                        },
+                        {
+                            message: "Optional explanation",
+                            propName: "anotherProp",
+                        },
+                    ],
+                    ruleName: "react/forbid-component-props",
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-ban-props.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-react/tests/jsx-ban-props.test.ts
@@ -26,7 +26,7 @@ describe(convertJsxBanProps, () => {
                 {
                     ruleArguments: [
                         {
-                            propName: "someProp",
+                            forbid: "someProp",
                         },
                     ],
                     ruleName: "react/forbid-component-props",
@@ -46,11 +46,13 @@ describe(convertJsxBanProps, () => {
                 {
                     ruleArguments: [
                         {
-                            propName: "someProp",
+                            forbid: "someProp",
                         },
                         {
-                            message: "Optional explanation",
-                            propName: "anotherProp",
+                            forbid: {
+                                message: "Optional explanation",
+                                propName: "anotherProp",
+                            },
                         },
                     ],
                     ruleName: "react/forbid-component-props",


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #517
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/palantir/tslint-react/blob/master/src/rules/jsxBanPropsRule.ts -> https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md. 