### PR TITLE
Do not use merger if arguments are the same.

### DIFF
--- a/docs/Architecture/Linters.md
+++ b/docs/Architecture/Linters.md
@@ -52,6 +52,8 @@ These are located in `src/rules/mergers/`, and keyed under their names by the ma
 
 For example, `@typescript-eslint/ban-types` spreads both arguments' `types` members into one large `types` object.
 
+**A merger does not need to be created if the rule does not accept any configuration.**
+
 ## Package Summaries
 
 ESLint configurations are summarized based on extended ESLint and TSLint presets.

--- a/docs/Architecture/Linters.md
+++ b/docs/Architecture/Linters.md
@@ -52,7 +52,7 @@ These are located in `src/rules/mergers/`, and keyed under their names by the ma
 
 For example, `@typescript-eslint/ban-types` spreads both arguments' `types` members into one large `types` object.
 
-> A merger does not need to be created if the rule does not accept any configuration.
+> A merger does not need to be created if the rule does not accept any configuration or all converters output exactly the same configuration.
 
 ## Package Summaries
 

--- a/docs/Architecture/Linters.md
+++ b/docs/Architecture/Linters.md
@@ -52,7 +52,7 @@ These are located in `src/rules/mergers/`, and keyed under their names by the ma
 
 For example, `@typescript-eslint/ban-types` spreads both arguments' `types` members into one large `types` object.
 
-**A merger does not need to be created if the rule does not accept any configuration.**
+> A merger does not need to be created if the rule does not accept any configuration.
 
 ## Package Summaries
 

--- a/docs/Architecture/Linters.md
+++ b/docs/Architecture/Linters.md
@@ -23,6 +23,8 @@ Those are run by `src/converters/lintConfigs/rules/convertRules.ts`, which takes
     * The output rule name is added to the TSLint rule's equivalency set.
     * The TSLint rule's config severity is mapped to its ESLint equivalent.
     * If this is the first time the output ESLint rule is seen, it's directly marked as converted.
+    * Notices are merged and deduplicated.
+    * If the existing output has the same arguments as the new output, merge lookups are skipped.
     * If not, a rule merger is run to combine it with its existing output settings.
 
 ### Rule Converters

--- a/src/converters/lintConfigs/rules/convertRules.ts
+++ b/src/converters/lintConfigs/rules/convertRules.ts
@@ -9,7 +9,7 @@ import { formatRawTslintRule } from "./formats/formatRawTslintRule";
 import { RuleMerger } from "./ruleMerger";
 import { RuleConverter } from "./ruleConverter";
 import { TSLintRuleOptions, ESLintRuleOptions } from "./types";
-import { Entries } from "../../../utils";
+import { Entries, uniqueFromSources } from "../../../utils";
 
 export type ConvertRulesDependencies = {
     ruleConverters: Map<string, RuleConverter>;
@@ -80,8 +80,11 @@ export const convertRules = (
                     continue;
                 }
 
-                // 4d. First it merges the notices, since that is always needed.
-                existingConversion.notices = mergeNotices(existingConversion, newConversion);
+                // 4d. First it deduplicates and merges notices.
+                existingConversion.notices = uniqueFromSources(
+                    existingConversion.notices,
+                    newConversion.notices,
+                );
                 converted.set(changes.ruleName, existingConversion);
 
                 // 4e. If the existing output has the same arguments as the new output don't bother with a merger.
@@ -116,10 +119,3 @@ export const convertRules = (
 
     return { converted, failed, missing, plugins, ruleEquivalents };
 };
-
-function mergeNotices(existingConversion: ESLintRuleOptions, newConversion: ESLintRuleOptions) {
-    const existingNotices = existingConversion.notices ?? [];
-    const newNotices = newConversion.notices ?? [];
-
-    return Array.from(new Set([...existingNotices, ...newNotices]));
-}

--- a/src/converters/lintConfigs/rules/convertRules.ts
+++ b/src/converters/lintConfigs/rules/convertRules.ts
@@ -80,14 +80,14 @@ export const convertRules = (
                     continue;
                 }
 
-                // 4d. First it deduplicates and merges notices.
+                // 4d. Notices are merged and deduplicated.
                 existingConversion.notices = uniqueFromSources(
                     existingConversion.notices,
                     newConversion.notices,
                 );
                 converted.set(changes.ruleName, existingConversion);
 
-                // 4e. If the existing output has the same arguments as the new output don't bother with a merger.
+                // 4e. If the existing output has the same arguments as the new output, merge lookups are skipped.
                 if (isEqual(existingConversion.ruleArguments, newConversion.ruleArguments)) {
                     continue;
                 }

--- a/src/converters/lintConfigs/rules/ruleMergers.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers.ts
@@ -2,7 +2,6 @@ import { mergeBanTypes } from "./ruleMergers/ban-types";
 import { mergeConsistentTypeAssertions } from "./ruleMergers/consistent-type-assertions";
 import { mergeIndent } from "./ruleMergers/indent";
 import { mergeNamingConvention } from "./ruleMergers/naming-convention";
-import { mergeNoCaller } from "./ruleMergers/no-caller";
 import { mergeNoEval } from "./ruleMergers/no-eval";
 import { mergeNoMemberDelimiterStyle } from "./ruleMergers/member-delimiter-style";
 import { mergeNoUnnecessaryTypeAssertion } from "./ruleMergers/no-unnecessary-type-assertion";
@@ -16,6 +15,5 @@ export const ruleMergers = new Map([
     ["@typescript-eslint/naming-convention", mergeNamingConvention],
     ["@typescript-eslint/no-unnecessary-type-assertion", mergeNoUnnecessaryTypeAssertion],
     ["@typescript-eslint/triple-slash-reference", mergeTripleSlashReference],
-    ["no-caller", mergeNoCaller],
     ["no-eval", mergeNoEval],
 ]);

--- a/src/converters/lintConfigs/rules/ruleMergers/eslint-plugin-react/jsx-no-bind.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/eslint-plugin-react/jsx-no-bind.ts
@@ -1,5 +1,0 @@
-import { RuleMerger } from "../../ruleMerger";
-
-export const mergeJsxNoBind: RuleMerger = () => {
-    return []; // jsx-no-bind rule does not accept any options
-};

--- a/src/converters/lintConfigs/rules/ruleMergers/eslint-plugin-react/tests/jsx-no-bind.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/eslint-plugin-react/tests/jsx-no-bind.test.ts
@@ -1,9 +1,0 @@
-import { mergeJsxNoBind } from "../jsx-no-bind";
-
-describe(mergeJsxNoBind, () => {
-    test("neither options existing", () => {
-        const result = mergeJsxNoBind(undefined, undefined);
-
-        expect(result).toEqual([]);
-    });
-});

--- a/src/converters/lintConfigs/rules/ruleMergers/no-caller.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/no-caller.ts
@@ -1,6 +1,0 @@
-import { RuleMerger } from "../ruleMerger";
-
-export const mergeNoCaller: RuleMerger = () => {
-    // no-caller rule does not accept any options
-    return [];
-};

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/no-caller.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/no-caller.test.ts
@@ -1,9 +1,0 @@
-import { mergeNoCaller } from "../no-caller";
-
-describe(mergeNoCaller, () => {
-    test("neither options existing", () => {
-        const result = mergeNoCaller(undefined, undefined);
-
-        expect(result).toEqual([]);
-    });
-});


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [X] Addresses an existing issue: fixes #1086
-   [X] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Do not use merger if arguments are the same.

Also this adds a new feature: creating a merger is not needed if there are no configuration options for the rule.

Removed unneeded mergers (for rules with no configuration options).
