### PR TITLE
Added obsolete rule converters for remaining tslint-microsoft-contrib rules

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -184,6 +184,7 @@ import { convertNoExplicitAny } from "./ruleConverters/no-explicit-any";
 import { convertNoFloatingPromises } from "./ruleConverters/no-floating-promises";
 import { convertNoForIn } from "./ruleConverters/no-for-in";
 import { convertNoForInArray } from "./ruleConverters/no-for-in-array";
+import { convertNoFunctionExpression } from "./ruleConverters/no-function-expression";
 import { convertNoImplicitDependencies } from "./ruleConverters/no-implicit-dependencies";
 import { convertNoImportSideEffect } from "./ruleConverters/no-import-side-effect";
 import { convertNoInferrableTypes } from "./ruleConverters/no-inferrable-types";
@@ -219,6 +220,7 @@ import { convertNoThisAssignment } from "./ruleConverters/no-this-assignment";
 import { convertNoTrailingWhitespace } from "./ruleConverters/no-trailing-whitespace";
 import { convertNoUnboundMethod } from "./ruleConverters/no-unbound-method";
 import { convertNoUnnecessaryClass } from "./ruleConverters/no-unnecessary-class";
+import { convertNoUnnecessaryFieldInitialization } from "./ruleConverters/no-unnecessary-field-initialization";
 import { convertNoUnnecessaryInitializer } from "./ruleConverters/no-unnecessary-initializer";
 import { convertNoUnnecessaryQualifier } from "./ruleConverters/no-unnecessary-qualifier";
 import { convertNoUnnecessarySemicolons } from "./ruleConverters/no-unnecessary-semicolons";
@@ -268,6 +270,7 @@ import { convertReactA11yRoleSupportsAriaProps } from "./ruleConverters/react-a1
 import { convertReactA11yTabIndexNoPositive } from "./ruleConverters/react-a11y-tabindex-no-positive";
 import { convertReactNoDangerousHtml } from "./ruleConverters/react-no-dangerous-html";
 import { convertReactTsxCurlySpacing } from "./ruleConverters/react-tsx-curly-spacing";
+import { convertReactUnusedPropsAndState } from "./ruleConverters/react-unused-props-and-state";
 import { convertRestrictPlusOperands } from "./ruleConverters/restrict-plus-operands";
 import { convertSemicolon } from "./ruleConverters/semicolon";
 import { convertSpaceBeforeFunctionParen } from "./ruleConverters/space-before-function-paren";
@@ -397,6 +400,7 @@ export const ruleConverters = new Map([
     ["no-for-in-array", convertNoForInArray],
     ["no-for-in", convertNoForIn],
     ["no-forward-ref", convertNoForwardRef],
+    ["no-function-expression", convertNoFunctionExpression],
     ["no-host-metadata-property", convertNoHostMetadataProperty],
     ["no-identical-conditions", convertNoIdenticalConditions],
     ["no-identical-expressions", convertNoIdenticalExpressions],
@@ -421,6 +425,7 @@ export const ruleConverters = new Map([
     ["no-multiline-string-literals", convertNoMultilineStringLiterals],
     ["no-multiline-string", convertNoMultilineString],
     ["no-namespace", convertNoNamespace],
+    ["no-unnecessary-field-initialization", convertNoUnnecessaryFieldInitialization],
     ["non-literal-fs-path", convertNonLiteralFsPath],
     ["no-non-null-assertion", convertNoNonNullAssertion],
     ["no-null-keyword", convertNoNullKeyword],
@@ -516,6 +521,7 @@ export const ruleConverters = new Map([
     ["react-a11y-tabindex-no-positive", convertReactA11yTabIndexNoPositive],
     ["react-no-dangerous-html", convertReactNoDangerousHtml],
     ["react-tsx-curly-spacing", convertReactTsxCurlySpacing],
+    ["react-unused-props-and-state", convertReactUnusedPropsAndState],
     ["relative-url-prefix", convertRelativeUrlPrefix],
     ["restrict-plus-operands", convertRestrictPlusOperands],
     ["rxjs-no-async-subscribe", convertNoAsyncSubscribe],

--- a/src/converters/lintConfigs/rules/ruleConverters/no-function-expression.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/no-function-expression.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertNoFunctionExpression: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/no-unnecessary-field-initialization.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/no-unnecessary-field-initialization.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertNoUnnecessaryFieldInitialization: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/react-unused-props-and-state.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/react-unused-props-and-state.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertReactUnusedPropsAndState: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-function-expression.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-function-expression.test.ts
@@ -1,0 +1,11 @@
+import { convertNoFunctionExpression } from "../no-function-expression";
+
+describe(convertNoFunctionExpression, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoFunctionExpression({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-field-initialization.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-field-initialization.test.ts
@@ -1,0 +1,11 @@
+import { convertNoUnnecessaryFieldInitialization } from "../no-unnecessary-field-initialization";
+
+describe(convertNoUnnecessaryFieldInitialization, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoUnnecessaryFieldInitialization({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-unused-props-and-state.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-unused-props-and-state.test.ts
@@ -1,0 +1,11 @@
+import { convertReactUnusedPropsAndState } from "../react-unused-props-and-state";
+
+describe(convertReactUnusedPropsAndState, () => {
+    test("conversion without arguments", () => {
+        const result = convertReactUnusedPropsAndState({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #874; fixes #880; fixes #894
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Adds obsolete rule converters for the last three `tslint-microsoft-contrib` rules.