### PR TITLE
Ignore parent NODE_OPTIONS in child_process exec

### DIFF
--- a/src/adapters/childProcessExec.ts
+++ b/src/adapters/childProcessExec.ts
@@ -1,6 +1,23 @@
 import { exec } from "child_process";
-import { promisify } from "util";
 
 import { Exec } from "./exec";
 
-export const childProcessExec: Exec = promisify(exec);
+export const childProcessExec: Exec = async (command: string) => {
+    return await new Promise((resolve, reject) => {
+        exec(
+            command,
+            {
+                env: {
+                    NODE_OPTIONS: "",
+                },
+            },
+            (error, stdout, stderr) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve({ stderr, stdout });
+                }
+            },
+        );
+    });
+};


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1149
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Turns out parent environment variables get sent to the exec child (makes sense), including debug ones. We want none of those.