### PR TITLE
Fix codelyzer template-accessibility-label-for converter

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/template-accessibility-label-for.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/template-accessibility-label-for.ts
@@ -1,9 +1,18 @@
 import { RuleConverter } from "../../ruleConverter";
 
-export const convertTemplateAccessibilityLabelFor: RuleConverter = () => {
+export const convertTemplateAccessibilityLabelFor: RuleConverter = (tslintRule) => {
     return {
         rules: [
             {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: [
+                        {
+                            ...(tslintRule.ruleArguments[0]?.controlComponents && { controlComponents: tslintRule.ruleArguments[0]?.controlComponents }),
+                            ...(tslintRule.ruleArguments[0]?.labelAttributes && { labelAttributes: tslintRule.ruleArguments[0]?.labelAttributes }),
+                            ...(tslintRule.ruleArguments[0]?.labelComponents && { labelComponents: tslintRule.ruleArguments[0]?.labelComponents }),
+                        },
+                    ],
+                }),
                 ruleName: "@angular-eslint/template/accessibility-label-for",
             },
         ],

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-accessibility-label-for.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-accessibility-label-for.test.ts
@@ -15,4 +15,30 @@ describe(convertTemplateAccessibilityLabelFor, () => {
             plugins: ["@angular-eslint/eslint-plugin-template"],
         });
     });
+
+    test("conversion with arguments", () => {
+        const result = convertTemplateAccessibilityLabelFor({
+            ruleArguments: [{
+                controlComponents: ["app-input", "app-select"],
+                labelAttributes: ["id"],
+                labelComponents: ["app-label"],
+            }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            controlComponents: ["app-input", "app-select"],
+                            labelAttributes: ["id"],
+                            labelComponents: ["app-label"],
+                        }
+                    ],
+                    ruleName: "@angular-eslint/template/accessibility-label-for",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin-template"],
+        });
+    });
 });


### PR DESCRIPTION
Added the missing rule options

<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

The rule converter was missing the available options at [codelyzer docs](http://codelyzer.com/rules/template-accessibility-label-for/) which are the same as [angular-eslint ones](https://github.com/angular-eslint/angular-eslint/blob/master/packages/eslint-plugin-template/src/rules/accessibility-label-for.ts).