### PR TITLE
Added converter for underscore-consistent-invocation

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -135,6 +135,7 @@ import { convertTripleEquals } from "./ruleConverters/triple-equals";
 import { convertTypedefWhitespace } from "./ruleConverters/typedef-whitespace";
 import { convertTypeLiteralDelimiter } from "./ruleConverters/type-literal-delimiter";
 import { convertTypeofCompare } from "./ruleConverters/typeof-compare";
+import { convertUnderscoreConsistentInvocation } from "./ruleConverters/underscore-consistent-invocation";
 import { convertUnifiedSignatures } from "./ruleConverters/unified-signatures";
 import { convertUnnecessaryBind } from "./ruleConverters/unnecessary-bind";
 import { convertUnnecessaryConstructor } from "./ruleConverters/unnecessary-constructor";
@@ -421,6 +422,7 @@ export const ruleConverters = new Map([
     ["type-literal-delimiter", convertTypeLiteralDelimiter],
     ["typedef-whitespace", convertTypedefWhitespace],
     ["typeof-compare", convertTypeofCompare],
+    ["underscore-consistent-invocation", convertUnderscoreConsistentInvocation],
     ["unified-signatures", convertUnifiedSignatures],
     ["unnecessary-bind", convertUnnecessaryBind],
     ["unnecessary-constructor", convertUnnecessaryConstructor],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/underscore-consistent-invocation.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/underscore-consistent-invocation.test.ts
@@ -1,0 +1,51 @@
+import { convertUnderscoreConsistentInvocation } from "../underscore-consistent-invocation";
+
+describe(convertUnderscoreConsistentInvocation, () => {
+    test("conversion without arguments", () => {
+        const result = convertUnderscoreConsistentInvocation({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-lodash"],
+            rules: [
+                {
+                    ruleArguments: ['never', 0],
+                    ruleName: "lodash/chaining",
+                },
+            ],
+        });
+    });
+
+    test("conversion with an instance argument", () => {
+        const result = convertUnderscoreConsistentInvocation({
+            ruleArguments: ['instance'],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-lodash"],
+            rules: [
+                {
+                    ruleArguments: ['never', 0],
+                    ruleName: "lodash/chaining",
+                },
+            ],
+        });
+    });
+
+    test("conversion with a static argument", () => {
+        const result = convertUnderscoreConsistentInvocation({
+            ruleArguments: ['static'],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-lodash"],
+            rules: [
+                {
+                    ruleArguments: ['always', 0],
+                    ruleName: "lodash/chaining",
+                },
+            ],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/underscore-consistent-invocation.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/underscore-consistent-invocation.test.ts
@@ -10,7 +10,7 @@ describe(convertUnderscoreConsistentInvocation, () => {
             plugins: ["eslint-plugin-lodash"],
             rules: [
                 {
-                    ruleArguments: ['never', 0],
+                    ruleArguments: ['never'],
                     ruleName: "lodash/chaining",
                 },
             ],
@@ -26,7 +26,7 @@ describe(convertUnderscoreConsistentInvocation, () => {
             plugins: ["eslint-plugin-lodash"],
             rules: [
                 {
-                    ruleArguments: ['never', 0],
+                    ruleArguments: ['never'],
                     ruleName: "lodash/chaining",
                 },
             ],

--- a/src/converters/lintConfigs/rules/ruleConverters/underscore-consistent-invocation.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/underscore-consistent-invocation.ts
@@ -5,10 +5,9 @@ export const convertUnderscoreConsistentInvocation: RuleConverter = (tslintRule)
         plugins: ["eslint-plugin-lodash"],
         rules: [
             {
-                ruleArguments: [
-                    tslintRule.ruleArguments.length === 0 || tslintRule.ruleArguments[0] === 'instance' ? 'never' : 'always',
-                    0,
-                ],
+                ruleArguments: tslintRule.ruleArguments.length === 0 || tslintRule.ruleArguments[0] === 'instance'
+                    ? ['never']
+                    : ['always', 0],
                 ruleName: "lodash/chaining",
             },
         ],

--- a/src/converters/lintConfigs/rules/ruleConverters/underscore-consistent-invocation.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/underscore-consistent-invocation.ts
@@ -1,0 +1,16 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertUnderscoreConsistentInvocation: RuleConverter = (tslintRule) => {
+    return {
+        plugins: ["eslint-plugin-lodash"],
+        rules: [
+            {
+                ruleArguments: [
+                    tslintRule.ruleArguments.length === 0 || tslintRule.ruleArguments[0] === 'instance' ? 'never' : 'always',
+                    0,
+                ],
+                ruleName: "lodash/chaining",
+            },
+        ],
+    };
+};


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #883
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/chaining.md