### PR TITLE
Manually correct 'a11y' in newConverter script

### DIFF
--- a/script/newConverter/index.js
+++ b/script/newConverter/index.js
@@ -19,7 +19,7 @@ const { writeConverterTest } = require("./writeConverterTest");
         }
     }
 
-    const tslintPascalCase = upperFirst(camelCase(args.tslint));
+    const tslintPascalCase = upperFirst(camelCase(args.tslint)).replace("A11Y", "A11y");
     const plugins = args.eslint.includes("/")
         ? `
         plugins: ["${args.eslint.split("/")[0]}"],`


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1138
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Adds a simple `.replace` call. 