### PR TITLE
feat: add deprecated/removed rxjs rules

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -74,14 +74,18 @@ import { convertJsxNoLambda } from "./ruleConverters/eslint-plugin-react/jsx-no-
 import { convertJsxSelfClose } from "./ruleConverters/eslint-plugin-react/jsx-self-close";
 import { convertJsxSpaceBeforeTrailingSlash } from "./ruleConverters/eslint-plugin-react/jsx-space-before-trailing-slash";
 import { convertJsxWrapMultiline } from "./ruleConverters/eslint-plugin-react/jsx-wrap-multiline";
+import { convertAdd } from "./ruleConverters/eslint-plugin-rxjs/add";
 import { convertBanObservables } from "./ruleConverters/eslint-plugin-rxjs/ban-observables";
 import { convertBanOperators } from "./ruleConverters/eslint-plugin-rxjs/ban-operators";
+import { convertDeepOperators } from "./ruleConverters/eslint-plugin-rxjs/deep-operators";
 import { convertFinnish } from "./ruleConverters/eslint-plugin-rxjs/finnish";
 import { convertJust } from "./ruleConverters/eslint-plugin-rxjs/just";
+import { convertNoAdd } from "./ruleConverters/eslint-plugin-rxjs/no-add";
 import { convertNoAsyncSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-async-subscribe";
 import { convertNoCompat } from "./ruleConverters/eslint-plugin-rxjs/no-compat";
 import { convertNoConnectable } from "./ruleConverters/eslint-plugin-rxjs/no-connectable";
 import { convertNoCreate } from "./ruleConverters/eslint-plugin-rxjs/no-create";
+import { convertNoDeepOperators } from "./ruleConverters/eslint-plugin-rxjs/no-deep-operators";
 import { convertNoExplicitGenerics } from "./ruleConverters/eslint-plugin-rxjs/no-explicit-generics";
 import { convertNoExposedSubjects } from "./ruleConverters/eslint-plugin-rxjs/no-exposed-subjects";
 import { convertNoFinnish } from "./ruleConverters/eslint-plugin-rxjs/no-finnish";
@@ -91,11 +95,13 @@ import { convertNoIgnoredObservable } from "./ruleConverters/eslint-plugin-rxjs/
 import { convertNoIgnoredReplayBuffer } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-replay-buffer";
 import { convertNoIgnoredSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-subscribe";
 import { convertNoIgnoredSubscription } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-subscription";
-import { convertNoIgnoredTakeWhileValue } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-takewhile-value";
+import { convertNoIgnoredTakewhileValue } from "./ruleConverters/eslint-plugin-rxjs/no-ignored-takewhile-value";
 import { convertNoImplicitAnyCatch } from "./ruleConverters/eslint-plugin-rxjs/no-implicit-any-catch";
 import { convertNoIndex } from "./ruleConverters/eslint-plugin-rxjs/no-index";
 import { convertNoInternal } from "./ruleConverters/eslint-plugin-rxjs/no-internal";
 import { convertNoNestedSubscribe } from "./ruleConverters/eslint-plugin-rxjs/no-nested-subscribe";
+import { convertNoOperator } from "./ruleConverters/eslint-plugin-rxjs/no-operator";
+import { convertNoPatched } from "./ruleConverters/eslint-plugin-rxjs/no-patched";
 import { convertNoRedundantNotify } from "./ruleConverters/eslint-plugin-rxjs/no-redundant-notify";
 import { convertNoShareReplay } from "./ruleConverters/eslint-plugin-rxjs/no-sharereplay";
 import { convertNoSubclass } from "./ruleConverters/eslint-plugin-rxjs/no-subclass";
@@ -106,9 +112,14 @@ import { convertNoToPromise } from "./ruleConverters/eslint-plugin-rxjs/no-topro
 import { convertNoUnboundMethods } from "./ruleConverters/eslint-plugin-rxjs/no-unbound-methods";
 import { convertNoUnsafeCatch } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-catch";
 import { convertNoUnsafeFirst } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-first";
+import { convertNoUnsafeScope } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-scope";
 import { convertNoUnsafeSubjectNext } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-subject-next";
 import { convertNoUnsafeSwitchmap } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-switchmap";
-import { convertNoUnsafeTakeUntil } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-takeuntil";
+import { convertNoUnsafeTakeuntil } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-takeuntil";
+import { convertNoUnsafeTakewhile } from "./ruleConverters/eslint-plugin-rxjs/no-unsafe-takewhile";
+import { convertNoUnusedAdd } from "./ruleConverters/eslint-plugin-rxjs/no-unused-add";
+import { convertNoWholesale } from "./ruleConverters/eslint-plugin-rxjs/no-wholesale";
+import { convertPreferAdd } from "./ruleConverters/eslint-plugin-rxjs/prefer-add";
 import { convertPreferAngularAsyncPipe } from "./ruleConverters/eslint-plugin-rxjs/prefer-angular-async-pipe";
 import { convertPreferAngularComposition } from "./ruleConverters/eslint-plugin-rxjs/prefer-angular-composition";
 import { convertPreferAngularTakeuntil } from "./ruleConverters/eslint-plugin-rxjs/prefer-angular-takeuntil";
@@ -548,14 +559,18 @@ export const ruleConverters = new Map([
     ["react-unused-props-and-state", convertReactUnusedPropsAndState],
     ["relative-url-prefix", convertRelativeUrlPrefix],
     ["restrict-plus-operands", convertRestrictPlusOperands],
+    ["rxjs-add", convertAdd],
     ["rxjs-ban-observables", convertBanObservables],
     ["rxjs-ban-operators", convertBanOperators],
+    ["rxjs-deep-operators", convertDeepOperators],
     ["rxjs-finnish", convertFinnish],
     ["rxjs-just", convertJust],
+    ["rxjs-no-add", convertNoAdd],
     ["rxjs-no-async-subscribe", convertNoAsyncSubscribe],
     ["rxjs-no-compat", convertNoCompat],
     ["rxjs-no-connectable", convertNoConnectable],
     ["rxjs-no-create", convertNoCreate],
+    ["rxjs-no-deep-operators", convertNoDeepOperators],
     ["rxjs-no-do", convertNoTap],
     ["rxjs-no-explicit-generics", convertNoExplicitGenerics],
     ["rxjs-no-exposed-subjects", convertNoExposedSubjects],
@@ -566,11 +581,13 @@ export const ruleConverters = new Map([
     ["rxjs-no-ignored-replay-buffer", convertNoIgnoredReplayBuffer],
     ["rxjs-no-ignored-subscribe", convertNoIgnoredSubscribe],
     ["rxjs-no-ignored-subscription", convertNoIgnoredSubscription],
-    ["rxjs-no-ignored-takewhile-value", convertNoIgnoredTakeWhileValue],
+    ["rxjs-no-ignored-takewhile-value", convertNoIgnoredTakewhileValue],
     ["rxjs-no-implicit-any-catch", convertNoImplicitAnyCatch],
     ["rxjs-no-index", convertNoIndex],
     ["rxjs-no-internal", convertNoInternal],
     ["rxjs-no-nested-subscribe", convertNoNestedSubscribe],
+    ["rxjs-no-operator", convertNoOperator],
+    ["rxjs-no-patched", convertNoPatched],
     ["rxjs-no-redundant-notify", convertNoRedundantNotify],
     ["rxjs-no-sharereplay", convertNoShareReplay],
     ["rxjs-no-subclass", convertNoSubclass],
@@ -581,9 +598,14 @@ export const ruleConverters = new Map([
     ["rxjs-no-unbound-methods", convertNoUnboundMethods],
     ["rxjs-no-unsafe-catch", convertNoUnsafeCatch],
     ["rxjs-no-unsafe-first", convertNoUnsafeFirst],
+    ["rxjs-no-unsafe-scope", convertNoUnsafeScope],
     ["rxjs-no-unsafe-subject-next", convertNoUnsafeSubjectNext],
     ["rxjs-no-unsafe-switchmap", convertNoUnsafeSwitchmap],
-    ["rxjs-no-unsafe-takeuntil", convertNoUnsafeTakeUntil],
+    ["rxjs-no-unsafe-takeuntil", convertNoUnsafeTakeuntil],
+    ["rxjs-no-unsafe-takewhile", convertNoUnsafeTakewhile],
+    ["rxjs-no-unused-add", convertNoUnusedAdd],
+    ["rxjs-no-wholesale", convertNoWholesale],
+    ["rxjs-prefer-add", convertPreferAdd],
     ["rxjs-prefer-angular-async-pipe", convertPreferAngularAsyncPipe],
     ["rxjs-prefer-angular-composition", convertPreferAngularComposition],
     ["rxjs-prefer-angular-takeuntil", convertPreferAngularTakeuntil],

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/add.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/add.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertAdd: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/deep-operators.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/deep-operators.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertDeepOperators: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-add.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-add.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoAdd: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-deep-operators.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-deep-operators.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoDeepOperators: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-operator.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-operator.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoOperator: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-patched.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-patched.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoPatched: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-scope.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-scope.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoUnsafeScope: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-takeuntil.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-takeuntil.ts
@@ -1,6 +1,6 @@
 import { RuleConverter } from "../../ruleConverter";
 
-export const convertNoUnsafeTakeUntil: RuleConverter = (tslintRule) => {
+export const convertNoUnsafeTakeuntil: RuleConverter = (tslintRule) => {
     return {
         rules: [
             {

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-takewhile.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unsafe-takewhile.ts
@@ -1,6 +1,6 @@
 import { RuleConverter } from "../../ruleConverter";
 
-export const convertNoIgnoredTakewhileValue: RuleConverter = () => {
+export const convertNoUnsafeTakewhile: RuleConverter = () => {
     return {
         rules: [
             {

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unused-add.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-unused-add.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoUnusedAdd: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-wholesale.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/no-wholesale.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertNoWholesale: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-add.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/prefer-add.ts
@@ -1,0 +1,5 @@
+import { RuleConverter } from "../../ruleConverter";
+
+export const convertPreferAdd: RuleConverter = () => {
+    return {};
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/add.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/add.test.ts
@@ -1,0 +1,11 @@
+import { convertAdd } from "../add";
+
+describe(convertAdd, () => {
+    test("conversion without arguments", () => {
+        const result = convertAdd({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/deep-operators.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/deep-operators.test.ts
@@ -1,0 +1,11 @@
+import { convertDeepOperators } from "../deep-operators";
+
+describe(convertDeepOperators, () => {
+    test("conversion without arguments", () => {
+        const result = convertDeepOperators({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-add.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-add.test.ts
@@ -1,0 +1,11 @@
+import { convertNoAdd } from "../no-add";
+
+describe(convertNoAdd, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoAdd({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-deep-operators.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-deep-operators.test.ts
@@ -1,0 +1,11 @@
+import { convertNoDeepOperators } from "../no-deep-operators";
+
+describe(convertNoDeepOperators, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoDeepOperators({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-operator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-operator.test.ts
@@ -1,0 +1,11 @@
+import { convertNoOperator } from "../no-operator";
+
+describe(convertNoOperator, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoOperator({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-patched.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-patched.test.ts
@@ -1,0 +1,11 @@
+import { convertNoPatched } from "../no-patched";
+
+describe(convertNoPatched, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoPatched({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-scope.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-scope.test.ts
@@ -1,0 +1,11 @@
+import { convertNoUnsafeScope } from "../no-unsafe-scope";
+
+describe(convertNoUnsafeScope, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoUnsafeScope({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-takeuntil.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-takeuntil.test.ts
@@ -1,8 +1,8 @@
-import { convertNoUnsafeTakeUntil } from "../no-unsafe-takeuntil";
+import { convertNoUnsafeTakeuntil } from "../no-unsafe-takeuntil";
 
-describe(convertNoUnsafeTakeUntil, () => {
+describe(convertNoUnsafeTakeuntil, () => {
     test("conversion without arguments", () => {
-        const result = convertNoUnsafeTakeUntil({
+        const result = convertNoUnsafeTakeuntil({
             ruleArguments: [],
         });
 
@@ -17,7 +17,7 @@ describe(convertNoUnsafeTakeUntil, () => {
     });
 
     test("conversion with alias argument", () => {
-        const result = convertNoUnsafeTakeUntil({
+        const result = convertNoUnsafeTakeuntil({
             ruleArguments: [{ alias: ["untilDestroyed"] }],
         });
 
@@ -33,7 +33,7 @@ describe(convertNoUnsafeTakeUntil, () => {
     });
 
     test("conversion with allow argument", () => {
-        const result = convertNoUnsafeTakeUntil({
+        const result = convertNoUnsafeTakeuntil({
             ruleArguments: [{ allow: ["shareReplay", "share"] }],
         });
 

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-takewhile.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unsafe-takewhile.test.ts
@@ -1,8 +1,8 @@
-import { convertNoIgnoredTakewhileValue } from "../no-ignored-takewhile-value";
+import { convertNoUnsafeTakewhile } from "../no-unsafe-takewhile";
 
-describe(convertNoIgnoredTakewhileValue, () => {
+describe(convertNoUnsafeTakewhile, () => {
     test("conversion without arguments", () => {
-        const result = convertNoIgnoredTakewhileValue({
+        const result = convertNoUnsafeTakewhile({
             ruleArguments: [],
         });
 

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unused-add.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-unused-add.test.ts
@@ -1,0 +1,11 @@
+import { convertNoUnusedAdd } from "../no-unused-add";
+
+describe(convertNoUnusedAdd, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoUnusedAdd({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-wholesale.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/no-wholesale.test.ts
@@ -1,0 +1,11 @@
+import { convertNoWholesale } from "../no-wholesale";
+
+describe(convertNoWholesale, () => {
+    test("conversion without arguments", () => {
+        const result = convertNoWholesale({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});

--- a/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-add.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/eslint-plugin-rxjs/tests/prefer-add.test.ts
@@ -1,0 +1,11 @@
+import { convertPreferAdd } from "../prefer-add";
+
+describe(convertPreferAdd, () => {
+    test("conversion without arguments", () => {
+        const result = convertPreferAdd({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({});
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [ ] Addresses an existing issue: https://github.com/typescript-eslint/tslint-to-eslint-config/pull/1194#issuecomment-907958459
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview
It adds missing converters for deprecated/removed rxjs rules.