### PR TITLE
Added converter for possible-timing-attack

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -112,6 +112,7 @@ import { convertOneLine } from "./ruleConverters/one-line";
 import { convertOneVariablePerDeclaration } from "./ruleConverters/one-variable-per-declaration";
 import { convertOnlyArrowFunctions } from "./ruleConverters/only-arrow-functions";
 import { convertOrderedImports } from "./ruleConverters/ordered-imports";
+import { convertPossibleTimingAttack } from "./ruleConverters/possible-timing-attack";
 import { convertPreferArrayLiteral } from "./ruleConverters/prefer-array-literal";
 import { convertPreferConditionalExpression } from "./ruleConverters/prefer-conditional-expression";
 import { convertPreferConst } from "./ruleConverters/prefer-const";
@@ -377,6 +378,7 @@ export const ruleConverters = new Map([
     ["only-arrow-functions", convertOnlyArrowFunctions],
     ["ordered-imports", convertOrderedImports],
     ["pipe-prefix", convertPipePrefix],
+    ["possible-timing-attack", convertPossibleTimingAttack],
     ["prefer-array-literal", convertPreferArrayLiteral],
     ["prefer-conditional-expression", convertPreferConditionalExpression],
     ["prefer-const", convertPreferConst],

--- a/src/converters/lintConfigs/rules/ruleConverters/possible-timing-attack.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/possible-timing-attack.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertPossibleTimingAttack: RuleConverter = () => {
+    return {
+        plugins: ["eslint-plugin-security"],
+        rules: [
+            {
+                ruleName: "security/detect-possible-timing-attacks",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/possible-timing-attacks.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/possible-timing-attacks.test.ts
@@ -1,0 +1,18 @@
+import { convertPossibleTimingAttack } from "../possible-timing-attack";
+
+describe(convertPossibleTimingAttack, () => {
+    test("conversion without arguments", () => {
+        const result = convertPossibleTimingAttack({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-security"],
+            rules: [
+                {
+                    ruleName: "security/detect-possible-timing-attacks",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #888
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/nodesecurity/eslint-plugin-security#detect-possible-timing-attacks