### PR TITLE
Added converter for no-empty-line-after-opening-brace

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -56,6 +56,7 @@ import { convertNoDuplicateVariable } from "./ruleConverters/no-duplicate-variab
 import { convertNoDynamicDelete } from './ruleConverters/no-dynamic-delete';
 import { convertNoEmpty } from "./ruleConverters/no-empty";
 import { convertNoEmptyInterface } from "./ruleConverters/no-empty-interface";
+import { convertNoEmptyLineAfterOpeningBrace } from "./ruleConverters/no-empty-line-after-opening-brace";
 import { convertNoEval } from "./ruleConverters/no-eval";
 import { convertNoExplicitAny } from "./ruleConverters/no-explicit-any";
 import { convertNoFloatingPromises } from "./ruleConverters/no-floating-promises";
@@ -307,6 +308,7 @@ export const ruleConverters = new Map([
     ["no-duplicate-variable", convertNoDuplicateVariable],
     ["no-dynamic-delete", convertNoDynamicDelete],
     ["no-empty-interface", convertNoEmptyInterface],
+    ["no-empty-line-after-opening-brace", convertNoEmptyLineAfterOpeningBrace], // padded-blocks
     ["no-empty", convertNoEmpty],
     ["no-eval", convertNoEval],
     ["no-floating-promises", convertNoFloatingPromises],
@@ -463,7 +465,6 @@ export const ruleConverters = new Map([
 
     // tslint-microsoft-contrib rules:
     // ["max-func-body-length", convertMaxFuncBodyLength],
-    // ["no-empty-line-after-opening-brace", convertNoEmptyLineAfterOpeningBrace], // padded-blocks
     // ["no-function-expression", convertNoFunctionExpression], // ban-syntax config
     // ["no-suspicious-comment", convertNoSuspiciousComment],
     // ["no-with-statement", convertNoWithStatement],

--- a/src/converters/lintConfigs/rules/ruleConverters/no-empty-line-after-opening-brace.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/no-empty-line-after-opening-brace.ts
@@ -1,0 +1,20 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertNoEmptyLineAfterOpeningBrace: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                notices: ["ESLint's padded-blocks rule also bans a blank line before a closing brace."],
+                ruleArguments: [
+                    {
+                        blocks: "never",
+                    },
+                    {
+                        "allowSingleLineBlocks": true,
+                    }
+                ],
+                ruleName: "padded-blocks",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-line-after-opening-brace.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-line-after-opening-brace.test.ts
@@ -1,0 +1,26 @@
+import { convertNoEmptyLineAfterOpeningBrace } from "../no-empty-line-after-opening-brace";
+
+describe(convertNoEmptyLineAfterOpeningBrace, () => {
+    test("conversion ", () => {
+        const result = convertNoEmptyLineAfterOpeningBrace({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: ["ESLint's padded-blocks rule also bans a blank line before a closing brace."],
+                    ruleArguments: [
+                        {
+                            blocks: "never",
+                        },
+                        {
+                            "allowSingleLineBlocks": true,
+                        }
+                    ],
+                    ruleName: "padded-blocks",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #872
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://eslint.org/docs/rules/padded-blocks