### PR TITLE
Added converter for react-a11y-role-has-required-aria-props

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -253,6 +253,7 @@ import { convertQuotemark } from "./ruleConverters/quotemark";
 import { convertRadix } from "./ruleConverters/radix";
 import { convertReactA11yAccessibleHeadings } from "./ruleConverters/react-a11y-accessible-headings";
 import { convertReactA11yAnchors } from "./ruleConverters/react-a11y-anchors";
+import { convertReactA11yRoleHasRequiredAriaProps } from "./ruleConverters/react-a11y-role-has-required-aria-props";
 import { convertReactNoDangerousHtml } from "./ruleConverters/react-no-dangerous-html";
 import { convertReactTsxCurlySpacing } from "./ruleConverters/react-tsx-curly-spacing";
 import { convertRestrictPlusOperands } from "./ruleConverters/restrict-plus-operands";
@@ -488,6 +489,7 @@ export const ruleConverters = new Map([
     ["quotemark", convertQuotemark],
     ["radix", convertRadix],
     ["react-a11y-anchors", convertReactA11yAnchors],
+    ["react-a11y-role-has-required-aria-props", convertReactA11yRoleHasRequiredAriaProps],
     ["react-no-dangerous-html", convertReactNoDangerousHtml],
     ["react-tsx-curly-spacing", convertReactTsxCurlySpacing],
     ["relative-url-prefix", convertRelativeUrlPrefix],

--- a/src/converters/lintConfigs/rules/ruleConverters/react-a11y-role-has-required-aria-props.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/react-a11y-role-has-required-aria-props.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertReactA11yRoleHasRequiredAriaProps: RuleConverter = () => {
+    return {
+        plugins: ["jsx-a11y"],
+        rules: [
+            {
+                ruleName: "jsx-a11y/role-has-required-aria-props",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-role-has-required-aria-props.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-role-has-required-aria-props.test.ts
@@ -1,0 +1,18 @@
+import { convertReactA11yRoleHasRequiredAriaProps } from "../react-a11y-role-has-required-aria-props";
+
+describe(convertReactA11yRoleHasRequiredAriaProps, () => {
+    test("conversion without arguments", () => {
+        const result = convertReactA11yRoleHasRequiredAriaProps({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            plugins: ["jsx-a11y"],
+            rules: [
+                {
+                    ruleName: "jsx-a11y/role-has-required-aria-props",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #000
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-has-required-aria-props.md
