### PR TITLE
fix: [variable-name] Use `id-denylist` ESLint rule instread of `id-blacklist` that deprecated

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/tests/variable-name.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/variable-name.test.ts
@@ -29,7 +29,7 @@ describe(convertVariableName, () => {
                     ruleName: "no-underscore-dangle",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -61,7 +61,7 @@ describe(convertVariableName, () => {
                     ruleName: "no-underscore-dangle",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -93,7 +93,7 @@ describe(convertVariableName, () => {
                     ruleName: "no-underscore-dangle",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -125,7 +125,7 @@ describe(convertVariableName, () => {
                     ruleName: "no-underscore-dangle",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -157,7 +157,7 @@ describe(convertVariableName, () => {
                     notices: [ForbiddenLeadingTrailingIdentifierMsg],
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -189,7 +189,7 @@ describe(convertVariableName, () => {
                     ruleName: "no-underscore-dangle",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -221,7 +221,7 @@ describe(convertVariableName, () => {
                     ruleName: "no-underscore-dangle",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -254,7 +254,7 @@ describe(convertVariableName, () => {
                     ruleName: "no-underscore-dangle",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -287,7 +287,7 @@ describe(convertVariableName, () => {
                     ruleSeverity: "off",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -320,7 +320,7 @@ describe(convertVariableName, () => {
                     ruleSeverity: "off",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -357,7 +357,7 @@ describe(convertVariableName, () => {
                     ruleSeverity: "off",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                 },
                 {
                     ruleName: "id-match",
@@ -399,7 +399,7 @@ describe(convertVariableName, () => {
                     ruleSeverity: "off",
                 },
                 {
-                    ruleName: "id-blacklist",
+                    ruleName: "id-denylist",
                     ruleArguments: [
                         "any",
                         "Number",

--- a/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
@@ -77,8 +77,8 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
         };
     };
 
-    const getBlackListRuleOptions = () => {
-        const blackListOptionArguments = tslintRule.ruleArguments.includes("ban-keywords")
+    const getDenyListRuleOptions = () => {
+        const denyListOptionArguments = tslintRule.ruleArguments.includes("ban-keywords")
             ? [
                   "any",
                   "Number",
@@ -93,10 +93,10 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
             : [];
 
         return {
-            ...(blackListOptionArguments.length !== 0 && {
-                ruleArguments: blackListOptionArguments,
+            ...(denyListOptionArguments.length !== 0 && {
+                ruleArguments: denyListOptionArguments,
             }),
-            ruleName: "id-blacklist",
+            ruleName: "id-denylist",
         };
     };
 
@@ -104,7 +104,7 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
         rules: [
             getCamelCaseRuleOptions(),
             getUnderscoreDangleRuleOptions(),
-            getBlackListRuleOptions(),
+            getDenyListRuleOptions(),
             {
                 ruleName: "id-match",
             },

--- a/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
@@ -17,6 +17,22 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
     const constRequiredForAllCaps = tslintRule.ruleArguments.includes("require-const-for-all-caps");
     const allowPascalCase = tslintRule.ruleArguments.includes("allow-pascal-case");
     const allowSnakeCase = tslintRule.ruleArguments.includes("allow-snake-case");
+    /**
+     * disallows the use of certain TypeScript keywords as variable or parameter names.
+     * @see https://palantir.github.io/tslint/rules/variable-name/
+     * @see https://github.com/palantir/tslint/blob/285fc1db18d1fd24680d6a2282c6445abf1566ee/src/rules/variableNameRule.ts#L26-L36
+     */
+    const banKeywords = [
+        "any",
+        "Number",
+        "number",
+        "String",
+        "string",
+        "Boolean",
+        "boolean",
+        "Undefined",
+        "undefined",
+    ];
 
     const getCamelCaseRuleOptions = () => {
         const camelCaseRules: Record<string, unknown>[] = [];
@@ -79,17 +95,7 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
 
     const getDenyListRuleOptions = () => {
         const denyListOptionArguments = tslintRule.ruleArguments.includes("ban-keywords")
-            ? [
-                  "any",
-                  "Number",
-                  "number",
-                  "String",
-                  "string",
-                  "Boolean",
-                  "boolean",
-                  "Undefined",
-                  "undefined",
-              ]
+            ? banKeywords
             : [];
 
         return {


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes https://github.com/typescript-eslint/tslint-to-eslint-config/issues/1028
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
`id-blacklist` was deprecated in favor of `id-denylist` since ESLint 7.4.0.

I was able to confirm that the logic of the options is the same, so I just renamed it.

**id-blacklist**
https://github.com/eslint/eslint/blob/47be8003d700bc0606495ae42610eaba94e639c5/lib/rules/id-blacklist.js#L140-L153

**id-denylist**
https://github.com/eslint/eslint/blob/47be8003d700bc0606495ae42610eaba94e639c5/lib/rules/id-denylist.js#L121-L134