### PR TITLE
feat: changes to some angular-eslint rules for v12

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/template-accessibility-label-for.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/template-accessibility-label-for.ts
@@ -7,13 +7,24 @@ export const convertTemplateAccessibilityLabelFor: RuleConverter = (tslintRule) 
                 ...(tslintRule.ruleArguments.length !== 0 && {
                     ruleArguments: [
                         {
-                            ...(tslintRule.ruleArguments[0]?.controlComponents && { controlComponents: tslintRule.ruleArguments[0]?.controlComponents }),
-                            ...(tslintRule.ruleArguments[0]?.labelAttributes && { labelAttributes: tslintRule.ruleArguments[0]?.labelAttributes }),
-                            ...(tslintRule.ruleArguments[0]?.labelComponents && { labelComponents: tslintRule.ruleArguments[0]?.labelComponents }),
+                            ...(tslintRule.ruleArguments[0]?.controlComponents && {
+                                controlComponents: tslintRule.ruleArguments[0]?.controlComponents,
+                            }),
+                            ...(tslintRule.ruleArguments[0]?.labelComponents && {
+                                labelComponents: tslintRule.ruleArguments[0]?.labelComponents.map(
+                                    (selector: string) => {
+                                        return {
+                                            inputs:
+                                                tslintRule.ruleArguments[0]?.labelAttributes || [],
+                                            selector,
+                                        };
+                                    },
+                                ),
+                            }),
                         },
                     ],
                 }),
-                ruleName: "@angular-eslint/template/accessibility-label-for",
+                ruleName: "@angular-eslint/template/accessibility-label-has-associated-control",
             },
         ],
         plugins: ["@angular-eslint/eslint-plugin-template"],

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/template-no-negated-async.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/template-no-negated-async.ts
@@ -4,6 +4,9 @@ export const convertTemplateNoNegatedAsync: RuleConverter = () => {
     return {
         rules: [
             {
+                ruleName: "@angular-eslint/template/eqeqeq",
+            },
+            {
                 ruleName: "@angular-eslint/template/no-negated-async",
             },
         ],

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-accessibility-label-for.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-accessibility-label-for.test.ts
@@ -9,7 +9,7 @@ describe(convertTemplateAccessibilityLabelFor, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "@angular-eslint/template/accessibility-label-for",
+                    ruleName: "@angular-eslint/template/accessibility-label-has-associated-control",
                 },
             ],
             plugins: ["@angular-eslint/eslint-plugin-template"],
@@ -18,11 +18,13 @@ describe(convertTemplateAccessibilityLabelFor, () => {
 
     test("conversion with arguments", () => {
         const result = convertTemplateAccessibilityLabelFor({
-            ruleArguments: [{
-                controlComponents: ["app-input", "app-select"],
-                labelAttributes: ["id"],
-                labelComponents: ["app-label"],
-            }],
+            ruleArguments: [
+                {
+                    controlComponents: ["app-input", "app-select"],
+                    labelAttributes: ["id"],
+                    labelComponents: ["app-label"],
+                },
+            ],
         });
 
         expect(result).toEqual({
@@ -31,11 +33,15 @@ describe(convertTemplateAccessibilityLabelFor, () => {
                     ruleArguments: [
                         {
                             controlComponents: ["app-input", "app-select"],
-                            labelAttributes: ["id"],
-                            labelComponents: ["app-label"],
-                        }
+                            labelComponents: [
+                                {
+                                    inputs: ["id"],
+                                    selector: "app-label",
+                                },
+                            ],
+                        },
                     ],
-                    ruleName: "@angular-eslint/template/accessibility-label-for",
+                    ruleName: "@angular-eslint/template/accessibility-label-has-associated-control",
                 },
             ],
             plugins: ["@angular-eslint/eslint-plugin-template"],

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-accessibility-label-for.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-accessibility-label-for.test.ts
@@ -47,4 +47,35 @@ describe(convertTemplateAccessibilityLabelFor, () => {
             plugins: ["@angular-eslint/eslint-plugin-template"],
         });
     });
+
+    test("conversion with arguments, missing labelAttributes", () => {
+        const result = convertTemplateAccessibilityLabelFor({
+            ruleArguments: [
+                {
+                    controlComponents: ["app-input", "app-select"],
+                    labelComponents: ["app-label"],
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            controlComponents: ["app-input", "app-select"],
+                            labelComponents: [
+                                {
+                                    inputs: [],
+                                    selector: "app-label",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "@angular-eslint/template/accessibility-label-has-associated-control",
+                },
+            ],
+            plugins: ["@angular-eslint/eslint-plugin-template"],
+        });
+    });
 });

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-no-negated-async.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/template-no-negated-async.test.ts
@@ -9,6 +9,9 @@ describe(convertTemplateNoNegatedAsync, () => {
         expect(result).toEqual({
             rules: [
                 {
+                    ruleName: "@angular-eslint/template/eqeqeq",
+                },
+                {
                     ruleName: "@angular-eslint/template/no-negated-async",
                 },
             ],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

- `@angular-eslint/template/no-negated-async` has historically done too much, and so a new rule, `@angular-eslint/template/eqeqeq` has been added to do half of what it used to do :)
- New rule `@angular-eslint/template/accessibility-label-has-associated-control`, with slightly different schema, is preferred to deprecated `@angular-eslint/template/accessibility-label-for`
