### PR TITLE
Added converter for mon-literal-require

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -73,6 +73,7 @@ import { convertNoMagicNumbers } from "./ruleConverters/no-magic-numbers";
 import { convertNoMisusedNew } from "./ruleConverters/no-misused-new";
 import { convertNoMultilineString } from "./ruleConverters/no-multiline-string";
 import { convertNoNamespace } from "./ruleConverters/no-namespace";
+import { convertNonLiteralRequire } from "./ruleConverters/non-literal-require";
 import { convertNoNonNullAssertion } from "./ruleConverters/no-non-null-assertion";
 import { convertNoNullKeyword } from "./ruleConverters/no-null-keyword";
 import { convertNoObjectLiteralTypeAssertion } from "./ruleConverters/no-object-literal-type-assertion";
@@ -330,6 +331,7 @@ export const ruleConverters = new Map([
     ["no-misused-new", convertNoMisusedNew],
     ["no-multiline-string", convertNoMultilineString],
     ["no-namespace", convertNoNamespace],
+    ["non-literal-require", convertNonLiteralRequire],
     ["no-non-null-assertion", convertNoNonNullAssertion],
     ["no-null-keyword", convertNoNullKeyword],
     ["no-object-literal-type-assertion", convertNoObjectLiteralTypeAssertion],

--- a/src/converters/lintConfigs/rules/ruleConverters/non-literal-require.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/non-literal-require.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertNonLiteralRequire: RuleConverter = () => {
+    return {
+        plugins: ["eslint-plugin-security"],
+        rules: [
+            {
+                ruleName: "security/detect-non-literal-require",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/non-literal-require.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/non-literal-require.test.ts
@@ -1,0 +1,18 @@
+import { convertNonLiteralRequire } from "../non-literal-require";
+
+describe(convertNonLiteralRequire, () => {
+    test("conversion without arguments", () => {
+        const result = convertNonLiteralRequire({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-security"],
+            rules: [
+                {
+                    ruleName: "security/detect-non-literal-require",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #887
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/nodesecurity/eslint-plugin-security#detect-non-literal-require