### PR TITLE
Add rxjs no-finnish converter

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -205,6 +205,7 @@ import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/js
 import { convertNoAsyncSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-async-subscribe";
 import { convertNoImplicitAnyCatch } from "./ruleConverters/eslint-plugin-rxjs/no-implicit-any-catch";
 import { convertNoCreate } from "./ruleConverters/eslint-plugin-rxjs/no-create";
+import { convertNoFinnish } from "./ruleConverters/eslint-plugin-rxjs/no-finnish";
 import { convertNoIgnoredNotifier } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-notifier";
 import { convertNoIgnoredReplayBuffer } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-replay-buffer";
 import { convertNoIgnoredTakeWhileValue } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-takewhile-value";
@@ -425,6 +426,7 @@ export const ruleConverters = new Map([
     ["rxjs-no-async-subscribe", convertNoAsyncSubscribe],
     ["rxjs-no-implicit-any-catch", convertNoImplicitAnyCatch],
     ["rxjs-no-create", convertNoCreate],
+    ["rxjs-no-finnish", convertNoFinnish],
     ["rxjs-no-ignored-notifier", convertNoIgnoredNotifier],
     ["rxjs-no-ignored-replay-buffer", convertNoIgnoredReplayBuffer],
     ["rxjs-no-ignored-takewhile-value", convertNoIgnoredTakeWhileValue],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-finnish.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-finnish.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoFinnish: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-finnish",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-finnish.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-finnish.test.ts
@@ -1,0 +1,18 @@
+import { convertNoFinnish } from "../no-finnish";
+
+describe(convertNoFinnish, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoFinnish({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-finnish",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1052
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Easy rule, has no configuration options.

- TSLint Rule: [rxjs-tslint-rules](https://cartant.github.io/rxjs-tslint-rules/)
- ESLint Rule: [eslint-plugin-rxjs/no-finnish](https://github.com/cartant/eslint-plugin-rxjs/blob/main/docs/rules/no-finnish.md)