### PR TITLE
Fixed no-param-reassign converter to not have prefix

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/no-parameter-reassignment.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/no-parameter-reassignment.ts
@@ -4,7 +4,7 @@ export const convertNoParameterReassignment: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "@typescript-eslint/no-param-reassign",
+                ruleName: "no-param-reassign",
             },
         ],
     };

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-parameter-reassignment.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-parameter-reassignment.test.ts
@@ -9,7 +9,7 @@ describe(convertNoParameterReassignment, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@typescript-eslint/no-param-reassign",
+                    ruleName: "no-param-reassign",
                 },
             ],
         });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1015
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Per @snebjorn's bug report, the `@typescript-eslint/` prefix is incorrect.
