### PR TITLE
feat: add missing converters for `rxjs` rules

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -74,12 +74,22 @@ import { convertJsxNoLambda } from "./ruleConverters/eslint-plugin-react/jsx-no-
 import { convertJsxSelfClose } from "./ruleConverters/eslint-plugin-react/jsx-self-close";
 import { convertJsxSpaceBeforeTrailingSlash } from "./ruleConverters/eslint-plugin-react/jsx-space-before-trailing-slash";
 import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/jsx-wrap-multiline";
+import { convertBanObservables } from "./ruleConverters/eslint-plugin-rxjs/ban-observables";
+import { convertBanOperators } from "./ruleConverters/eslint-plugin-rxjs/ban-operators";
+import { convertFinnish } from "./ruleConverters/eslint-plugin-rxjs/finnish";
+import { convertJust } from "./ruleConverters/eslint-plugin-rxjs/just";
 import { convertNoAsyncSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-async-subscribe";
+import { convertNoCompat } from "./ruleConverters/eslint-plugin-rxjs/no-compat";
+import { convertNoConnectable } from "./ruleConverters/eslint-plugin-rxjs/no-connectable";
 import { convertNoCreate } from "./ruleConverters/eslint-plugin-rxjs/no-create";
+import { convertNoExplicitGenerics } from "./ruleConverters/eslint-plugin-rxjs/no-explicit-generics";
 import { convertNoExposedSubjects } from "./ruleConverters/eslint-plugin-rxjs/no-exposed-subjects";
 import { convertNoFinnish } from "./ruleConverters/eslint-plugin-rxjs/no-finnish";
+import { convertNoIgnoredError } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-error";
 import { convertNoIgnoredNotifier } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-notifier";
+import { convertNoIgnoredObservable } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-observable";
 import { convertNoIgnoredReplayBuffer } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-replay-buffer";
+import { convertNoIgnoredSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-subscribe";
 import { convertNoIgnoredSubscription } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-subscription";
 import { convertNoIgnoredTakeWhileValue } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-takewhile-value";
 import { convertNoImplicitAnyCatch } from "./ruleConverters/eslint-plugin-rxjs/no-implicit-any-catch";
@@ -88,11 +98,23 @@ import { convertNoInternal } from "./ruleConverters/eslint-plugin-rxjs/no-intern
 import { convertNoNestedSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-nested-subscribe";
 import { convertNoRedundantNotify } from "./ruleConverters/eslint-plugin-rxjs/no-redundant-notify";
 import { convertNoShareReplay } from "./ruleConverters/eslint-plugin-rxjs/no-sharereplay";
+import { convertNoSubclass } from "./ruleConverters/eslint-plugin-rxjs/no-subclass";
 import { convertNoSubjectUnubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-subject-unsubscribe";
 import { convertNoSubjectValue } from "./ruleConverters/eslint-plugin-rxjs/no-subject-value";
+import { convertNoTap } from "./ruleConverters/eslint-plugin-rxjs/no-tap";
+import { convertNoToPromise } from "./ruleConverters/eslint-plugin-rxjs/no-topromise";
 import { convertNoUnboundMethods } from "./ruleConverters/eslint-plugin-rxjs/no-unbound-methods";
+import { convertNoUnsafeCatch } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-catch";
+import { convertNoUnsafeFirst } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-first";
 import { convertNoUnsafeSubjectNext } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-subject-next";
+import { convertNoUnsafeSwitchmap } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-switchmap";
 import { convertNoUnsafeTakeUntil } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-takeuntil";
+import { convertPreferAngularAsyncPipe } from "./ruleConverters/eslint-plugin-rxjs/prefer-angular-async-pipe";
+import { convertPreferAngularComposition } from "./ruleConverters/eslint-plugin-rxjs/prefer-angular-composition";
+import { convertPreferAngularTakeuntil } from "./ruleConverters/eslint-plugin-rxjs/prefer-angular-takeuntil";
+import { convertPreferObserver } from "./ruleConverters/eslint-plugin-rxjs/prefer-observer";
+import { convertSuffixSubjects } from "./ruleConverters/eslint-plugin-rxjs/suffix-subjects";
+import { convertThrowError } from "./ruleConverters/eslint-plugin-rxjs/throw-error";
 import { convertCognitiveComplexity } from "./ruleConverters/eslint-plugin-sonarjs/cognitive-complexity";
 import { convertConsecutiveOverloads } from "./ruleConverters/eslint-plugin-sonarjs/consecutive-overloads";
 import { convertMaxSwitchCases } from "./ruleConverters/eslint-plugin-sonarjs/max-switch-cases";
@@ -518,12 +540,23 @@ export const ruleConverters = new Map([
     ["react-tsx-curly-spacing", convertReactTsxCurlySpacing],
     ["relative-url-prefix", convertRelativeUrlPrefix],
     ["restrict-plus-operands", convertRestrictPlusOperands],
+    ["rxjs-ban-observables", convertBanObservables],
+    ["rxjs-ban-operators", convertBanOperators],
+    ["rxjs-finnish", convertFinnish],
+    ["rxjs-just", convertJust],
     ["rxjs-no-async-subscribe", convertNoAsyncSubscribe],
+    ["rxjs-no-compat", convertNoCompat],
+    ["rxjs-no-connectable", convertNoConnectable],
     ["rxjs-no-create", convertNoCreate],
+    ["rxjs-no-do", convertNoTap],
+    ["rxjs-no-explicit-generics", convertNoExplicitGenerics],
     ["rxjs-no-exposed-subjects", convertNoExposedSubjects],
     ["rxjs-no-finnish", convertNoFinnish],
+    ["rxjs-no-ignored-error", convertNoIgnoredError],
     ["rxjs-no-ignored-notifier", convertNoIgnoredNotifier],
+    ["rxjs-no-ignored-observable", convertNoIgnoredObservable],
     ["rxjs-no-ignored-replay-buffer", convertNoIgnoredReplayBuffer],
+    ["rxjs-no-ignored-subscribe", convertNoIgnoredSubscribe],
     ["rxjs-no-ignored-subscription", convertNoIgnoredSubscription],
     ["rxjs-no-ignored-takewhile-value", convertNoIgnoredTakeWhileValue],
     ["rxjs-no-implicit-any-catch", convertNoImplicitAnyCatch],
@@ -532,11 +565,23 @@ export const ruleConverters = new Map([
     ["rxjs-no-nested-subscribe", convertNoNestedSubscribe],
     ["rxjs-no-redundant-notify", convertNoRedundantNotify],
     ["rxjs-no-sharereplay", convertNoShareReplay],
+    ["rxjs-no-subclass", convertNoSubclass],
     ["rxjs-no-subject-unsubscribe", convertNoSubjectUnubscribe],
     ["rxjs-no-subject-value", convertNoSubjectValue],
+    ["rxjs-no-tap", convertNoTap],
+    ["rxjs-no-topromise", convertNoToPromise],
     ["rxjs-no-unbound-methods", convertNoUnboundMethods],
+    ["rxjs-no-unsafe-catch", convertNoUnsafeCatch],
+    ["rxjs-no-unsafe-first", convertNoUnsafeFirst],
     ["rxjs-no-unsafe-subject-next", convertNoUnsafeSubjectNext],
+    ["rxjs-no-unsafe-switchmap", convertNoUnsafeSwitchmap],
     ["rxjs-no-unsafe-takeuntil", convertNoUnsafeTakeUntil],
+    ["rxjs-prefer-angular-async-pipe", convertPreferAngularAsyncPipe],
+    ["rxjs-prefer-angular-composition", convertPreferAngularComposition],
+    ["rxjs-prefer-angular-takeuntil", convertPreferAngularTakeuntil],
+    ["rxjs-prefer-observer", convertPreferObserver],
+    ["rxjs-suffix-subjects", convertSuffixSubjects],
+    ["rxjs-throw-error", convertThrowError],
     ["semicolon", convertSemicolon],
     ["space-before-function-paren", convertSpaceBeforeFunctionParen],
     ["space-within-parens", convertSpaceWithinParens],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/ban-observables.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/ban-observables.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertBanObservables: RuleConverter = ({ ruleArguments }) => {
+    return {
+        rules: [
+            {
+                ...(ruleArguments.length !== 0 && { ruleArguments }),
+                ruleName: "rxjs/ban-observables",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/ban-operators.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/ban-operators.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertBanOperators: RuleConverter = ({ ruleArguments }) => {
+    return {
+        rules: [
+            {
+                ...(ruleArguments.length !== 0 && { ruleArguments }),
+                ruleName: "rxjs/ban-operators",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/finnish.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/finnish.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertFinnish: RuleConverter = ({ ruleArguments }) => {
+    return {
+        rules: [
+            {
+                ...(ruleArguments.length !== 0 && { ruleArguments }),
+                ruleName: "rxjs/finnish",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/just.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/just.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertJust: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/just",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-compat.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-compat.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoCompat: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-compat",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-connectable.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-connectable.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoConnectable: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-connectable",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-explicit-generics.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-explicit-generics.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoExplicitGenerics: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-explicit-generics",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-ignored-error.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-ignored-error.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoIgnoredError: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-ignored-error",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-ignored-observable.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-ignored-observable.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoIgnoredObservable: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-ignored-observable",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-ignored-subscribe.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-ignored-subscribe.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoIgnoredSubscribe: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-ignored-subscribe",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-subclass.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-subclass.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoSubclass: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-subclass",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-tap.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-tap.ts
@@ -4,7 +4,8 @@ export const convertNoTap: RuleConverter = () => {
     return {
         rules: [
             {
-                ruleName: "rxjs/no-tap",
+                ruleArguments: [{ tap: true }],
+                ruleName: "rxjs/ban-operators",
             },
         ],
         plugins: ["eslint-plugin-rxjs"],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-tap.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-tap.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoTap: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-tap",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-topromise.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-topromise.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoToPromise: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-topromise",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-catch.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-catch.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoUnsafeCatch: RuleConverter = ({ ruleArguments }) => {
+    return {
+        rules: [
+            {
+                ...(ruleArguments.length !== 0 && { ruleArguments }),
+                ruleName: "rxjs/no-unsafe-catch",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-first.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-first.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoUnsafeFirst: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/no-unsafe-first",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-switchmap.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-switchmap.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoUnsafeSwitchmap: RuleConverter = ({ ruleArguments }) => {
+    return {
+        rules: [
+            {
+                ...(ruleArguments.length !== 0 && { ruleArguments }),
+                ruleName: "rxjs/no-unsafe-switchmap",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-angular-async-pipe.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-angular-async-pipe.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertPreferAngularAsyncPipe: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "prefer-async-pipe",
+            },
+        ],
+        plugins: ["rxjs-angular"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-angular-composition.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-angular-composition.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertPreferAngularComposition: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "prefer-composition",
+            },
+        ],
+        plugins: ["rxjs-angular"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-angular-takeuntil.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-angular-takeuntil.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertPreferAngularTakeuntil: RuleConverter = ({ ruleArguments }) => {
+    return {
+        rules: [
+            {
+                ...(ruleArguments.length !== 0 && { ruleArguments }),
+                ruleName: "prefer-takeuntil",
+            },
+        ],
+        plugins: ["rxjs-angular"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-observer.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-observer.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertPreferObserver: RuleConverter = ({ ruleArguments }) => {
+    return {
+        rules: [
+            {
+                ...(ruleArguments.length !== 0 && { ruleArguments }),
+                ruleName: "rxjs/prefer-observer",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/suffix-subjects.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/suffix-subjects.ts
@@ -1,0 +1,13 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertSuffixSubjects: RuleConverter = ({ ruleArguments }) => {
+    return {
+        rules: [
+            {
+                ...(ruleArguments.length !== 0 && { ruleArguments }),
+                ruleName: "rxjs/suffix-subjects",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/ban-observables.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/ban-observables.test.ts
@@ -1,0 +1,34 @@
+import { convertBanObservables } from "../ban-observables";
+
+describe(convertBanObservables, () => {
+    test("conversion without arguments", () => {
+        const result = convertBanObservables({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/ban-observables",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with options", () => {
+        const result = convertBanObservables({
+            ruleArguments: [{ merge: true }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/ban-observables",
+                    ruleArguments: [{ merge: true }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/ban-operators.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/ban-operators.test.ts
@@ -1,0 +1,34 @@
+import { convertBanOperators } from "../ban-operators";
+
+describe(convertBanOperators, () => {
+    test("conversion without arguments", () => {
+        const result = convertBanOperators({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/ban-operators",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with options", () => {
+        const result = convertBanOperators({
+            ruleArguments: [{ concat: "Use the concat factory function" }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/ban-operators",
+                    ruleArguments: [{ concat: "Use the concat factory function" }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/finnish.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/finnish.test.ts
@@ -1,0 +1,98 @@
+import { convertFinnish } from "../finnish";
+
+describe(convertFinnish, () => {
+    test("conversion without arguments", () => {
+        const result = convertFinnish({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/finnish",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `functions` argument", () => {
+        const result = convertFinnish({
+            ruleArguments: [{ functions: true }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/finnish",
+                    ruleArguments: [{ functions: true }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `methods` argument", () => {
+        const result = convertFinnish({
+            ruleArguments: [{ methods: false }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/finnish",
+                    ruleArguments: [{ methods: false }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `parameters` argument", () => {
+        const result = convertFinnish({
+            ruleArguments: [{ parameters: true }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/finnish",
+                    ruleArguments: [{ parameters: true }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `properties` argument", () => {
+        const result = convertFinnish({
+            ruleArguments: [{ properties: false }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/finnish",
+                    ruleArguments: [{ properties: false }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `variables` argument", () => {
+        const result = convertFinnish({
+            ruleArguments: [{ variables: true }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/finnish",
+                    ruleArguments: [{ variables: true }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/just.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/just.test.ts
@@ -1,0 +1,18 @@
+import { convertJust } from "../just";
+
+describe(convertJust, () => {
+    test("conversion without arguments", () => {
+        const result = convertJust({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/just",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-compat.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-compat.test.ts
@@ -1,0 +1,18 @@
+import { convertNoCompat } from "../no-compat";
+
+describe(convertNoCompat, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoCompat({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-compat",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-connectable.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-connectable.test.ts
@@ -1,0 +1,18 @@
+import { convertNoConnectable } from "../no-connectable";
+
+describe(convertNoConnectable, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoConnectable({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-connectable",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-explicit-generics.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-explicit-generics.test.ts
@@ -1,0 +1,18 @@
+import { convertNoExplicitGenerics } from "../no-explicit-generics";
+
+describe(convertNoExplicitGenerics, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoExplicitGenerics({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-explicit-generics",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-ignored-error.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-ignored-error.test.ts
@@ -1,0 +1,18 @@
+import { convertNoIgnoredError } from "../no-ignored-error";
+
+describe(convertNoIgnoredError, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoIgnoredError({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-ignored-error",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-ignored-observable.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-ignored-observable.test.ts
@@ -1,0 +1,18 @@
+import { convertNoIgnoredObservable } from "../no-ignored-observable";
+
+describe(convertNoIgnoredObservable, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoIgnoredObservable({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-ignored-observable",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-ignored-subscribe.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-ignored-subscribe.test.ts
@@ -1,0 +1,18 @@
+import { convertNoIgnoredSubscribe } from "../no-ignored-subscribe";
+
+describe(convertNoIgnoredSubscribe, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoIgnoredSubscribe({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-ignored-subscribe",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-subclass.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-subclass.test.ts
@@ -1,0 +1,18 @@
+import { convertNoSubclass } from "../no-subclass";
+
+describe(convertNoSubclass, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoSubclass({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-subclass",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-tap.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-tap.test.ts
@@ -9,7 +9,8 @@ describe(convertNoTap, () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleName: "rxjs/no-tap",
+                    ruleArguments: [{ tap: true }],
+                    ruleName: "rxjs/ban-operators",
                 },
             ],
             plugins: ["eslint-plugin-rxjs"],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-tap.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-tap.test.ts
@@ -1,0 +1,18 @@
+import { convertNoTap } from "../no-tap";
+
+describe(convertNoTap, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoTap({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-tap",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-topromise.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-topromise.test.ts
@@ -1,0 +1,18 @@
+import { convertNoToPromise } from "../no-topromise";
+
+describe(convertNoToPromise, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoToPromise({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-topromise",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-catch.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-catch.test.ts
@@ -1,0 +1,34 @@
+import { convertNoUnsafeCatch } from "../no-unsafe-catch";
+
+describe(convertNoUnsafeCatch, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoUnsafeCatch({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-unsafe-catch",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `observable` argument", () => {
+        const result = convertNoUnsafeCatch({
+            ruleArguments: [{ observable: "action(s|\\$)?" }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-unsafe-catch",
+                    ruleArguments: [{ observable: "action(s|\\$)?" }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-first.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-first.test.ts
@@ -1,0 +1,18 @@
+import { convertNoUnsafeFirst } from "../no-unsafe-first";
+
+describe(convertNoUnsafeFirst, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoUnsafeFirst({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-unsafe-first",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-switchmap.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-switchmap.test.ts
@@ -1,0 +1,65 @@
+import { convertNoUnsafeSwitchmap } from "../no-unsafe-switchmap";
+
+describe(convertNoUnsafeSwitchmap, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoUnsafeSwitchmap({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-unsafe-switchmap",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `disallow` argument", () => {
+        const result = convertNoUnsafeSwitchmap({
+            ruleArguments: [
+                { disallow: ["add", "create", "delete", "post", "put", "remove", "set", "update"] },
+            ],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-unsafe-switchmap",
+                    ruleArguments: [
+                        {
+                            disallow: [
+                                "add",
+                                "create",
+                                "delete",
+                                "post",
+                                "put",
+                                "remove",
+                                "set",
+                                "update",
+                            ],
+                        },
+                    ],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `observable` argument", () => {
+        const result = convertNoUnsafeSwitchmap({
+            ruleArguments: [{ observable: "action(s|\\$)?" }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/no-unsafe-switchmap",
+                    ruleArguments: [{ observable: "action(s|\\$)?" }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-angular-async-pipe.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-angular-async-pipe.test.ts
@@ -1,0 +1,18 @@
+import { convertPreferAngularAsyncPipe } from "../prefer-angular-async-pipe";
+
+describe(convertPreferAngularAsyncPipe, () => {
+    test("conversion without arguments", () => {
+        const result = convertPreferAngularAsyncPipe({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "prefer-async-pipe",
+                },
+            ],
+            plugins: ["rxjs-angular"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-angular-composition.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-angular-composition.test.ts
@@ -1,0 +1,18 @@
+import { convertPreferAngularComposition } from "../prefer-angular-composition";
+
+describe(convertPreferAngularComposition, () => {
+    test("conversion without arguments", () => {
+        const result = convertPreferAngularComposition({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "prefer-composition",
+                },
+            ],
+            plugins: ["rxjs-angular"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-angular-takeuntil.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-angular-takeuntil.test.ts
@@ -1,0 +1,66 @@
+import { convertPreferAngularTakeuntil } from "../prefer-angular-takeuntil";
+
+describe(convertPreferAngularTakeuntil, () => {
+    test("conversion without arguments", () => {
+        const result = convertPreferAngularTakeuntil({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "prefer-takeuntil",
+                },
+            ],
+            plugins: ["rxjs-angular"],
+        });
+    });
+
+    test("conversion with `alias` argument", () => {
+        const result = convertPreferAngularTakeuntil({
+            ruleArguments: [{ alias: ["untilDestroyed"] }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "prefer-takeuntil",
+                    ruleArguments: [{ alias: ["untilDestroyed"] }],
+                },
+            ],
+            plugins: ["rxjs-angular"],
+        });
+    });
+
+    test("conversion with `checkComplete` argument", () => {
+        const result = convertPreferAngularTakeuntil({
+            ruleArguments: [{ checkComplete: true }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "prefer-takeuntil",
+                    ruleArguments: [{ checkComplete: true }],
+                },
+            ],
+            plugins: ["rxjs-angular"],
+        });
+    });
+
+    test("conversion with `checkDecorators` argument", () => {
+        const result = convertPreferAngularTakeuntil({
+            ruleArguments: [{ checkDecorators: ["Component"] }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "prefer-takeuntil",
+                    ruleArguments: [{ checkDecorators: ["Component"] }],
+                },
+            ],
+            plugins: ["rxjs-angular"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-observer.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-observer.test.ts
@@ -1,0 +1,34 @@
+import { convertPreferObserver } from "../prefer-observer";
+
+describe(convertPreferObserver, () => {
+    test("conversion without arguments", () => {
+        const result = convertPreferObserver({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/prefer-observer",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `allowNext` argument", () => {
+        const result = convertPreferObserver({
+            ruleArguments: [{ allowNext: false }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/prefer-observer",
+                    ruleArguments: [{ allowNext: false }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/suffix-subjects.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/suffix-subjects.test.ts
@@ -1,0 +1,82 @@
+import { convertSuffixSubjects } from "../suffix-subjects";
+
+describe(convertSuffixSubjects, () => {
+    test("conversion without arguments", () => {
+        const result = convertSuffixSubjects({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/suffix-subjects",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `parameters` argument", () => {
+        const result = convertSuffixSubjects({
+            ruleArguments: [{ parameters: true }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/suffix-subjects",
+                    ruleArguments: [{ parameters: true }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `properties` argument", () => {
+        const result = convertSuffixSubjects({
+            ruleArguments: [{ properties: false }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/suffix-subjects",
+                    ruleArguments: [{ properties: false }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `suffix` argument", () => {
+        const result = convertSuffixSubjects({
+            ruleArguments: [{ suffix: true }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/suffix-subjects",
+                    ruleArguments: [{ suffix: true }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+
+    test("conversion with `variables` argument", () => {
+        const result = convertSuffixSubjects({
+            ruleArguments: [{ variables: false }],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/suffix-subjects",
+                    ruleArguments: [{ variables: false }],
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/throw-error.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/throw-error.test.ts
@@ -1,0 +1,18 @@
+import { convertThrowError } from "../throw-error";
+
+describe(convertThrowError, () => {
+    test("conversion without arguments", () => {
+        const result = convertThrowError({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "rxjs/throw-error",
+                },
+            ],
+            plugins: ["eslint-plugin-rxjs"],
+        });
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/throw-error.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/throw-error.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertThrowError: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "rxjs/throw-error",
+            },
+        ],
+        plugins: ["eslint-plugin-rxjs"],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleMergers/eslint-plugin-rxjs/ban-operators.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/eslint-plugin-rxjs/ban-operators.ts
@@ -1,0 +1,14 @@
+import { RuleMerger } from "../../ruleMerger";
+
+export const mergeBanOperators: RuleMerger = (existingOptions, newOptions) => {
+    if (existingOptions === undefined && newOptions === undefined) {
+        return [];
+    }
+
+    return [
+        {
+            ...existingOptions?.[0],
+            ...newOptions?.[0],
+        },
+    ];
+};

--- a/src/converters/lintConfigs/rules/ruleMergers/eslint-plugin-rxjs/tests/ban-operators.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/eslint-plugin-rxjs/tests/ban-operators.test.ts
@@ -1,0 +1,29 @@
+import { mergeBanOperators } from "../ban-operators";
+
+describe(mergeBanOperators, () => {
+    test("neither operators existing", () => {
+        const result = mergeBanOperators(undefined, undefined);
+
+        expect(result).toEqual([]);
+    });
+
+    test("original operators existing", () => {
+        const result = mergeBanOperators([{ merge: true }], undefined);
+
+        expect(result).toEqual([{ merge: true }]);
+    });
+
+    test("new operator existing", () => {
+        const result = mergeBanOperators(undefined, [
+            { concat: "Use the concat factory function" },
+        ]);
+
+        expect(result).toEqual([{ concat: "Use the concat factory function" }]);
+    });
+
+    test("both operators existing", () => {
+        const result = mergeBanOperators([{ tap: "No tap" }], [{ share: true, from: false }]);
+
+        expect(result).toEqual([{ tap: "No tap", share: true, from: false }]);
+    });
+});


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
There's no specific issue for this, but as I saw that there're some missing rule converters from `rxjs-tslint-rules` I decided to propose its addition.

Ref: https://github.com/cartant/eslint-plugin-rxjs/issues/7