### PR TITLE
Added rule converter for react-a11y-anchors

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -129,6 +129,7 @@ import { convertPreferTemplate } from "./ruleConverters/prefer-template";
 import { convertPromiseFunctionAsync } from "./ruleConverters/promise-function-async";
 import { convertQuotemark } from "./ruleConverters/quotemark";
 import { convertRadix } from "./ruleConverters/radix";
+import { convertReactA11yAnchors } from "./ruleConverters/react-a11y-anchors";
 import { convertRestrictPlusOperands } from "./ruleConverters/restrict-plus-operands";
 import { convertSemicolon } from "./ruleConverters/semicolon";
 import { convertSpaceBeforeFunctionParen } from "./ruleConverters/space-before-function-paren";
@@ -403,6 +404,7 @@ export const ruleConverters = new Map([
     ["quotemark", convertQuotemark],
     ["radix", convertRadix],
     ["relative-url-prefix", convertRelativeUrlPrefix],
+    ["react-a11y-anchors", convertReactA11yAnchors],
     ["restrict-plus-operands", convertRestrictPlusOperands],
     ["semicolon", convertSemicolon],
     ["space-before-function-paren", convertSpaceBeforeFunctionParen],

--- a/src/converters/lintConfigs/rules/ruleConverters/react-a11y-anchors.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/react-a11y-anchors.ts
@@ -1,0 +1,15 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertReactA11yAnchors: RuleConverter = (tslintRule) => {
+    return {
+        ...(tslintRule.ruleArguments.length > 0 && ({
+            notices: Object.keys(tslintRule.ruleArguments[0] as Record<string, unknown>).map(key => `jsx-a11y/anchor-is-valid does not support the '${key}' option.`)
+        })),
+        plugins: ["jsx-a11y"],
+        rules: [
+            {
+                ruleName: "jsx-a11y/anchor-is-valid",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-anchors.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-anchors.test.ts
@@ -1,0 +1,40 @@
+import { convertReactA11yAnchors } from "../react-a11y-anchors";
+
+describe(convertReactA11yAnchors, () => {
+    test("conversion without arguments", () => {
+        const result = convertReactA11yAnchors({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            plugins: ["jsx-a11y"],
+            rules: [
+                {
+                    ruleName: "jsx-a11y/anchor-is-valid",
+                },
+            ],
+        });
+    });
+
+    test("conversion with arguments", () => {
+        const result = convertReactA11yAnchors({
+            ruleArguments: [{
+                'ignore-case': true,
+                'ignore-whitespace': 'trim'
+            }],
+        });
+
+        expect(result).toEqual({
+            notices: [
+                `jsx-a11y/anchor-is-valid does not support the 'ignore-case' option.`,
+                `jsx-a11y/anchor-is-valid does not support the 'ignore-whitespace' option.`
+            ],
+            plugins: ["jsx-a11y"],
+            rules: [
+                {
+                    ruleName: "jsx-a11y/anchor-is-valid",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #907
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md