### PR TITLE
Fix import path in rewriteConvertersMap.js

### DIFF
--- a/script/newConverter/rewriteConvertersMap.js
+++ b/script/newConverter/rewriteConvertersMap.js
@@ -1,6 +1,5 @@
 const { promises: fs } = require("fs");
-const { EOL } = require("node:os");
-const path = require("path");
+const { EOL } = require("os");
 
 const filePath = "./src/converters/lintConfigs/rules/ruleConverters.ts";
 


### PR DESCRIPTION
Noticed this while using the script: it's `require('os')`, not `require('node:os')`. Also the `path` import is unused.