### PR TITLE
Add prefer-switch converter

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -116,6 +116,7 @@ import { convertPreferForOf } from "./ruleConverters/prefer-for-of";
 import { convertPreferFunctionOverMethod } from "./ruleConverters/prefer-function-over-method";
 import { convertPreferObjectSpread } from "./ruleConverters/prefer-object-spread";
 import { convertPreferReadonly } from "./ruleConverters/prefer-readonly";
+import { convertPreferSwitch } from "./ruleConverters/prefer-switch";
 import { convertPreferTemplate } from "./ruleConverters/prefer-template";
 import { convertPromiseFunctionAsync } from "./ruleConverters/promise-function-async";
 import { convertQuotemark } from "./ruleConverters/quotemark";
@@ -376,6 +377,7 @@ export const ruleConverters = new Map([
     ["prefer-on-push-component-change-detection", convertPreferOnPushComponentChangeDetection],
     ["prefer-output-readonly", convertPreferOutputReadonly],
     ["prefer-readonly", convertPreferReadonly],
+    ["prefer-switch", convertPreferSwitch],
     ["prefer-template", convertPreferTemplate],
     ["promise-function-async", convertPromiseFunctionAsync],
     ["quotemark", convertQuotemark],

--- a/src/converters/lintConfigs/rules/ruleConverters/prefer-switch.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/prefer-switch.ts
@@ -1,0 +1,16 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertPreferSwitch: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 &&
+                    "min-cases" in tslintRule.ruleArguments[0] && {
+                        ruleArguments: [{ minimumCases: tslintRule.ruleArguments[0]["min-cases"] }],
+                    }),
+                ruleName: "unicorn/prefer-switch",
+            },
+        ],
+        plugins: ["eslint-plugin-unicorn"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-switch.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-switch.test.ts
@@ -1,0 +1,34 @@
+import { convertPreferSwitch } from "../prefer-switch";
+
+describe(convertPreferSwitch, () => {
+    test("conversion without arguments", () => {
+        const result = convertPreferSwitch({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "unicorn/prefer-switch",
+                },
+            ],
+            plugins: ["eslint-plugin-unicorn"],
+        });
+    });
+
+    test("conversion with 'min-cases' argument", () => {
+        const result = convertPreferSwitch({
+            ruleArguments: [{ 'min-cases': 4 }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [{ minimumCases: 4 }],
+                    ruleName: "unicorn/prefer-switch",
+                },
+            ],
+            plugins: ["eslint-plugin-unicorn"],
+        });
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue: Nope
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

- TSLint Rule: [prefer-switch](https://palantir.github.io/tslint/rules/prefer-switch/)
- ESLint Rule: [eslint-plugin-unicorn/prefer-switch](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-switch.md)

Pretty much stumbled upon this missing rule converter while reading about the ternary one.