### PR TITLE
refactor: remove use-pipe-decorator converter

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/use-pipe-decorator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/use-pipe-decorator.test.ts
@@ -6,13 +6,6 @@ describe(convertUsePipeDecorator, () => {
             ruleArguments: [],
         });
 
-        expect(result).toEqual({
-            rules: [
-                {
-                    ruleName: "@angular-eslint/use-pipe-decorator",
-                },
-            ],
-            plugins: ["@angular-eslint/eslint-plugin"],
-        });
+        expect(result).toEqual({ rules: [] });
     });
 });

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/use-pipe-decorator.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/use-pipe-decorator.ts
@@ -2,11 +2,6 @@ import { RuleConverter } from "../../ruleConverter";
 
 export const convertUsePipeDecorator: RuleConverter = () => {
     return {
-        rules: [
-            {
-                ruleName: "@angular-eslint/use-pipe-decorator",
-            },
-        ],
-        plugins: ["@angular-eslint/eslint-plugin"],
+        rules: [],
     };
 };


### PR DESCRIPTION
## Overview
As mentioned in https://github.com/mgechev/codelyzer/issues/592, https://github.com/angular-eslint/angular-eslint/pull/241 and https://github.com/angular-eslint/angular-eslint/pull/245, this rule seems to be unnecessary since Angular 8 (pre-Ivy) and in order to drop it in angular-eslint repo the converter should be removed first.

cc @JamesHenry @JoshuaKGoldberg.