### PR TITLE
Added converter for no-suspicious-comment

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -90,6 +90,7 @@ import { convertNoSparseArrays } from "./ruleConverters/no-sparse-arrays";
 import { convertNoStringLiteral } from "./ruleConverters/no-string-literal";
 import { convertNoStringThrow } from "./ruleConverters/no-string-throw";
 import { convertNoSubmoduleImports } from "./ruleConverters/no-submodule-imports";
+import { convertNoSuspiciousComment } from "./ruleConverters/no-suspicious-comment";
 import { convertNoSwitchCaseFallThrough } from "./ruleConverters/no-switch-case-fall-through";
 import { convertNoThisAssignment } from "./ruleConverters/no-this-assignment";
 import { convertNoTrailingWhitespace } from "./ruleConverters/no-trailing-whitespace";
@@ -354,6 +355,7 @@ export const ruleConverters = new Map([
     ["no-string-literal", convertNoStringLiteral],
     ["no-string-throw", convertNoStringThrow],
     ["no-submodule-imports", convertNoSubmoduleImports],
+    ["no-suspicious-comment", convertNoSuspiciousComment],
     ["no-switch-case-fall-through", convertNoSwitchCaseFallThrough],
     ["no-this-assignment", convertNoThisAssignment],
     ["no-trailing-whitespace", convertNoTrailingWhitespace],

--- a/src/converters/lintConfigs/rules/ruleConverters/no-suspicious-comment.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/no-suspicious-comment.ts
@@ -5,7 +5,7 @@ export const convertNoSuspiciousComment: RuleConverter = (tslintRule) => {
         rules: [
             {
                 ...(tslintRule.ruleArguments.length !== 0
-                    ? { notices: ["ESLint's no-warning-comments does not allow an array of terms to ignore."] }
+                    ? { notices: ["ESLint's no-warning-comments does not allow an array of terms to match."] }
                     : {}),
                 ruleArguments: [
                     {

--- a/src/converters/lintConfigs/rules/ruleConverters/no-suspicious-comment.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/no-suspicious-comment.ts
@@ -1,0 +1,20 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertNoSuspiciousComment: RuleConverter = (tslintRule) => {
+    return {
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0
+                    ? { notices: ["ESLint's no-warning-comments does not allow an array of terms to ignore."] }
+                    : {}),
+                ruleArguments: [
+                    {
+                        location: "anywhere",
+                        terms: ['BUG', 'HACK', 'FIXME', 'LATER', 'LATER2', 'TODO']
+                    }
+                ],
+                ruleName: "no-warning-comments",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-suspicious-comment.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-suspicious-comment.test.ts
@@ -29,7 +29,7 @@ describe(convertNoSuspiciousComment, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    notices: ["ESLint's no-warning-comments does not allow an array of terms to ignore."],
+                    notices: ["ESLint's no-warning-comments does not allow an array of terms to match."],
                     ruleArguments: [
                         {
                             location: "anywhere",

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-suspicious-comment.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-suspicious-comment.test.ts
@@ -1,0 +1,44 @@
+import { convertNoSuspiciousComment } from "../no-suspicious-comment";
+
+describe(convertNoSuspiciousComment, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoSuspiciousComment({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            location: "anywhere",
+                            terms: ['BUG', 'HACK', 'FIXME', 'LATER', 'LATER2', 'TODO']
+                        }
+                    ],
+                    ruleName: "no-warning-comments",
+                },
+            ],
+        });
+    });
+
+    test("conversion with terms argument", () => {
+        const result = convertNoSuspiciousComment({
+            ruleArguments: ["https://github.com/my-org/my-project/(.*)"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    notices: ["ESLint's no-warning-comments does not allow an array of terms to ignore."],
+                    ruleArguments: [
+                        {
+                            location: "anywhere",
+                            terms: ['BUG', 'HACK', 'FIXME', 'LATER', 'LATER2', 'TODO']
+                        }
+                    ],
+                    ruleName: "no-warning-comments",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #879
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://eslint.org/docs/rules/no-warning-comments