### PR TITLE
feat: add converter for `class-method-newlines` rule

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters.ts
@@ -10,6 +10,7 @@ import { convertBanTsIgnore } from "./ruleConverters/ban-ts-ignore";
 import { convertBanTypes } from "./ruleConverters/ban-types";
 import { convertBinaryExpressionOperandOrder } from "./ruleConverters/binary-expression-operand-order";
 import { convertCallableTypes } from "./ruleConverters/callable-types";
+import { convertClassMethodNewlines } from "./ruleConverters/class-method-newlines";
 import { convertClassName } from "./ruleConverters/class-name";
 import { convertCognitiveComplexity } from "./ruleConverters/cognitive-complexity";
 import { convertCommentFormat } from "./ruleConverters/comment-format";
@@ -353,6 +354,7 @@ export const ruleConverters = new Map([
     ["ban-types", convertBanTypes],
     ["binary-expression-operand-order", convertBinaryExpressionOperandOrder],
     ["callable-types", convertCallableTypes],
+    ["class-method-newlines", convertClassMethodNewlines],
     ["class-name", convertClassName],
     ["cognitive-complexity", convertCognitiveComplexity],
     ["comment-format", convertCommentFormat],

--- a/src/converters/lintConfigs/rules/ruleConverters/class-method-newlines.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/class-method-newlines.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../ruleConverter";
+
+export const convertClassMethodNewlines: RuleConverter = () => {
+    return {
+        plugins: ["eslint-plugin-class-method-newlines"],
+        rules: [
+            {
+                ruleName: "class-method-newlines/class-method-newlines",
+            },
+        ],
+    };
+};

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/class-method-newlines.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/class-method-newlines.test.ts
@@ -1,0 +1,18 @@
+import { convertClassMethodNewlines } from "../class-method-newlines";
+
+describe(convertClassMethodNewlines, () => {
+    test("conversion without arguments", () => {
+        const result = convertClassMethodNewlines({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-class-method-newlines"],
+            rules: [
+                {
+                    ruleName: "class-method-newlines/class-method-newlines",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

-   [X] Addresses an existing issue: fixes #1355
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Very simple standard rule converter with an extra [plugin](https://www.npmjs.com/package/eslint-plugin-class-method-newlines).
