### PR TITLE
Add codelyzer template-no-any converter

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -162,6 +162,7 @@ import { convertPipePrefix } from "./ruleConverters/codelyzer/pipe-prefix";
 import { convertPreferOnPushComponentChangeDetection } from "./ruleConverters/codelyzer/prefer-on-push-component-change-detection";
 import { convertPreferOutputReadonly } from "./ruleConverters/codelyzer/prefer-output-readonly";
 import { convertRelativeUrlPrefix } from "./ruleConverters/codelyzer/relative-url-prefix";
+import { convertTemplateNoAny } from "./ruleConverters/codelyzer/template-no-any";
 import { convertTemplateAccessibilityTabindexNoPositive } from "./ruleConverters/codelyzer/template-accessibility-tabindex-no-positive";
 import { convertTemplateBananaInBox } from "./ruleConverters/codelyzer/template-banana-in-box";
 import { convertTemplateCyclomaticComplexity } from "./ruleConverters/codelyzer/template-cyclomatic-complexity";
@@ -371,6 +372,7 @@ export const ruleConverters = new Map([
     ["space-within-parens", convertSpaceWithinParens],
     ["strict-boolean-expressions", convertStrictBooleanExpressions],
     ["switch-default", convertSwitchDefault],
+    ["template-no-any", convertTemplateNoAny],
     ["template-accessibility-tabindex-no-positive", convertTemplateAccessibilityTabindexNoPositive],
     ["template-banana-in-box", convertTemplateBananaInBox],
     ["template-cyclomatic-complexity", convertTemplateCyclomaticComplexity],

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/template-no-any.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/template-no-any.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertTemplateNoAny: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "@angular-eslint/template/no-any",
+            },
+        ],
+        plugins: ["@angular-eslint/eslint-plugin-template"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-no-any.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-no-any.test.ts
@@ -1,0 +1,18 @@
+import { convertTemplateNoAny } from "../template-no-any";
+
+describe(convertTemplateNoAny, () => {
+    test("conversion without arguments", () => {
+        const result = convertTemplateNoAny({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@angular-eslint/template/no-any",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin-template"],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #506  
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Adds converter for codelyzer `template-no-any` rule which has been added to `@angular-eslint`.