### PR TITLE
Switch from cat to type on Windows

### DIFF
--- a/src/api/dependencies.ts
+++ b/src/api/dependencies.ts
@@ -108,6 +108,7 @@ export const boundImporter = bind(importer, nativeImporterDependencies);
 export const findConfigurationDependencies = {
     exec: childProcessExec,
     importer: boundImporter,
+    platform: process.platform,
 };
 
 export const findOriginalConfigurationsDependencies: FindOriginalConfigurationsDependencies = {

--- a/src/input/findPackagesConfiguration.test.ts
+++ b/src/input/findPackagesConfiguration.test.ts
@@ -2,9 +2,9 @@ import { createStubExec } from "../adapters/exec.stubs";
 import { findPackagesConfiguration } from "./findPackagesConfiguration";
 
 describe("findPackagesConfiguration", () => {
-    it("defaults the configuration file when one isn't provided", async () => {
+    it("defaults the configuration file with cat when one isn't provided on a non-Windows platform", async () => {
         // Arrange
-        const dependencies = { exec: createStubExec() };
+        const dependencies = { exec: createStubExec(), platform: "darwin" };
 
         // Act
         await findPackagesConfiguration(dependencies, undefined);
@@ -13,9 +13,20 @@ describe("findPackagesConfiguration", () => {
         expect(dependencies.exec).toHaveBeenLastCalledWith(`cat "./package.json"`);
     });
 
+    it("defaults the configuration file with type when one isn't provided on a Windows platform", async () => {
+        // Arrange
+        const dependencies = { exec: createStubExec(), platform: "win32" };
+
+        // Act
+        await findPackagesConfiguration(dependencies, undefined);
+
+        // Assert
+        expect(dependencies.exec).toHaveBeenLastCalledWith(`type "./package.json"`);
+    });
+
     it("includes a configuration file in the packages command when one is provided", async () => {
         // Arrange
-        const dependencies = { exec: createStubExec() };
+        const dependencies = { exec: createStubExec(), platform: "darwin" };
         const config = "./custom/package.json";
 
         // Act
@@ -27,7 +38,7 @@ describe("findPackagesConfiguration", () => {
 
     it("applies packages defaults when none are provided", async () => {
         // Arrange
-        const dependencies = { exec: createStubExec({ stdout: "{}" }) };
+        const dependencies = { exec: createStubExec({ stdout: "{}" }), platform: "darwin" };
         const config = "./package.json";
 
         // Act

--- a/src/input/findPackagesConfiguration.ts
+++ b/src/input/findPackagesConfiguration.ts
@@ -14,7 +14,7 @@ export const findPackagesConfiguration = async (
 ): Promise<PackagesConfiguration | Error> => {
     const rawConfiguration = await findReportedConfiguration<PackagesConfiguration>(
         dependencies.exec,
-        "cat",
+        dependencies.platform === "win32" ? "type" : "cat",
         config ?? "./package.json",
     );
 

--- a/src/input/findReportedConfiguration.ts
+++ b/src/input/findReportedConfiguration.ts
@@ -7,6 +7,7 @@ export type DeepPartial<T> = {
 
 export type FindReportedConfigurationDependencies = {
     exec: Exec;
+    platform: string;
 };
 
 export const findReportedConfiguration = async <Configuration>(

--- a/src/input/findTypeScriptConfiguration.test.ts
+++ b/src/input/findTypeScriptConfiguration.test.ts
@@ -5,7 +5,10 @@ describe("findTypeScriptConfiguration", () => {
     it("returns an error when one occurs", async () => {
         // Arrange
         const message = "error";
-        const dependencies = { exec: createStubThrowingExec({ stderr: message }) };
+        const dependencies = {
+            exec: createStubThrowingExec({ stderr: message }),
+            platform: "darwin",
+        };
 
         // Act
         const result = await findTypeScriptConfiguration(dependencies, undefined);
@@ -20,7 +23,7 @@ describe("findTypeScriptConfiguration", () => {
 
     it("defaults the configuration file when one isn't provided", async () => {
         // Arrange
-        const dependencies = { exec: createStubExec() };
+        const dependencies = { exec: createStubExec(), platform: "darwin" };
 
         // Act
         await findTypeScriptConfiguration(dependencies, undefined);
@@ -31,7 +34,7 @@ describe("findTypeScriptConfiguration", () => {
 
     it("includes a configuration file in the TypeScript command when one is provided", async () => {
         // Arrange
-        const dependencies = { exec: createStubExec() };
+        const dependencies = { exec: createStubExec(), platform: "darwin" };
         const config = "./custom/tsconfig.json";
 
         // Act
@@ -45,7 +48,7 @@ describe("findTypeScriptConfiguration", () => {
 
     it("applies TypeScript defaults when none are provided", async () => {
         // Arrange
-        const dependencies = { exec: createStubExec({ stdout: "{}" }) };
+        const dependencies = { exec: createStubExec({ stdout: "{}" }), platform: "darwin" };
         const config = "./tsconfig.json";
 
         // Act


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1150
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Switches `findPackagesConfiguration` to use `type` on Windows instead of `cat`.
