### PR TITLE
Added converter for no-exec-script

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -57,6 +57,7 @@ import { convertNoDynamicDelete } from './ruleConverters/no-dynamic-delete';
 import { convertNoEmpty } from "./ruleConverters/no-empty";
 import { convertNoEmptyInterface } from "./ruleConverters/no-empty-interface";
 import { convertNoEval } from "./ruleConverters/no-eval";
+import { convertNoExecScript } from "./ruleConverters/no-exec-script";
 import { convertNoExplicitAny } from "./ruleConverters/no-explicit-any";
 import { convertNoFloatingPromises } from "./ruleConverters/no-floating-promises";
 import { convertNoForIn } from "./ruleConverters/no-for-in";
@@ -308,6 +309,7 @@ export const ruleConverters = new Map([
     ["no-dynamic-delete", convertNoDynamicDelete],
     ["no-empty-interface", convertNoEmptyInterface],
     ["no-empty", convertNoEmpty],
+    ["no-exec-script", convertNoExecScript],
     ["no-eval", convertNoEval],
     ["no-floating-promises", convertNoFloatingPromises],
     ["no-for-in-array", convertNoForInArray],

--- a/src/converters/lintConfigs/rules/ruleConverters/no-exec-script.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/no-exec-script.ts
@@ -1,0 +1,17 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertNoExecScript: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleArguments: [
+                    {
+                        message: "Forbidden call to execScript",
+                        selector: 'CallExpression[callee.name="execScript"]',
+                    }
+                ],
+                ruleName: "restricted-syntax",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-exec-script.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-exec-script.test.ts
@@ -1,0 +1,23 @@
+import { convertNoExecScript } from "../no-exec-script";
+
+describe(convertNoExecScript, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoExecScript({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            message: "Forbidden call to execScript",
+                            selector: 'CallExpression[callee.name="execScript"]',
+                        }
+                    ],
+                    ruleName: "restricted-syntax",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #891
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/ROADMAP.md#security