### PR TITLE
Added converter for max-func-body-length

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -27,6 +27,7 @@ import { convertJSDocFormat } from "./ruleConverters/jsdoc-format";
 import { convertLabelPosition } from "./ruleConverters/label-position";
 import { convertLinebreakStyle } from "./ruleConverters/linebreak-style";
 import { convertMaxClassesPerFile } from "./ruleConverters/max-classes-per-file";
+import { convertMaxFuncBodyLength } from "./ruleConverters/max-func-body-length";
 import { convertMaxFileLineCount } from "./ruleConverters/max-file-line-count";
 import { convertMaxLineLength } from "./ruleConverters/max-line-length";
 import { convertMemberAccess } from "./ruleConverters/member-access";
@@ -276,6 +277,7 @@ export const ruleConverters = new Map([
     ["label-position", convertLabelPosition],
     ["linebreak-style", convertLinebreakStyle],
     ["max-classes-per-file", convertMaxClassesPerFile],
+    ["max-func-body-length", convertMaxFuncBodyLength],
     ["max-file-line-count", convertMaxFileLineCount],
     ["max-line-length", convertMaxLineLength],
     ["member-access", convertMemberAccess],

--- a/src/converters/lintConfigs/rules/ruleConverters/max-func-body-length.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/max-func-body-length.ts
@@ -1,0 +1,42 @@
+import { isNumber } from "lodash";
+
+import { RuleConverter } from "../ruleConverter";
+
+const parseExtras = (ruleArguments: any[]) => {
+    if (ruleArguments.length === 0) {
+        return {};
+    }
+
+    const [max] = ruleArguments;
+    if (typeof max === "number") {
+        return {
+            ruleArguments: [max],
+        }
+    }
+
+    const notices = [
+        "ESLint's max-statements rule only supports a single maximum function length."
+    ];
+
+    if (max["ignore-comments"]) {
+        notices.push("ESLint's max-statements rule does not have an option to ignore comments.")
+    }
+
+    return {
+        notices,
+        ruleArguments: [
+            Math.max(...Object.values(max as Record<string, number | string>).filter(isNumber)),
+        ]
+    }
+}
+
+export const convertMaxFuncBodyLength: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...parseExtras(tslintRule.ruleArguments),
+                ruleName: "max-statements",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/max-func-body-length.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/max-func-body-length.test.ts
@@ -1,0 +1,76 @@
+import { convertMaxFuncBodyLength } from "../max-func-body-length";
+
+describe(convertMaxFuncBodyLength, () => {
+    test("conversion without arguments", () => {
+        const result = convertMaxFuncBodyLength({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "max-statements",
+                },
+            ],
+        });
+    });
+
+    test("conversion with a max number", () => {
+        const result = convertMaxFuncBodyLength({
+            ruleArguments: [10],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [10],
+                    ruleName: "max-statements",
+                },
+            ],
+        });
+    });
+
+    test("conversion with a max object", () => {
+        const result = convertMaxFuncBodyLength({
+            ruleArguments: [{
+                "ctor-body-length": 15,
+                "func-body-length": 5,
+            }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [
+                        "ESLint's max-statements rule only supports a single maximum function length."
+                    ],
+                    ruleArguments: [15],
+                    ruleName: "max-statements",
+                },
+            ],
+        });
+    });
+
+    test("conversion with the ignore-comments option", () => {
+        const result = convertMaxFuncBodyLength({
+            ruleArguments: [{
+                "ctor-body-length": 15,
+                "func-body-length": 5,
+                "ignore-comments": true,
+            }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: [
+                        "ESLint's max-statements rule only supports a single maximum function length.",
+                        "ESLint's max-statements rule does not have an option to ignore comments."
+                    ],
+                    ruleArguments: [15],
+                    ruleName: "max-statements",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #867
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Per https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/ROADMAP.md, the equivalent rule is now `max-statements`. https://eslint.org/docs/rules/max-statements