### PR TITLE
Added converter for react-a11y-tabindex-no-positive

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -253,6 +253,7 @@ import { convertQuotemark } from "./ruleConverters/quotemark";
 import { convertRadix } from "./ruleConverters/radix";
 import { convertReactA11yAccessibleHeadings } from "./ruleConverters/react-a11y-accessible-headings";
 import { convertReactA11yAnchors } from "./ruleConverters/react-a11y-anchors";
+import { convertReactA11yTabIndexNoPositive } from "./ruleConverters/react-a11y-tabindex-no-positive";
 import { convertReactNoDangerousHtml } from "./ruleConverters/react-no-dangerous-html";
 import { convertReactTsxCurlySpacing } from "./ruleConverters/react-tsx-curly-spacing";
 import { convertRestrictPlusOperands } from "./ruleConverters/restrict-plus-operands";
@@ -488,6 +489,7 @@ export const ruleConverters = new Map([
     ["quotemark", convertQuotemark],
     ["radix", convertRadix],
     ["react-a11y-anchors", convertReactA11yAnchors],
+    ["react-a11y-tabindex-no-positive", convertReactA11yTabIndexNoPositive],
     ["react-no-dangerous-html", convertReactNoDangerousHtml],
     ["react-tsx-curly-spacing", convertReactTsxCurlySpacing],
     ["relative-url-prefix", convertRelativeUrlPrefix],

--- a/src/converters/lintConfigs/rules/ruleConverters/react-a11y-tabindex-no-positive.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/react-a11y-tabindex-no-positive.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertReactA11yTabIndexNoPositive: RuleConverter = () => {
+    return {
+        plugins: ["jsx-a11y"],
+        rules: [
+            {
+                ruleName: "jsx-a11y/tabindex-no-positive",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-tabindex-no-positive.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-tabindex-no-positive.test.ts
@@ -1,0 +1,18 @@
+import { convertReactA11yTabIndexNoPositive } from "../react-a11y-tabindex-no-positive";
+
+describe(convertReactA11yTabIndexNoPositive, () => {
+    test("conversion without arguments", () => {
+        const result = convertReactA11yTabIndexNoPositive({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            plugins: ["jsx-a11y"],
+            rules: [
+                {
+                    ruleName: "jsx-a11y/tabindex-no-positive",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #895
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/tabindex-no-positive.md