### PR TITLE
Fix tsc complaint in runCli.ts

### DIFF
--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -42,6 +42,7 @@ export const runCli = async (
 
     const parsedArgv = {
         config: "./.eslintrc.js",
+        // eslint-disable-next-line -- this gets deduced as the same type, for some erroneous reason
         ...(command.parse(rawArgv).opts() as Partial<TSLintToESLintSettings>),
     } as TSLintToESLintSettings;
 

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -42,7 +42,7 @@ export const runCli = async (
 
     const parsedArgv = {
         config: "./.eslintrc.js",
-        ...command.parse(rawArgv).opts(),
+        ...(command.parse(rawArgv).opts() as Partial<TSLintToESLintSettings>),
     } as TSLintToESLintSettings;
 
     // 2. If the version should be printed, we do that and stop execution.


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1130
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://app.circleci.com/pipelines/github/typescript-eslint/tslint-to-eslint-config/2131/workflows/941c2781-b0f2-4250-b680-4a6187e4a948/jobs/10958

```
> tsc

src/cli/runCli.ts:44:9 - error TS2783: 'config' is specified more than once, so this usage will be overwritten.

44         config: "./.eslintrc.js",
           ~~~~~~~~~~~~~~~~~~~~~~~~

  src/cli/runCli.ts:45:9
    45         ...command.parse(rawArgv).opts(),
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    This spread always overwrites this property.

```
