### PR TITLE
Add rxjs no-ignored-subscription converter

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -207,6 +207,7 @@ import { convertNoImplicitAnyCatch } from "./ruleConverters/eslint-plugin-rxjs/n
 import { convertNoCreate } from "./ruleConverters/eslint-plugin-rxjs/no-create";
 import { convertNoIgnoredNotifier } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-notifier";
 import { convertNoIgnoredReplayBuffer } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-replay-buffer";
+import { convertNoIgnoredSubscription } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-subscription";
 import { convertNoIgnoredTakeWhileValue } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-takewhile-value";
 import { convertNoIndex } from "./ruleConverters/eslint-plugin-rxjs/no-index";
 import { convertNoInternal } from "./ruleConverters/eslint-plugin-rxjs/no-internal";
@@ -427,6 +428,7 @@ export const ruleConverters = new Map([
     ["rxjs-no-create", convertNoCreate],
     ["rxjs-no-ignored-notifier", convertNoIgnoredNotifier],
     ["rxjs-no-ignored-replay-buffer", convertNoIgnoredReplayBuffer],
+    ["rxjs-no-ignored-subscription", convertNoIgnoredSubscription],
     ["rxjs-no-ignored-takewhile-value", convertNoIgnoredTakeWhileValue],
     ["rxjs-no-index", convertNoIndex],
     ["rxjs-no-internal", convertNoInternal],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-ignored-subscription.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-ignored-subscription.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoIgnoredSubscription: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-ignored-subscription",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-ignored-subscription.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-ignored-subscription.test.ts
@@ -1,0 +1,18 @@
+import { convertNoIgnoredSubscription } from "../no-ignored-subscription";
+
+describe(convertNoIgnoredSubscription, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoIgnoredSubscription({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-ignored-subscription",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1053
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Easy rule, has no configuration options.

- TSLint Rule: [rxjs-tslint-rules](https://cartant.github.io/rxjs-tslint-rules/)
- ESLint Rule: [eslint-plugin-rxjs/no-ignored-subscription](https://github.com/cartant/eslint-plugin-rxjs/blob/main/docs/rules/no-ignored-subscription.md)