### PR TITLE
Add rxjs no-exposed-subjects converter

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -205,6 +205,7 @@ import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/js
 import { convertNoAsyncSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-async-subscribe";
 import { convertNoImplicitAnyCatch } from "./ruleConverters/eslint-plugin-rxjs/no-implicit-any-catch";
 import { convertNoCreate } from "./ruleConverters/eslint-plugin-rxjs/no-create";
+import { convertNoExposedSubjects } from "./ruleConverters/eslint-plugin-rxjs/no-exposed-subjects";
 import { convertNoIgnoredNotifier } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-notifier";
 import { convertNoIgnoredReplayBuffer } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-replay-buffer";
 import { convertNoIgnoredTakeWhileValue } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-takewhile-value";
@@ -425,6 +426,7 @@ export const ruleConverters = new Map([
     ["rxjs-no-async-subscribe", convertNoAsyncSubscribe],
     ["rxjs-no-implicit-any-catch", convertNoImplicitAnyCatch],
     ["rxjs-no-create", convertNoCreate],
+    ["rxjs-no-exposed-subjects", convertNoExposedSubjects],
     ["rxjs-no-ignored-notifier", convertNoIgnoredNotifier],
     ["rxjs-no-ignored-replay-buffer", convertNoIgnoredReplayBuffer],
     ["rxjs-no-ignored-takewhile-value", convertNoIgnoredTakeWhileValue],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-exposed-subjects.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-exposed-subjects.ts
@@ -1,0 +1,15 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoExposedSubjects: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: tslintRule.ruleArguments,
+                }),
+                ruleName: "rxjs/no-exposed-subjects",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-exposed-subjects.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-exposed-subjects.test.ts
@@ -1,0 +1,34 @@
+import { convertNoExposedSubjects } from "../no-exposed-subjects";
+
+describe(convertNoExposedSubjects, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoExposedSubjects({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-exposed-subjects",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with allowProtected argument", () => {
+        const result = convertNoExposedSubjects({
+            ruleArguments: [{ allowProtected: true }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-exposed-subjects",
+                    ruleArguments: [{ allowProtected: true }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1051
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

- TSLint Rule: [rxjs-tslint-rules/rxjs-no-exposed-subjects](https://cartant.github.io/rxjs-tslint-rules/#rxjs-no-exposed-subjects)
- ESLint Rule: [eslint-plugin-rxjs/no-exposed-subjects](https://github.com/cartant/eslint-plugin-rxjs/blob/main/docs/rules/no-exposed-subjects.md)