### PR TITLE
Added converter for no-with-statement 

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -106,6 +106,7 @@ import { convertNoUseBeforeDeclare } from "./ruleConverters/no-use-before-declar
 import { convertNoVarKeyword } from "./ruleConverters/no-var-keyword";
 import { convertNoVarRequires } from "./ruleConverters/no-var-requires";
 import { convertNoVoidExpression } from "./ruleConverters/no-void-expression";
+import { convertNoWithStatement } from "./ruleConverters/no-with-statement";
 import { convertObjectLiteralKeyQuotes } from "./ruleConverters/object-literal-key-quotes";
 import { convertObjectLiteralShorthand } from "./ruleConverters/object-literal-shorthand";
 import { convertOneLine } from "./ruleConverters/one-line";
@@ -370,6 +371,7 @@ export const ruleConverters = new Map([
     ["no-var-keyword", convertNoVarKeyword],
     ["no-var-requires", convertNoVarRequires],
     ["no-void-expression", convertNoVoidExpression],
+    ["no-with-statement", convertNoWithStatement],
     ["object-literal-key-quotes", convertObjectLiteralKeyQuotes],
     ["object-literal-shorthand", convertObjectLiteralShorthand],
     ["one-line", convertOneLine],
@@ -466,5 +468,4 @@ export const ruleConverters = new Map([
     // ["no-empty-line-after-opening-brace", convertNoEmptyLineAfterOpeningBrace], // padded-blocks
     // ["no-function-expression", convertNoFunctionExpression], // ban-syntax config
     // ["no-suspicious-comment", convertNoSuspiciousComment],
-    // ["no-with-statement", convertNoWithStatement],
 ]);

--- a/src/converters/lintConfigs/rules/ruleConverters/no-with-statement.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/no-with-statement.ts
@@ -1,0 +1,11 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertNoWithStatement: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "no-with",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-with-statement.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-with-statement.test.ts
@@ -1,0 +1,17 @@
+import { convertNoWithStatement } from "../no-with-statement";
+
+describe(convertNoWithStatement, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoWithStatement({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "no-with",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #882
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://eslint.org/docs/rules/no-with