### PR TITLE
Allowed converters to specify output rule severity

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverter.ts
+++ b/src/converters/lintConfigs/rules/ruleConverter.ts
@@ -1,4 +1,4 @@
-import { TSLintRuleOptions } from "./types";
+import { ESLintRuleSeverity, TSLintRuleOptions } from "./types";
 import { ConversionError } from "../../../errors/conversionError";
 
 /**
@@ -51,4 +51,9 @@ export type ConvertedRuleChanges = {
      * Equivalent ESLint rule name that should be enabled.
      */
     ruleName: string;
+
+    /**
+     * Custom severity for the output rule.
+     */
+    ruleSeverity?: ESLintRuleSeverity;
 };

--- a/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
@@ -1,4 +1,5 @@
 import { RuleConverter } from "../ruleConverter";
+import { ESLintRuleSeverity } from "../types";
 
 export const ConstRequiredForAllCapsMsg =
     "typescript-eslint does not enforce uppercase for const only.";
@@ -57,7 +58,7 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
     };
 
     const getUnderscoreDangleRuleOptions = () => {
-        let underscoreDangleOptionSeverity: string | null = null;
+        let underscoreDangleOptionSeverity: ESLintRuleSeverity | undefined;
         const underscoreDangleOptionNotice: string[] = [];
 
         if (hasCheckFormat && (allowedLeadingUnderscore || allowedTrailingUnderscore)) {
@@ -69,7 +70,7 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
 
         return {
             notices: underscoreDangleOptionNotice,
-            ...(underscoreDangleOptionSeverity !== null && {
+            ...(underscoreDangleOptionSeverity !== undefined && {
                 ruleSeverity: underscoreDangleOptionSeverity,
             }),
             ruleName: "no-underscore-dangle",
@@ -79,16 +80,16 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
     const getBlackListRuleOptions = () => {
         const blackListOptionArguments = tslintRule.ruleArguments.includes("ban-keywords")
             ? [
-                  "any",
-                  "Number",
-                  "number",
-                  "String",
-                  "string",
-                  "Boolean",
-                  "boolean",
-                  "Undefined",
-                  "undefined",
-              ]
+                    "any",
+                    "Number",
+                    "number",
+                    "String",
+                    "string",
+                    "Boolean",
+                    "boolean",
+                    "Undefined",
+                    "undefined",
+                ]
             : [];
 
         return {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1043
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Amusingly, the `variable-name` already relies on being able to output this severity. It just wasn't reflected well in the type system. Yay, structural typing!