### PR TITLE
Added converter for react-a11y-image-button-has-alt, react-a11y-img-has-alt

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -253,6 +253,7 @@ import { convertQuotemark } from "./ruleConverters/quotemark";
 import { convertRadix } from "./ruleConverters/radix";
 import { convertReactA11yAccessibleHeadings } from "./ruleConverters/react-a11y-accessible-headings";
 import { convertReactA11yAnchors } from "./ruleConverters/react-a11y-anchors";
+import { convertReactA11yImageButtonHasAlt } from "./ruleConverters/react-a11y-image-button-has-alt";
 import { convertReactA11yImgHasAlt } from "./ruleConverters/react-a11y-img-has-alt";
 import { convertReactNoDangerousHtml } from "./ruleConverters/react-no-dangerous-html";
 import { convertReactTsxCurlySpacing } from "./ruleConverters/react-tsx-curly-spacing";
@@ -489,6 +490,7 @@ export const ruleConverters = new Map([
     ["quotemark", convertQuotemark],
     ["radix", convertRadix],
     ["react-a11y-anchors", convertReactA11yAnchors],
+    ["react-a11y-image-button-has-alt", convertReactA11yImageButtonHasAlt],
     ["react-a11y-img-has-alt", convertReactA11yImgHasAlt],
     ["react-no-dangerous-html", convertReactNoDangerousHtml],
     ["react-tsx-curly-spacing", convertReactTsxCurlySpacing],

--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -253,6 +253,7 @@ import { convertQuotemark } from "./ruleConverters/quotemark";
 import { convertRadix } from "./ruleConverters/radix";
 import { convertReactA11yAccessibleHeadings } from "./ruleConverters/react-a11y-accessible-headings";
 import { convertReactA11yAnchors } from "./ruleConverters/react-a11y-anchors";
+import { convertReactA11yImgHasAlt } from "./ruleConverters/react-a11y-img-has-alt";
 import { convertReactNoDangerousHtml } from "./ruleConverters/react-no-dangerous-html";
 import { convertReactTsxCurlySpacing } from "./ruleConverters/react-tsx-curly-spacing";
 import { convertRestrictPlusOperands } from "./ruleConverters/restrict-plus-operands";
@@ -488,6 +489,7 @@ export const ruleConverters = new Map([
     ["quotemark", convertQuotemark],
     ["radix", convertRadix],
     ["react-a11y-anchors", convertReactA11yAnchors],
+    ["react-a11y-img-has-alt", convertReactA11yImgHasAlt],
     ["react-no-dangerous-html", convertReactNoDangerousHtml],
     ["react-tsx-curly-spacing", convertReactTsxCurlySpacing],
     ["relative-url-prefix", convertRelativeUrlPrefix],

--- a/src/converters/lintConfigs/rules/ruleConverters/react-a11y-image-button-has-alt.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/react-a11y-image-button-has-alt.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertReactA11yImageButtonHasAlt: RuleConverter = () => {
+    return {
+        notices: ["jsx-a11y/alt-text covers more cases than react-a11y-image-button-has-alt"],
+        plugins: ["jsx-a11y"],
+        rules: [
+            {
+                ruleName: "jsx-a11y/alt-text",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/react-a11y-img-has-alt.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/react-a11y-img-has-alt.ts
@@ -1,0 +1,19 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertReactA11yImgHasAlt: RuleConverter = (tslintRule) => {
+    return {
+        plugins: ["jsx-a11y"],
+        rules: [
+            {
+                ...(tslintRule.ruleArguments.length !== 0 && {
+                    ruleArguments: [
+                        {
+                            elements: tslintRule.ruleArguments,
+                        },
+                    ],
+                }),
+                ruleName: "jsx-a11y/alt-text",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/react-a11y-img-has-alt.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/react-a11y-img-has-alt.ts
@@ -2,6 +2,7 @@ import { RuleConverter } from "../ruleConverter";
 
 export const convertReactA11yImgHasAlt: RuleConverter = (tslintRule) => {
     return {
+        notices: ["jsx-a11y/alt-text covers more cases than react-a11y-img-has-alt"],
         plugins: ["jsx-a11y"],
         rules: [
             {

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-image-button-has-alt.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-image-button-has-alt.test.ts
@@ -1,0 +1,19 @@
+import { convertReactA11yImageButtonHasAlt } from "../react-a11y-image-button-has-alt";
+
+describe(convertReactA11yImageButtonHasAlt, () => {
+    test("conversion without arguments", () => {
+        const result = convertReactA11yImageButtonHasAlt({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            notices: ["jsx-a11y/alt-text covers more cases than react-a11y-image-button-has-alt"],
+            plugins: ["jsx-a11y"],
+            rules: [
+                {
+                    ruleName: "jsx-a11y/alt-text",
+                },
+            ],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-img-has-alt.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-img-has-alt.test.ts
@@ -7,6 +7,7 @@ describe(convertReactA11yImgHasAlt, () => {
         });
 
         expect(result).toEqual({
+            notices: ["jsx-a11y/alt-text covers more cases than react-a11y-img-has-alt"],
             plugins: ["jsx-a11y"],
             rules: [
                 {
@@ -23,6 +24,7 @@ describe(convertReactA11yImgHasAlt, () => {
         });
 
         expect(result).toEqual({
+            notices: ["jsx-a11y/alt-text covers more cases than react-a11y-img-has-alt"],
             plugins: ["jsx-a11y"],
             rules: [
                 {

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-img-has-alt.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-img-has-alt.test.ts
@@ -1,0 +1,35 @@
+import { convertReactA11yImgHasAlt } from "../react-a11y-img-has-alt";
+
+describe(convertReactA11yImgHasAlt, () => {
+    test("conversion without arguments", () => {
+        const result = convertReactA11yImgHasAlt({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            plugins: ["jsx-a11y"],
+            rules: [
+                {
+                    ruleName: "jsx-a11y/alt-text",
+                },
+            ],
+        });
+    });
+
+    test("conversion with an argument", () => {
+        const elements = ["Image"];
+        const result = convertReactA11yImgHasAlt({
+            ruleArguments: elements,
+        });
+
+        expect(result).toEqual({
+            plugins: ["jsx-a11y"],
+            rules: [
+                {
+                    ruleArguments: [{ elements }],
+                    ruleName: "jsx-a11y/alt-text",
+                },
+            ],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleMergers.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers.ts
@@ -1,6 +1,7 @@
 import { mergeBanTypes } from "./ruleMergers/ban-types";
 import { mergeConsistentTypeAssertions } from "./ruleMergers/consistent-type-assertions";
 import { mergeIndent } from "./ruleMergers/indent";
+import { mergeJsxA11yAltText } from "./ruleMergers/jsx-a11y-alt-text";
 import { mergeNoMemberDelimiterStyle } from "./ruleMergers/member-delimiter-style";
 import { mergeNamingConvention } from "./ruleMergers/naming-convention";
 import { mergeNoEmpty } from "./ruleMergers/no-empty";
@@ -18,6 +19,7 @@ export const ruleMergers = new Map([
     ["@typescript-eslint/no-use-before-define", mergeNoUseBeforeDefine],
     ["@typescript-eslint/no-unnecessary-type-assertion", mergeNoUnnecessaryTypeAssertion],
     ["@typescript-eslint/triple-slash-reference", mergeTripleSlashReference],
+    ["jsx-a11y/alt-text", mergeJsxA11yAltText],
     ["no-empty", mergeNoEmpty],
     ["no-eval", mergeNoEval],
 ]);

--- a/src/converters/lintConfigs/rules/ruleMergers/jsx-a11y-alt-text.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/jsx-a11y-alt-text.ts
@@ -1,0 +1,15 @@
+import { uniqueFromSources } from "../../../../utils";
+import { RuleMerger } from "../ruleMerger";
+
+export const mergeJsxA11yAltText: RuleMerger = (existingOptions, newOptions) => {
+    const existingElements = existingOptions?.[0]?.elements;
+    const newElements = newOptions?.[0]?.elements;
+
+    return existingElements || newElements
+        ? [
+              {
+                  elements: uniqueFromSources(existingElements ?? [], newElements ?? []),
+              },
+          ]
+        : [];
+};

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/jsx-a11y-alt-text.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/jsx-a11y-alt-text.test.ts
@@ -1,0 +1,30 @@
+import { mergeJsxA11yAltText } from "../jsx-a11y-alt-text";
+
+describe(mergeJsxA11yAltText, () => {
+    test("neither options existing", () => {
+        const result = mergeJsxA11yAltText(undefined, undefined);
+
+        expect(result).toEqual([]);
+    });
+
+    test("original elements existing", () => {
+        const result = mergeJsxA11yAltText([{ elements: ["Image"] }], undefined);
+
+        expect(result).toEqual([{ elements: ["Image"] }]);
+    });
+
+    test("new elements existing", () => {
+        const result = mergeJsxA11yAltText(undefined, [{ elements: ["Image"] }]);
+
+        expect(result).toEqual([{ elements: ["Image"] }]);
+    });
+
+    test("both elements existing", () => {
+        const result = mergeJsxA11yAltText(
+            [{ elements: ["Button", "Image"] }],
+            [{ elements: ["Image"] }],
+        );
+
+        expect(result).toEqual([{ elements: ["Button", "Image"] }]);
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #903, fixes #904
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md

Since both input TSLint rules go into the same output ESLint rule, I'm putting them into the same PR. Each input TSLint rule has a notice that the output ESLint rule covers more cases.