### PR TITLE
Added converter for non-literal-fs-path

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -73,6 +73,7 @@ import { convertNoMagicNumbers } from "./ruleConverters/no-magic-numbers";
 import { convertNoMisusedNew } from "./ruleConverters/no-misused-new";
 import { convertNoMultilineString } from "./ruleConverters/no-multiline-string";
 import { convertNoNamespace } from "./ruleConverters/no-namespace";
+import { convertNonLiteralFsPath } from "./ruleConverters/non-literal-fs-path";
 import { convertNoNonNullAssertion } from "./ruleConverters/no-non-null-assertion";
 import { convertNoNullKeyword } from "./ruleConverters/no-null-keyword";
 import { convertNoObjectLiteralTypeAssertion } from "./ruleConverters/no-object-literal-type-assertion";
@@ -330,6 +331,7 @@ export const ruleConverters = new Map([
     ["no-misused-new", convertNoMisusedNew],
     ["no-multiline-string", convertNoMultilineString],
     ["no-namespace", convertNoNamespace],
+    ["non-literal-fs-path", convertNonLiteralFsPath],
     ["no-non-null-assertion", convertNoNonNullAssertion],
     ["no-null-keyword", convertNoNullKeyword],
     ["no-object-literal-type-assertion", convertNoObjectLiteralTypeAssertion],

--- a/src/converters/lintConfigs/rules/ruleConverters/non-literal-fs-path.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/non-literal-fs-path.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertNonLiteralFsPath: RuleConverter = () => {
+    return {
+        plugins: ["eslint-plugin-security"],
+        rules: [
+            {
+                ruleName: "security/detect-non-literal-fs-filename",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/non-literal-fs-path.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/non-literal-fs-path.test.ts
@@ -1,0 +1,18 @@
+import { convertNonLiteralFsPath } from "../non-literal-fs-path";
+
+describe(convertNonLiteralFsPath, () => {
+    test("conversion without arguments", () => {
+        const result = convertNonLiteralFsPath({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-security"],
+            rules: [
+                {
+                    ruleName: "security/detect-non-literal-fs-filename",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #886
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/nodesecurity/eslint-plugin-security#detect-non-literal-fs-filename