### PR TITLE
Add obsolete rule converter

### DIFF
--- a/src/converters/lintConfigs/rules/obsoleteRule.stubs.ts
+++ b/src/converters/lintConfigs/rules/obsoleteRule.stubs.ts
@@ -1,0 +1,25 @@
+import { OBSOLETE_RULE_NOTICE } from "./obsoleteRule";
+import { RuleConverter } from "./ruleConverter";
+
+export const obsoleteRuleTest = (
+    ruleTest: RuleConverter,
+    tslintRuleName: string,
+    pluginName: string,
+) => {
+    describe(ruleTest, () => {
+        test("conversion without arguments", () => {
+            const result = ruleTest({
+                ruleArguments: [],
+            });
+
+            expect(result).toEqual({
+                rules: [
+                    {
+                        ruleName: "",
+                        notices: [OBSOLETE_RULE_NOTICE(tslintRuleName, pluginName)],
+                    },
+                ],
+            });
+        });
+    });
+};

--- a/src/converters/lintConfigs/rules/obsoleteRule.ts
+++ b/src/converters/lintConfigs/rules/obsoleteRule.ts
@@ -1,0 +1,19 @@
+import { ConversionError } from "../../../errors/conversionError";
+import { ConversionResult } from "./ruleConverter";
+
+export const OBSOLETE_RULE_NOTICE = (tslintRuleName: string, pluginName: string) =>
+    `"${tslintRuleName}" rule is no longer supported by the plugin ${pluginName}.`;
+
+export const convertObsoleteRule = (
+    tslintRuleName: string,
+    pluginName: string,
+): ConversionError | ConversionResult => {
+    return {
+        rules: [
+            {
+                ruleName: "",
+                notices: [OBSOLETE_RULE_NOTICE(tslintRuleName, pluginName)],
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -150,6 +150,7 @@ import { convertContextualLifecycle } from "./ruleConverters/codelyzer/contextua
 import { convertContextualDecorator } from "./ruleConverters/codelyzer/contextual-decorator";
 import { convertDirectiveClassSuffix } from "./ruleConverters/codelyzer/directive-class-suffix";
 import { convertDirectiveSelector } from "./ruleConverters/codelyzer/directive-selector";
+import { convertImportDestructuringSpacing } from "./ruleConverters/codelyzer/import-destructuring-spacing";
 import { convertNoAttributeDecorator } from "./ruleConverters/codelyzer/no-attribute-decorator";
 import { convertNoConflictingLifecycle } from "./ruleConverters/codelyzer/no-conflicting-lifecycle";
 import { convertNoForwardRef } from "./ruleConverters/codelyzer/no-forward-ref";
@@ -165,6 +166,7 @@ import { convertNoOutputsMetadataProperty } from "./ruleConverters/codelyzer/no-
 import { convertNoPipeImpure } from "./ruleConverters/codelyzer/no-pipe-impure";
 import { convertNoQueriesMetadataProperty } from "./ruleConverters/codelyzer/no-queries-metadata-property";
 import { convertPipePrefix } from "./ruleConverters/codelyzer/pipe-prefix";
+import { convertPreferInlineDecorator } from "./ruleConverters/codelyzer/prefer-inline-decorator";
 import { convertPreferOnPushComponentChangeDetection } from "./ruleConverters/codelyzer/prefer-on-push-component-change-detection";
 import { convertPreferOutputReadonly } from "./ruleConverters/codelyzer/prefer-output-readonly";
 import { convertRelativeUrlPrefix } from "./ruleConverters/codelyzer/relative-url-prefix";
@@ -258,6 +260,7 @@ export const ruleConverters = new Map([
     ["forin", convertForin],
     ["function-constructor", convertFunctionConstructor],
     ["import-blacklist", convertImportBlacklist],
+    ["import-destructuring-spacing", convertImportDestructuringSpacing],
     ["increment-decrement", convertIncrementDecrement],
     ["indent", convertIndent],
     ["interface-name", convertInterfaceName],
@@ -380,6 +383,7 @@ export const ruleConverters = new Map([
     ["prefer-array-literal", convertPreferArrayLiteral],
     ["prefer-conditional-expression", convertPreferConditionalExpression],
     ["prefer-const", convertPreferConst],
+    ["prefer-inline-decorator", convertPreferInlineDecorator],
     ["prefer-for-of", convertPreferForOf],
     ["prefer-function-over-method", convertPreferFunctionOverMethod],
     ["prefer-object-spread", convertPreferObjectSpread],

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/import-destructuring-spacing.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/import-destructuring-spacing.ts
@@ -1,0 +1,5 @@
+import { convertObsoleteRule } from "../../obsoleteRule";
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertImportDestructuringSpacing: RuleConverter = () =>
+    convertObsoleteRule("import-destructuring-spacing", "@angular-eslint/eslint-plugin");

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/prefer-inline-decorator.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/prefer-inline-decorator.ts
@@ -1,0 +1,5 @@
+import { convertObsoleteRule } from "../../obsoleteRule";
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertPreferInlineDecorator: RuleConverter = () =>
+    convertObsoleteRule("prefer-inline-decorator", "@angular-eslint/eslint-plugin");

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/import-destructuring-spacing.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/import-destructuring-spacing.test.ts
@@ -1,0 +1,8 @@
+import { obsoleteRuleTest } from "../../../obsoleteRule.stubs";
+import { convertImportDestructuringSpacing } from "../import-destructuring-spacing";
+
+obsoleteRuleTest(
+    convertImportDestructuringSpacing,
+    "import-destructuring-spacing",
+    "@angular-eslint/eslint-plugin",
+);

--- a/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/prefer-inline-decorator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/codelyzer/tests/prefer-inline-decorator.test.ts
@@ -1,0 +1,8 @@
+import { obsoleteRuleTest } from "../../../obsoleteRule.stubs";
+import { convertPreferInlineDecorator } from "../prefer-inline-decorator";
+
+obsoleteRuleTest(
+    convertPreferInlineDecorator,
+    "prefer-inline-decorator",
+    "@angular-eslint/eslint-plugin",
+);


### PR DESCRIPTION
Used for prefer-inline-decorators and import-destructuring-spacing converters

<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #490, #472
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Also includes a obsolete rule function and test stub for making it easier to use.