### PR TITLE
Revert "Ignore parent NODE_OPTIONS in child_process exec"

### DIFF
--- a/src/adapters/childProcessExec.ts
+++ b/src/adapters/childProcessExec.ts
@@ -1,23 +1,6 @@
 import { exec } from "child_process";
+import { promisify } from "util";
 
 import { Exec } from "./exec";
 
-export const childProcessExec: Exec = async (command: string) => {
-    return await new Promise((resolve, reject) => {
-        exec(
-            command,
-            {
-                env: {
-                    NODE_OPTIONS: "",
-                },
-            },
-            (error, stdout, stderr) => {
-                if (error) {
-                    reject(error);
-                } else {
-                    resolve({ stderr, stdout });
-                }
-            },
-        );
-    });
-};
+export const childProcessExec: Exec = promisify(exec);


### PR DESCRIPTION
Reverts typescript-eslint/tslint-to-eslint-config#1152

See https://github.com/typescript-eslint/tslint-to-eslint-config/issues/1159 / https://github.com/angular-eslint/angular-eslint/issues/571