### PR TITLE
Used SWC instead of Babel for Jest tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-    presets: [["@babel/preset-env", { targets: { node: "current" } }], "@babel/preset-typescript"],
-};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
     collectCoverageFrom: [
         "./src/**/*.ts",
-        "!./src/index.ts",
         "!./src/**/*.d.ts",
         "!./src/**/*.stubs.ts",
         "!./src/adapters/*.ts",
@@ -10,6 +9,7 @@ module.exports = {
         "!./src/converters/editorConfigs/editorSettingsConverters.ts",
         "!./src/converters/lintConfigs/rules/ruleConverters.ts",
         "!./src/converters/lintConfigs/rules/ruleMergers.ts",
+        "!./src/index.ts",
     ],
     coverageThreshold: {
         global: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
     collectCoverageFrom: [
         "./src/**/*.ts",
+        "!./src/index.ts",
         "!./src/**/*.d.ts",
         "!./src/**/*.stubs.ts",
         "!./src/adapters/*.ts",
@@ -22,6 +23,13 @@ module.exports = {
     testRegex: "src(.*)\\.test\\.tsx?$",
     testEnvironment: "node",
     transform: {
-        "^.+\\.(t|j)s$": "@swc/jest",
+        "^.+\\.(t|j)s$": [
+            "@swc/jest",
+            {
+                jsc: {
+                    target: "es2021",
+                },
+            },
+        ],
     },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,4 +21,7 @@ module.exports = {
     moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
     testRegex: "src(.*)\\.test\\.tsx?$",
     testEnvironment: "node",
+    transform: {
+        "^.+\\.(t|j)s$": "@swc/jest",
+    },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
                 "tslint-to-eslint-config": "bin/tslint-to-eslint-config"
             },
             "devDependencies": {
-                "@swc/core": "^1.2.143",
                 "@swc/jest": "^0.2.17",
                 "@types/eslint-config-prettier": "6.11.0",
                 "@types/glob": "7.2.0",
@@ -1024,6 +1023,7 @@
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.143.tgz",
             "integrity": "sha512-kZ1OVaNS183b3nMZBDQMev/ULpF/iUcF4bwlx+Nz6GH7D9qGTTbhiN7xWkoCWjcCY1TF8Bt7z1+ddX6ibPSc8w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1059,6 +1059,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1075,6 +1076,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1091,6 +1093,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1107,6 +1110,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1123,6 +1127,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1139,6 +1144,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1155,6 +1161,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1171,6 +1178,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1187,6 +1195,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1203,6 +1212,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1219,6 +1229,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1235,6 +1246,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -1251,6 +1263,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
@@ -6952,6 +6965,7 @@
             "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.143.tgz",
             "integrity": "sha512-kZ1OVaNS183b3nMZBDQMev/ULpF/iUcF4bwlx+Nz6GH7D9qGTTbhiN7xWkoCWjcCY1TF8Bt7z1+ddX6ibPSc8w==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@swc/core-android-arm-eabi": "1.2.143",
                 "@swc/core-android-arm64": "1.2.143",
@@ -6973,91 +6987,104 @@
             "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.143.tgz",
             "integrity": "sha512-OyRhH2NfHRm8jgN6KxpEX5fBg2KaGdocPQgSWzhk9QSnn+juacBXg6lE9lQEb1nekb36XusE51GNiImOnZI9RQ==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-android-arm64": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.143.tgz",
             "integrity": "sha512-hMnZcFkoI26n3QakazyNmuMpaIm/pyC1KJXvp49wTaFazbeG0OqxbWvzUIK3vDnXJPuNf1m9c0jXtvQaXbacvQ==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-darwin-arm64": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.143.tgz",
             "integrity": "sha512-Mcd27MvxBCqNJ9HHEu2RH7lY0zcImSP1/3uivJ4eiiAE7WSUdrs9flhryZ7AlOfs0DR7b4fpjJgK0tZyg9K9Yw==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-darwin-x64": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.143.tgz",
             "integrity": "sha512-KV8147NuOqU6wCliAF+PmpbUecwUn0GynOUjb44kMbwCsYeH/Pm5FewGvyW9Dr7rnpnoT11pOUAJlcRzRfXrDA==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-freebsd-x64": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.143.tgz",
             "integrity": "sha512-SU3hOtPqwaCxTO8jajEaNMO8aU0/5JduuRBbv843UzCz9S2on+dTYNkm94TsBxhX+JYN+T9yGi/tynoTjKj1QA==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-linux-arm-gnueabihf": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.143.tgz",
             "integrity": "sha512-ZGfb0Fz2jQqrRv3gg0gdzQfkZbqTAC9ac03fXx0KiNFgkAjnWNm0JYRQe0sxa1L5wBml2Sv4aAFIN1BHi6roVA==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-linux-arm64-gnu": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.143.tgz",
             "integrity": "sha512-roLB+QYf7omusDTNfqsAuFWMyeRjXi2Wp1abNh++7YZVhkZ57q1tUNJiqw6KJhaSd5KSQGpBygarDRvL70ZZ4Q==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-linux-arm64-musl": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.143.tgz",
             "integrity": "sha512-66qRHVh2F4Z0b6G8n9CEKuKwYVIzfTlNHixwoqCgdCbHT5n1lUiWigDel1psCDbrD/p9nWTU0lfVtbqmKJWnPw==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-linux-x64-gnu": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.143.tgz",
             "integrity": "sha512-FSn9E+uWSyLQtHFpJcj+jNU+NPxrwOMlB+XUObfRcZwRzV6W0KeGLwnwvuhByYmGE7ujvEGCEQpLP95ER88TzQ==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-linux-x64-musl": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.143.tgz",
             "integrity": "sha512-yCD0LkqUVTLz07MD1m5gajfdOobIqUdQ8E0ZarkcCqvd6eLygXb7U2fn0pZs1eadOqxLSjEjig1i2bCx655Z5w==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-win32-arm64-msvc": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.143.tgz",
             "integrity": "sha512-ehdvirsmL5yJ3J5HUcZD48VBFFiINX61FM5NTfRQgZgqGTyZo88iNTHsBmQXaEtp25y9xr6xXtKXeRGIBpuszg==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-win32-ia32-msvc": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.143.tgz",
             "integrity": "sha512-ZWENEbRo9Jbqm/3ezLGotYN7siIEYC5PoJQBi+P/Fg42xm7bUpewIbbGmizOMN0d0+OWVc2V1IFg9bbA0oZbpg==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/core-win32-x64-msvc": {
             "version": "1.2.143",
             "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.143.tgz",
             "integrity": "sha512-IBJ4DLOtMOAzW1+fFkdoj0e85l+CLj+Zn3jjUtdlYKroEunA3xNGci5+Ak/NRvt4lnlPlyVyw+2JXsfpnV2FCA==",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "@swc/jest": {
             "version": "0.2.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,8 +41,7 @@
                 "husky": "7.0.4",
                 "jest": "27.5.1",
                 "lint-staged": "12.3.4",
-                "prettier": "2.5.1",
-                "regenerator-runtime": "^0.13.9"
+                "prettier": "2.5.1"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -5175,12 +5174,6 @@
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.13.9",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-            "dev": true
-        },
         "node_modules/regexpp": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -10004,12 +9997,6 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true
-        },
-        "regenerator-runtime": {
-            "version": "0.13.9",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
             "dev": true
         },
         "regexpp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,8 @@
                 "tslint-to-eslint-config": "bin/tslint-to-eslint-config"
             },
             "devDependencies": {
-                "@babel/core": "7.17.5",
-                "@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
-                "@babel/plugin-proposal-optional-chaining": "7.16.7",
-                "@babel/preset-env": "7.16.11",
-                "@babel/preset-typescript": "7.16.7",
+                "@swc/core": "^1.2.143",
+                "@swc/jest": "^0.2.17",
                 "@types/eslint-config-prettier": "6.11.0",
                 "@types/glob": "7.2.0",
                 "@types/jest": "27.4.0",
@@ -39,13 +36,13 @@
                 "@typescript-eslint/eslint-plugin": "5.12.0",
                 "@typescript-eslint/parser": "5.12.0",
                 "ansi-regex": "6.0.1",
-                "babel-jest": "27.5.1",
                 "eslint": "8.9.0",
                 "eslint-plugin-simple-import-sort": "7.0.0",
                 "husky": "7.0.4",
                 "jest": "27.5.1",
                 "lint-staged": "12.3.4",
-                "prettier": "2.5.1"
+                "prettier": "2.5.1",
+                "regenerator-runtime": "^0.13.9"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -136,31 +133,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
-            "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz",
-            "integrity": "sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-explode-assignable-expression": "^7.16.7",
-                "@babel/types": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
@@ -188,87 +160,10 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.16.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.10.tgz",
-            "integrity": "sha512-wDeej0pu3WN/ffTxMNCPW5UCiOav8IcLRxSIyp/9+IF2xJUM9h/OYjg0IJLHaL6F8oU8kqMz9nc1vryXhMsgXg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-environment-visitor": "^7.16.7",
-                "@babel/helper-function-name": "^7.16.7",
-                "@babel/helper-member-expression-to-functions": "^7.16.7",
-                "@babel/helper-optimise-call-expression": "^7.16.7",
-                "@babel/helper-replace-supers": "^7.16.7",
-                "@babel/helper-split-export-declaration": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.7.tgz",
-            "integrity": "sha512-fk5A6ymfp+O5+p2yCkXAu5Kyj6v0xh0RBeNcAkYUMDvvAAoxvSKXn+Jb37t/yWFiQVDFK1ELpUTD8/aLhCPu+g==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "regexpu-core": "^4.7.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
-            "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-compilation-targets": "^7.13.0",
-                "@babel/helper-module-imports": "^7.12.13",
-                "@babel/helper-plugin-utils": "^7.13.0",
-                "@babel/traverse": "^7.13.0",
-                "debug": "^4.1.1",
-                "lodash.debounce": "^4.0.8",
-                "resolve": "^1.14.2",
-                "semver": "^6.1.2"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.4.0-0"
-            }
-        },
-        "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@babel/helper-environment-visitor": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
             "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-explode-assignable-expression": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz",
-            "integrity": "sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.16.7"
@@ -315,18 +210,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
-            "integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
@@ -358,53 +241,11 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
-            "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-plugin-utils": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
             "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
             "dev": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-remap-async-to-generator": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz",
-            "integrity": "sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-wrap-function": "^7.16.8",
-                "@babel/types": "^7.16.8"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-replace-supers": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
-            "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-environment-visitor": "^7.16.7",
-                "@babel/helper-member-expression-to-functions": "^7.16.7",
-                "@babel/helper-optimise-call-expression": "^7.16.7",
-                "@babel/traverse": "^7.16.7",
-                "@babel/types": "^7.16.7"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -416,18 +257,6 @@
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
-            "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -458,21 +287,6 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
             "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
             "dev": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-wrap-function": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.8.tgz",
-            "integrity": "sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-function-name": "^7.16.7",
-                "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.16.8",
-                "@babel/types": "^7.16.8"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -540,286 +354,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz",
-            "integrity": "sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz",
-            "integrity": "sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-                "@babel/plugin-proposal-optional-chaining": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.13.0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.8.tgz",
-            "integrity": "sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-remap-async-to-generator": "^7.16.8",
-                "@babel/plugin-syntax-async-generators": "^7.8.4"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-class-properties": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
-            "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-class-static-block": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.7.tgz",
-            "integrity": "sha512-dgqJJrcZoG/4CkMopzhPJjGxsIe9A8RlkQLnL/Vhhx8AA9ZuaRwGSlscSh42hazc7WSrya/IK7mTeoF0DP9tEw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.12.0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-dynamic-import": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
-            "integrity": "sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-export-namespace-from": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz",
-            "integrity": "sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-json-strings": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz",
-            "integrity": "sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-json-strings": "^7.8.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz",
-            "integrity": "sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz",
-            "integrity": "sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-numeric-separator": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
-            "integrity": "sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.7.tgz",
-            "integrity": "sha512-3O0Y4+dw94HA86qSg9IHfyPktgR7q3gpNVAeiKQd+8jBKFaU5NQS1Yatgo4wY+UFNuLjvxcSmzcsHqrhgTyBUA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/compat-data": "^7.16.4",
-                "@babel/helper-compilation-targets": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-optional-catch-binding": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz",
-            "integrity": "sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-optional-chaining": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz",
-            "integrity": "sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-private-methods": {
-            "version": "7.16.11",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz",
-            "integrity": "sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.16.10",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-private-property-in-object": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz",
-            "integrity": "sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-create-class-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-unicode-property-regex": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz",
-            "integrity": "sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
         "node_modules/@babel/plugin-syntax-async-generators": {
             "version": "7.8.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -848,45 +382,6 @@
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.12.13"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-class-static-block": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-dynamic-import": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-export-namespace-from": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.3"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/@babel/plugin-syntax-import-meta": {
@@ -964,21 +459,6 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
-        "node_modules/@babel/plugin-syntax-private-property-in-object": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
         "node_modules/@babel/plugin-syntax-top-level-await": {
             "version": "7.14.5",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
@@ -1004,671 +484,6 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
-            "integrity": "sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.8.tgz",
-            "integrity": "sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-remap-async-to-generator": "^7.16.8"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
-            "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz",
-            "integrity": "sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz",
-            "integrity": "sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-environment-visitor": "^7.16.7",
-                "@babel/helper-function-name": "^7.16.7",
-                "@babel/helper-optimise-call-expression": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-replace-supers": "^7.16.7",
-                "@babel/helper-split-export-declaration": "^7.16.7",
-                "globals": "^11.1.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz",
-            "integrity": "sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.7.tgz",
-            "integrity": "sha512-VqAwhTHBnu5xBVDCvrvqJbtLUa++qZaWC0Fgr2mqokBlulZARGyIvZDoqbPlPaKImQ9dKAcCzbv+ul//uqu70A==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-dotall-regex": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz",
-            "integrity": "sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-duplicate-keys": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.7.tgz",
-            "integrity": "sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz",
-            "integrity": "sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
-            "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
-            "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-compilation-targets": "^7.16.7",
-                "@babel/helper-function-name": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-literals": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz",
-            "integrity": "sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
-            "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-modules-amd": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.7.tgz",
-            "integrity": "sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "babel-plugin-dynamic-import-node": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz",
-            "integrity": "sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-simple-access": "^7.16.7",
-                "babel-plugin-dynamic-import-node": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz",
-            "integrity": "sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-hoist-variables": "^7.16.7",
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-validator-identifier": "^7.16.7",
-                "babel-plugin-dynamic-import-node": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-modules-umd": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.7.tgz",
-            "integrity": "sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.8.tgz",
-            "integrity": "sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-new-target": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.7.tgz",
-            "integrity": "sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
-            "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-replace-supers": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz",
-            "integrity": "sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
-            "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz",
-            "integrity": "sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==",
-            "dev": true,
-            "dependencies": {
-                "regenerator-transform": "^0.14.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-reserved-words": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.7.tgz",
-            "integrity": "sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
-            "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz",
-            "integrity": "sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-sticky-regex": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz",
-            "integrity": "sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz",
-            "integrity": "sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-typeof-symbol": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.7.tgz",
-            "integrity": "sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-typescript": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.7.tgz",
-            "integrity": "sha512-Hzx1lvBtOCWuCEwMmYOfpQpO7joFeXLgoPuzZZBtTxXqSqUGUubvFGZv2ygo1tB5Bp9q6PXV3H0E/kf7KM0RLA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-typescript": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-unicode-escapes": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
-            "integrity": "sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-unicode-regex": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz",
-            "integrity": "sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/preset-env": {
-            "version": "7.16.11",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.11.tgz",
-            "integrity": "sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==",
-            "dev": true,
-            "dependencies": {
-                "@babel/compat-data": "^7.16.8",
-                "@babel/helper-compilation-targets": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-validator-option": "^7.16.7",
-                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.7",
-                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.7",
-                "@babel/plugin-proposal-async-generator-functions": "^7.16.8",
-                "@babel/plugin-proposal-class-properties": "^7.16.7",
-                "@babel/plugin-proposal-class-static-block": "^7.16.7",
-                "@babel/plugin-proposal-dynamic-import": "^7.16.7",
-                "@babel/plugin-proposal-export-namespace-from": "^7.16.7",
-                "@babel/plugin-proposal-json-strings": "^7.16.7",
-                "@babel/plugin-proposal-logical-assignment-operators": "^7.16.7",
-                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.7",
-                "@babel/plugin-proposal-numeric-separator": "^7.16.7",
-                "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
-                "@babel/plugin-proposal-optional-chaining": "^7.16.7",
-                "@babel/plugin-proposal-private-methods": "^7.16.11",
-                "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.16.7",
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/plugin-syntax-class-properties": "^7.12.13",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-                "@babel/plugin-syntax-json-strings": "^7.8.3",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-                "@babel/plugin-syntax-top-level-await": "^7.14.5",
-                "@babel/plugin-transform-arrow-functions": "^7.16.7",
-                "@babel/plugin-transform-async-to-generator": "^7.16.8",
-                "@babel/plugin-transform-block-scoped-functions": "^7.16.7",
-                "@babel/plugin-transform-block-scoping": "^7.16.7",
-                "@babel/plugin-transform-classes": "^7.16.7",
-                "@babel/plugin-transform-computed-properties": "^7.16.7",
-                "@babel/plugin-transform-destructuring": "^7.16.7",
-                "@babel/plugin-transform-dotall-regex": "^7.16.7",
-                "@babel/plugin-transform-duplicate-keys": "^7.16.7",
-                "@babel/plugin-transform-exponentiation-operator": "^7.16.7",
-                "@babel/plugin-transform-for-of": "^7.16.7",
-                "@babel/plugin-transform-function-name": "^7.16.7",
-                "@babel/plugin-transform-literals": "^7.16.7",
-                "@babel/plugin-transform-member-expression-literals": "^7.16.7",
-                "@babel/plugin-transform-modules-amd": "^7.16.7",
-                "@babel/plugin-transform-modules-commonjs": "^7.16.8",
-                "@babel/plugin-transform-modules-systemjs": "^7.16.7",
-                "@babel/plugin-transform-modules-umd": "^7.16.7",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.8",
-                "@babel/plugin-transform-new-target": "^7.16.7",
-                "@babel/plugin-transform-object-super": "^7.16.7",
-                "@babel/plugin-transform-parameters": "^7.16.7",
-                "@babel/plugin-transform-property-literals": "^7.16.7",
-                "@babel/plugin-transform-regenerator": "^7.16.7",
-                "@babel/plugin-transform-reserved-words": "^7.16.7",
-                "@babel/plugin-transform-shorthand-properties": "^7.16.7",
-                "@babel/plugin-transform-spread": "^7.16.7",
-                "@babel/plugin-transform-sticky-regex": "^7.16.7",
-                "@babel/plugin-transform-template-literals": "^7.16.7",
-                "@babel/plugin-transform-typeof-symbol": "^7.16.7",
-                "@babel/plugin-transform-unicode-escapes": "^7.16.7",
-                "@babel/plugin-transform-unicode-regex": "^7.16.7",
-                "@babel/preset-modules": "^0.1.5",
-                "@babel/types": "^7.16.8",
-                "babel-plugin-polyfill-corejs2": "^0.3.0",
-                "babel-plugin-polyfill-corejs3": "^0.5.0",
-                "babel-plugin-polyfill-regenerator": "^0.3.0",
-                "core-js-compat": "^3.20.2",
-                "semver": "^6.3.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/preset-env/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@babel/preset-modules": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
-            "integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-                "@babel/plugin-transform-dotall-regex": "^7.4.4",
-                "@babel/types": "^7.4.4",
-                "esutils": "^2.0.2"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/preset-typescript": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz",
-            "integrity": "sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-validator-option": "^7.16.7",
-                "@babel/plugin-transform-typescript": "^7.16.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/runtime": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-            "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-            "dev": true,
-            "dependencies": {
-                "regenerator-runtime": "^0.13.4"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
@@ -1910,6 +725,18 @@
                 "node-notifier": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@jest/create-cache-key-function": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
+            "integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^27.5.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
         "node_modules/@jest/environment": {
@@ -2191,6 +1018,257 @@
             "dev": true,
             "dependencies": {
                 "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "node_modules/@swc/core": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.143.tgz",
+            "integrity": "sha512-kZ1OVaNS183b3nMZBDQMev/ULpF/iUcF4bwlx+Nz6GH7D9qGTTbhiN7xWkoCWjcCY1TF8Bt7z1+ddX6ibPSc8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/swc"
+            },
+            "optionalDependencies": {
+                "@swc/core-android-arm-eabi": "1.2.143",
+                "@swc/core-android-arm64": "1.2.143",
+                "@swc/core-darwin-arm64": "1.2.143",
+                "@swc/core-darwin-x64": "1.2.143",
+                "@swc/core-freebsd-x64": "1.2.143",
+                "@swc/core-linux-arm-gnueabihf": "1.2.143",
+                "@swc/core-linux-arm64-gnu": "1.2.143",
+                "@swc/core-linux-arm64-musl": "1.2.143",
+                "@swc/core-linux-x64-gnu": "1.2.143",
+                "@swc/core-linux-x64-musl": "1.2.143",
+                "@swc/core-win32-arm64-msvc": "1.2.143",
+                "@swc/core-win32-ia32-msvc": "1.2.143",
+                "@swc/core-win32-x64-msvc": "1.2.143"
+            }
+        },
+        "node_modules/@swc/core-android-arm-eabi": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.143.tgz",
+            "integrity": "sha512-OyRhH2NfHRm8jgN6KxpEX5fBg2KaGdocPQgSWzhk9QSnn+juacBXg6lE9lQEb1nekb36XusE51GNiImOnZI9RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-android-arm64": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.143.tgz",
+            "integrity": "sha512-hMnZcFkoI26n3QakazyNmuMpaIm/pyC1KJXvp49wTaFazbeG0OqxbWvzUIK3vDnXJPuNf1m9c0jXtvQaXbacvQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-arm64": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.143.tgz",
+            "integrity": "sha512-Mcd27MvxBCqNJ9HHEu2RH7lY0zcImSP1/3uivJ4eiiAE7WSUdrs9flhryZ7AlOfs0DR7b4fpjJgK0tZyg9K9Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-darwin-x64": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.143.tgz",
+            "integrity": "sha512-KV8147NuOqU6wCliAF+PmpbUecwUn0GynOUjb44kMbwCsYeH/Pm5FewGvyW9Dr7rnpnoT11pOUAJlcRzRfXrDA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-freebsd-x64": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.143.tgz",
+            "integrity": "sha512-SU3hOtPqwaCxTO8jajEaNMO8aU0/5JduuRBbv843UzCz9S2on+dTYNkm94TsBxhX+JYN+T9yGi/tynoTjKj1QA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm-gnueabihf": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.143.tgz",
+            "integrity": "sha512-ZGfb0Fz2jQqrRv3gg0gdzQfkZbqTAC9ac03fXx0KiNFgkAjnWNm0JYRQe0sxa1L5wBml2Sv4aAFIN1BHi6roVA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-gnu": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.143.tgz",
+            "integrity": "sha512-roLB+QYf7omusDTNfqsAuFWMyeRjXi2Wp1abNh++7YZVhkZ57q1tUNJiqw6KJhaSd5KSQGpBygarDRvL70ZZ4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-arm64-musl": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.143.tgz",
+            "integrity": "sha512-66qRHVh2F4Z0b6G8n9CEKuKwYVIzfTlNHixwoqCgdCbHT5n1lUiWigDel1psCDbrD/p9nWTU0lfVtbqmKJWnPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-gnu": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.143.tgz",
+            "integrity": "sha512-FSn9E+uWSyLQtHFpJcj+jNU+NPxrwOMlB+XUObfRcZwRzV6W0KeGLwnwvuhByYmGE7ujvEGCEQpLP95ER88TzQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.143.tgz",
+            "integrity": "sha512-yCD0LkqUVTLz07MD1m5gajfdOobIqUdQ8E0ZarkcCqvd6eLygXb7U2fn0pZs1eadOqxLSjEjig1i2bCx655Z5w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-arm64-msvc": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.143.tgz",
+            "integrity": "sha512-ehdvirsmL5yJ3J5HUcZD48VBFFiINX61FM5NTfRQgZgqGTyZo88iNTHsBmQXaEtp25y9xr6xXtKXeRGIBpuszg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-ia32-msvc": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.143.tgz",
+            "integrity": "sha512-ZWENEbRo9Jbqm/3ezLGotYN7siIEYC5PoJQBi+P/Fg42xm7bUpewIbbGmizOMN0d0+OWVc2V1IFg9bbA0oZbpg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core-win32-x64-msvc": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.143.tgz",
+            "integrity": "sha512-IBJ4DLOtMOAzW1+fFkdoj0e85l+CLj+Zn3jjUtdlYKroEunA3xNGci5+Ak/NRvt4lnlPlyVyw+2JXsfpnV2FCA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/jest": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.17.tgz",
+            "integrity": "sha512-n/g989+O8xxMcTZnP0phDrrgezGZBQBf7cX4QuzEsn07QkWbqmMsfaCxdF0kzajXublXWJ8yk5vRe3VNk1tczA==",
+            "dev": true,
+            "dependencies": {
+                "@jest/create-cache-key-function": "^27.4.2"
+            },
+            "engines": {
+                "npm": ">= 7.0.0"
+            },
+            "peerDependencies": {
+                "@swc/core": "*"
             }
         },
         "node_modules/@tootallnate/once": {
@@ -2854,15 +1932,6 @@
                 "@babel/core": "^7.8.0"
             }
         },
-        "node_modules/babel-plugin-dynamic-import-node": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-            "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-            "dev": true,
-            "dependencies": {
-                "object.assign": "^4.1.0"
-            }
-        },
         "node_modules/babel-plugin-istanbul": {
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -2892,54 +1961,6 @@
             },
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
-            "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
-            "dev": true,
-            "dependencies": {
-                "@babel/compat-data": "^7.13.11",
-                "@babel/helper-define-polyfill-provider": "^0.3.0",
-                "semver": "^6.1.1"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.0.tgz",
-            "integrity": "sha512-Hcrgnmkf+4JTj73GbK3bBhlVPiLL47owUAnoJIf69Hakl3q+KfodbDXiZWGMM7iqCZTxCG3Z2VRfPNYES4rXqQ==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.3.0",
-                "core-js-compat": "^3.20.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
-            "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.3.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
             }
         },
         "node_modules/babel-preset-current-node-syntax": {
@@ -3057,19 +2078,6 @@
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/callsites": {
@@ -3335,29 +2343,6 @@
                 "safe-buffer": "~5.1.1"
             }
         },
-        "node_modules/core-js-compat": {
-            "version": "3.20.2",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.20.2.tgz",
-            "integrity": "sha512-qZEzVQ+5Qh6cROaTPFLNS4lkvQ6mBzE3R6A6EEpssj7Zr2egMHgsy4XapdifqJDGC9CBiNv7s+ejI96rLNQFdg==",
-            "dev": true,
-            "dependencies": {
-                "browserslist": "^4.19.1",
-                "semver": "7.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
-        },
-        "node_modules/core-js-compat/node_modules/semver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-            "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3460,18 +2445,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
-            "dependencies": {
-                "object-keys": "^1.0.12"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/delayed-stream": {
@@ -4217,20 +3190,6 @@
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
-        "node_modules/get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-            "dev": true,
-            "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4352,18 +3311,6 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/html-encoding-sniffer": {
@@ -5655,12 +4602,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "node_modules/lodash.debounce": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-            "dev": true
-        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5923,33 +4864,6 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
             "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
             "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/object.assign": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "has-symbols": "^1.0.1",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -6261,38 +5175,11 @@
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
         },
-        "node_modules/regenerate": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-            "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-            "dev": true
-        },
-        "node_modules/regenerate-unicode-properties": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
-            "integrity": "sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==",
-            "dev": true,
-            "dependencies": {
-                "regenerate": "^1.4.2"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/regenerator-runtime": {
             "version": "0.13.9",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
             "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
             "dev": true
-        },
-        "node_modules/regenerator-transform": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
-            "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.8.4"
-            }
         },
         "node_modules/regexpp": {
             "version": "3.2.0",
@@ -6303,50 +5190,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/mysticatea"
-            }
-        },
-        "node_modules/regexpu-core": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.8.0.tgz",
-            "integrity": "sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==",
-            "dev": true,
-            "dependencies": {
-                "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^9.0.0",
-                "regjsgen": "^0.5.2",
-                "regjsparser": "^0.7.0",
-                "unicode-match-property-ecmascript": "^2.0.0",
-                "unicode-match-property-value-ecmascript": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/regjsgen": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-            "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
-            "dev": true
-        },
-        "node_modules/regjsparser": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.7.0.tgz",
-            "integrity": "sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==",
-            "dev": true,
-            "dependencies": {
-                "jsesc": "~0.5.0"
-            },
-            "bin": {
-                "regjsparser": "bin/parser"
-            }
-        },
-        "node_modules/regjsparser/node_modules/jsesc": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-            "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-            "dev": true,
-            "bin": {
-                "jsesc": "bin/jsesc"
             }
         },
         "node_modules/require-directory": {
@@ -7048,46 +5891,6 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/unicode-canonical-property-names-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/unicode-match-property-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
-            "dev": true,
-            "dependencies": {
-                "unicode-canonical-property-names-ecmascript": "^2.0.0",
-                "unicode-property-aliases-ecmascript": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/unicode-match-property-value-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/unicode-property-aliases-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -7435,25 +6238,6 @@
                 "source-map": "^0.5.0"
             }
         },
-        "@babel/helper-annotate-as-pure": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
-            "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.16.7"
-            }
-        },
-        "@babel/helper-builder-binary-assignment-operator-visitor": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz",
-            "integrity": "sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-explode-assignable-expression": "^7.16.7",
-                "@babel/types": "^7.16.7"
-            }
-        },
         "@babel/helper-compilation-targets": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
@@ -7474,68 +6258,10 @@
                 }
             }
         },
-        "@babel/helper-create-class-features-plugin": {
-            "version": "7.16.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.10.tgz",
-            "integrity": "sha512-wDeej0pu3WN/ffTxMNCPW5UCiOav8IcLRxSIyp/9+IF2xJUM9h/OYjg0IJLHaL6F8oU8kqMz9nc1vryXhMsgXg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-environment-visitor": "^7.16.7",
-                "@babel/helper-function-name": "^7.16.7",
-                "@babel/helper-member-expression-to-functions": "^7.16.7",
-                "@babel/helper-optimise-call-expression": "^7.16.7",
-                "@babel/helper-replace-supers": "^7.16.7",
-                "@babel/helper-split-export-declaration": "^7.16.7"
-            }
-        },
-        "@babel/helper-create-regexp-features-plugin": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.7.tgz",
-            "integrity": "sha512-fk5A6ymfp+O5+p2yCkXAu5Kyj6v0xh0RBeNcAkYUMDvvAAoxvSKXn+Jb37t/yWFiQVDFK1ELpUTD8/aLhCPu+g==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "regexpu-core": "^4.7.1"
-            }
-        },
-        "@babel/helper-define-polyfill-provider": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
-            "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-compilation-targets": "^7.13.0",
-                "@babel/helper-module-imports": "^7.12.13",
-                "@babel/helper-plugin-utils": "^7.13.0",
-                "@babel/traverse": "^7.13.0",
-                "debug": "^4.1.1",
-                "lodash.debounce": "^4.0.8",
-                "resolve": "^1.14.2",
-                "semver": "^6.1.2"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
-        },
         "@babel/helper-environment-visitor": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
             "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.16.7"
-            }
-        },
-        "@babel/helper-explode-assignable-expression": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz",
-            "integrity": "sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.16.7"
@@ -7570,15 +6296,6 @@
                 "@babel/types": "^7.16.7"
             }
         },
-        "@babel/helper-member-expression-to-functions": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
-            "integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.16.7"
-            }
-        },
         "@babel/helper-module-imports": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
@@ -7604,44 +6321,11 @@
                 "@babel/types": "^7.16.7"
             }
         },
-        "@babel/helper-optimise-call-expression": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
-            "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.16.7"
-            }
-        },
         "@babel/helper-plugin-utils": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
             "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
             "dev": true
-        },
-        "@babel/helper-remap-async-to-generator": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz",
-            "integrity": "sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-wrap-function": "^7.16.8",
-                "@babel/types": "^7.16.8"
-            }
-        },
-        "@babel/helper-replace-supers": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
-            "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-environment-visitor": "^7.16.7",
-                "@babel/helper-member-expression-to-functions": "^7.16.7",
-                "@babel/helper-optimise-call-expression": "^7.16.7",
-                "@babel/traverse": "^7.16.7",
-                "@babel/types": "^7.16.7"
-            }
         },
         "@babel/helper-simple-access": {
             "version": "7.16.7",
@@ -7650,15 +6334,6 @@
             "dev": true,
             "requires": {
                 "@babel/types": "^7.16.7"
-            }
-        },
-        "@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
-            "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -7680,18 +6355,6 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
             "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
             "dev": true
-        },
-        "@babel/helper-wrap-function": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.8.tgz",
-            "integrity": "sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-function-name": "^7.16.7",
-                "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.16.8",
-                "@babel/types": "^7.16.8"
-            }
         },
         "@babel/helpers": {
             "version": "7.17.2",
@@ -7740,184 +6403,6 @@
             "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
             "dev": true
         },
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz",
-            "integrity": "sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz",
-            "integrity": "sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-                "@babel/plugin-proposal-optional-chaining": "^7.16.7"
-            }
-        },
-        "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.8.tgz",
-            "integrity": "sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-remap-async-to-generator": "^7.16.8",
-                "@babel/plugin-syntax-async-generators": "^7.8.4"
-            }
-        },
-        "@babel/plugin-proposal-class-properties": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
-            "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-proposal-class-static-block": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.7.tgz",
-            "integrity": "sha512-dgqJJrcZoG/4CkMopzhPJjGxsIe9A8RlkQLnL/Vhhx8AA9ZuaRwGSlscSh42hazc7WSrya/IK7mTeoF0DP9tEw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5"
-            }
-        },
-        "@babel/plugin-proposal-dynamic-import": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
-            "integrity": "sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3"
-            }
-        },
-        "@babel/plugin-proposal-export-namespace-from": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz",
-            "integrity": "sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
-            }
-        },
-        "@babel/plugin-proposal-json-strings": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz",
-            "integrity": "sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-json-strings": "^7.8.3"
-            }
-        },
-        "@babel/plugin-proposal-logical-assignment-operators": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz",
-            "integrity": "sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
-            }
-        },
-        "@babel/plugin-proposal-nullish-coalescing-operator": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz",
-            "integrity": "sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-            }
-        },
-        "@babel/plugin-proposal-numeric-separator": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
-            "integrity": "sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-            }
-        },
-        "@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.7.tgz",
-            "integrity": "sha512-3O0Y4+dw94HA86qSg9IHfyPktgR7q3gpNVAeiKQd+8jBKFaU5NQS1Yatgo4wY+UFNuLjvxcSmzcsHqrhgTyBUA==",
-            "dev": true,
-            "requires": {
-                "@babel/compat-data": "^7.16.4",
-                "@babel/helper-compilation-targets": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.16.7"
-            }
-        },
-        "@babel/plugin-proposal-optional-catch-binding": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz",
-            "integrity": "sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
-            }
-        },
-        "@babel/plugin-proposal-optional-chaining": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz",
-            "integrity": "sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
-            }
-        },
-        "@babel/plugin-proposal-private-methods": {
-            "version": "7.16.11",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz",
-            "integrity": "sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.16.10",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-proposal-private-property-in-object": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz",
-            "integrity": "sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-create-class-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-            }
-        },
-        "@babel/plugin-proposal-unicode-property-regex": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz",
-            "integrity": "sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
         "@babel/plugin-syntax-async-generators": {
             "version": "7.8.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -7943,33 +6428,6 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.12.13"
-            }
-        },
-        "@babel/plugin-syntax-class-static-block": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            }
-        },
-        "@babel/plugin-syntax-dynamic-import": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            }
-        },
-        "@babel/plugin-syntax-export-namespace-from": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
         "@babel/plugin-syntax-import-meta": {
@@ -8044,15 +6502,6 @@
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
-        "@babel/plugin-syntax-private-property-in-object": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            }
-        },
         "@babel/plugin-syntax-top-level-await": {
             "version": "7.14.5",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
@@ -8069,454 +6518,6 @@
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-arrow-functions": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
-            "integrity": "sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-async-to-generator": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.8.tgz",
-            "integrity": "sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-module-imports": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-remap-async-to-generator": "^7.16.8"
-            }
-        },
-        "@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
-            "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-block-scoping": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz",
-            "integrity": "sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-classes": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz",
-            "integrity": "sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-annotate-as-pure": "^7.16.7",
-                "@babel/helper-environment-visitor": "^7.16.7",
-                "@babel/helper-function-name": "^7.16.7",
-                "@babel/helper-optimise-call-expression": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-replace-supers": "^7.16.7",
-                "@babel/helper-split-export-declaration": "^7.16.7",
-                "globals": "^11.1.0"
-            }
-        },
-        "@babel/plugin-transform-computed-properties": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz",
-            "integrity": "sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-destructuring": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.7.tgz",
-            "integrity": "sha512-VqAwhTHBnu5xBVDCvrvqJbtLUa++qZaWC0Fgr2mqokBlulZARGyIvZDoqbPlPaKImQ9dKAcCzbv+ul//uqu70A==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-dotall-regex": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz",
-            "integrity": "sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-duplicate-keys": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.7.tgz",
-            "integrity": "sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-exponentiation-operator": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz",
-            "integrity": "sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-for-of": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
-            "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-function-name": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
-            "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-compilation-targets": "^7.16.7",
-                "@babel/helper-function-name": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-literals": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz",
-            "integrity": "sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-member-expression-literals": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
-            "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-modules-amd": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.7.tgz",
-            "integrity": "sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "babel-plugin-dynamic-import-node": "^2.3.3"
-            }
-        },
-        "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz",
-            "integrity": "sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-simple-access": "^7.16.7",
-                "babel-plugin-dynamic-import-node": "^2.3.3"
-            }
-        },
-        "@babel/plugin-transform-modules-systemjs": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz",
-            "integrity": "sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-hoist-variables": "^7.16.7",
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-validator-identifier": "^7.16.7",
-                "babel-plugin-dynamic-import-node": "^2.3.3"
-            }
-        },
-        "@babel/plugin-transform-modules-umd": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.7.tgz",
-            "integrity": "sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-named-capturing-groups-regex": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.8.tgz",
-            "integrity": "sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-new-target": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.7.tgz",
-            "integrity": "sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-object-super": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
-            "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-replace-supers": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-parameters": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz",
-            "integrity": "sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-property-literals": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
-            "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-regenerator": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz",
-            "integrity": "sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==",
-            "dev": true,
-            "requires": {
-                "regenerator-transform": "^0.14.2"
-            }
-        },
-        "@babel/plugin-transform-reserved-words": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.7.tgz",
-            "integrity": "sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-shorthand-properties": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
-            "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-spread": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz",
-            "integrity": "sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
-            }
-        },
-        "@babel/plugin-transform-sticky-regex": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz",
-            "integrity": "sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-template-literals": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz",
-            "integrity": "sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-typeof-symbol": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.7.tgz",
-            "integrity": "sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-typescript": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.7.tgz",
-            "integrity": "sha512-Hzx1lvBtOCWuCEwMmYOfpQpO7joFeXLgoPuzZZBtTxXqSqUGUubvFGZv2ygo1tB5Bp9q6PXV3H0E/kf7KM0RLA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/plugin-syntax-typescript": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-unicode-escapes": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
-            "integrity": "sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/plugin-transform-unicode-regex": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz",
-            "integrity": "sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7"
-            }
-        },
-        "@babel/preset-env": {
-            "version": "7.16.11",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.11.tgz",
-            "integrity": "sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==",
-            "dev": true,
-            "requires": {
-                "@babel/compat-data": "^7.16.8",
-                "@babel/helper-compilation-targets": "^7.16.7",
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-validator-option": "^7.16.7",
-                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.7",
-                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.7",
-                "@babel/plugin-proposal-async-generator-functions": "^7.16.8",
-                "@babel/plugin-proposal-class-properties": "^7.16.7",
-                "@babel/plugin-proposal-class-static-block": "^7.16.7",
-                "@babel/plugin-proposal-dynamic-import": "^7.16.7",
-                "@babel/plugin-proposal-export-namespace-from": "^7.16.7",
-                "@babel/plugin-proposal-json-strings": "^7.16.7",
-                "@babel/plugin-proposal-logical-assignment-operators": "^7.16.7",
-                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.7",
-                "@babel/plugin-proposal-numeric-separator": "^7.16.7",
-                "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
-                "@babel/plugin-proposal-optional-chaining": "^7.16.7",
-                "@babel/plugin-proposal-private-methods": "^7.16.11",
-                "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.16.7",
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/plugin-syntax-class-properties": "^7.12.13",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-                "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-                "@babel/plugin-syntax-json-strings": "^7.8.3",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-                "@babel/plugin-syntax-top-level-await": "^7.14.5",
-                "@babel/plugin-transform-arrow-functions": "^7.16.7",
-                "@babel/plugin-transform-async-to-generator": "^7.16.8",
-                "@babel/plugin-transform-block-scoped-functions": "^7.16.7",
-                "@babel/plugin-transform-block-scoping": "^7.16.7",
-                "@babel/plugin-transform-classes": "^7.16.7",
-                "@babel/plugin-transform-computed-properties": "^7.16.7",
-                "@babel/plugin-transform-destructuring": "^7.16.7",
-                "@babel/plugin-transform-dotall-regex": "^7.16.7",
-                "@babel/plugin-transform-duplicate-keys": "^7.16.7",
-                "@babel/plugin-transform-exponentiation-operator": "^7.16.7",
-                "@babel/plugin-transform-for-of": "^7.16.7",
-                "@babel/plugin-transform-function-name": "^7.16.7",
-                "@babel/plugin-transform-literals": "^7.16.7",
-                "@babel/plugin-transform-member-expression-literals": "^7.16.7",
-                "@babel/plugin-transform-modules-amd": "^7.16.7",
-                "@babel/plugin-transform-modules-commonjs": "^7.16.8",
-                "@babel/plugin-transform-modules-systemjs": "^7.16.7",
-                "@babel/plugin-transform-modules-umd": "^7.16.7",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.8",
-                "@babel/plugin-transform-new-target": "^7.16.7",
-                "@babel/plugin-transform-object-super": "^7.16.7",
-                "@babel/plugin-transform-parameters": "^7.16.7",
-                "@babel/plugin-transform-property-literals": "^7.16.7",
-                "@babel/plugin-transform-regenerator": "^7.16.7",
-                "@babel/plugin-transform-reserved-words": "^7.16.7",
-                "@babel/plugin-transform-shorthand-properties": "^7.16.7",
-                "@babel/plugin-transform-spread": "^7.16.7",
-                "@babel/plugin-transform-sticky-regex": "^7.16.7",
-                "@babel/plugin-transform-template-literals": "^7.16.7",
-                "@babel/plugin-transform-typeof-symbol": "^7.16.7",
-                "@babel/plugin-transform-unicode-escapes": "^7.16.7",
-                "@babel/plugin-transform-unicode-regex": "^7.16.7",
-                "@babel/preset-modules": "^0.1.5",
-                "@babel/types": "^7.16.8",
-                "babel-plugin-polyfill-corejs2": "^0.3.0",
-                "babel-plugin-polyfill-corejs3": "^0.5.0",
-                "babel-plugin-polyfill-regenerator": "^0.3.0",
-                "core-js-compat": "^3.20.2",
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
-        },
-        "@babel/preset-modules": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
-            "integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-                "@babel/plugin-transform-dotall-regex": "^7.4.4",
-                "@babel/types": "^7.4.4",
-                "esutils": "^2.0.2"
-            }
-        },
-        "@babel/preset-typescript": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz",
-            "integrity": "sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-validator-option": "^7.16.7",
-                "@babel/plugin-transform-typescript": "^7.16.7"
-            }
-        },
-        "@babel/runtime": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-            "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
-            "dev": true,
-            "requires": {
-                "regenerator-runtime": "^0.13.4"
             }
         },
         "@babel/template": {
@@ -8711,6 +6712,15 @@
                 "rimraf": "^3.0.0",
                 "slash": "^3.0.0",
                 "strip-ansi": "^6.0.0"
+            }
+        },
+        "@jest/create-cache-key-function": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
+            "integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+            "dev": true,
+            "requires": {
+                "@jest/types": "^27.5.1"
             }
         },
         "@jest/environment": {
@@ -8942,6 +6952,127 @@
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.7.0"
+            }
+        },
+        "@swc/core": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.143.tgz",
+            "integrity": "sha512-kZ1OVaNS183b3nMZBDQMev/ULpF/iUcF4bwlx+Nz6GH7D9qGTTbhiN7xWkoCWjcCY1TF8Bt7z1+ddX6ibPSc8w==",
+            "dev": true,
+            "requires": {
+                "@swc/core-android-arm-eabi": "1.2.143",
+                "@swc/core-android-arm64": "1.2.143",
+                "@swc/core-darwin-arm64": "1.2.143",
+                "@swc/core-darwin-x64": "1.2.143",
+                "@swc/core-freebsd-x64": "1.2.143",
+                "@swc/core-linux-arm-gnueabihf": "1.2.143",
+                "@swc/core-linux-arm64-gnu": "1.2.143",
+                "@swc/core-linux-arm64-musl": "1.2.143",
+                "@swc/core-linux-x64-gnu": "1.2.143",
+                "@swc/core-linux-x64-musl": "1.2.143",
+                "@swc/core-win32-arm64-msvc": "1.2.143",
+                "@swc/core-win32-ia32-msvc": "1.2.143",
+                "@swc/core-win32-x64-msvc": "1.2.143"
+            }
+        },
+        "@swc/core-android-arm-eabi": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.143.tgz",
+            "integrity": "sha512-OyRhH2NfHRm8jgN6KxpEX5fBg2KaGdocPQgSWzhk9QSnn+juacBXg6lE9lQEb1nekb36XusE51GNiImOnZI9RQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-android-arm64": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.143.tgz",
+            "integrity": "sha512-hMnZcFkoI26n3QakazyNmuMpaIm/pyC1KJXvp49wTaFazbeG0OqxbWvzUIK3vDnXJPuNf1m9c0jXtvQaXbacvQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-darwin-arm64": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.143.tgz",
+            "integrity": "sha512-Mcd27MvxBCqNJ9HHEu2RH7lY0zcImSP1/3uivJ4eiiAE7WSUdrs9flhryZ7AlOfs0DR7b4fpjJgK0tZyg9K9Yw==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-darwin-x64": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.143.tgz",
+            "integrity": "sha512-KV8147NuOqU6wCliAF+PmpbUecwUn0GynOUjb44kMbwCsYeH/Pm5FewGvyW9Dr7rnpnoT11pOUAJlcRzRfXrDA==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-freebsd-x64": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.143.tgz",
+            "integrity": "sha512-SU3hOtPqwaCxTO8jajEaNMO8aU0/5JduuRBbv843UzCz9S2on+dTYNkm94TsBxhX+JYN+T9yGi/tynoTjKj1QA==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-arm-gnueabihf": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.143.tgz",
+            "integrity": "sha512-ZGfb0Fz2jQqrRv3gg0gdzQfkZbqTAC9ac03fXx0KiNFgkAjnWNm0JYRQe0sxa1L5wBml2Sv4aAFIN1BHi6roVA==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-arm64-gnu": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.143.tgz",
+            "integrity": "sha512-roLB+QYf7omusDTNfqsAuFWMyeRjXi2Wp1abNh++7YZVhkZ57q1tUNJiqw6KJhaSd5KSQGpBygarDRvL70ZZ4Q==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-arm64-musl": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.143.tgz",
+            "integrity": "sha512-66qRHVh2F4Z0b6G8n9CEKuKwYVIzfTlNHixwoqCgdCbHT5n1lUiWigDel1psCDbrD/p9nWTU0lfVtbqmKJWnPw==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-x64-gnu": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.143.tgz",
+            "integrity": "sha512-FSn9E+uWSyLQtHFpJcj+jNU+NPxrwOMlB+XUObfRcZwRzV6W0KeGLwnwvuhByYmGE7ujvEGCEQpLP95ER88TzQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-linux-x64-musl": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.143.tgz",
+            "integrity": "sha512-yCD0LkqUVTLz07MD1m5gajfdOobIqUdQ8E0ZarkcCqvd6eLygXb7U2fn0pZs1eadOqxLSjEjig1i2bCx655Z5w==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-win32-arm64-msvc": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.143.tgz",
+            "integrity": "sha512-ehdvirsmL5yJ3J5HUcZD48VBFFiINX61FM5NTfRQgZgqGTyZo88iNTHsBmQXaEtp25y9xr6xXtKXeRGIBpuszg==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-win32-ia32-msvc": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.143.tgz",
+            "integrity": "sha512-ZWENEbRo9Jbqm/3ezLGotYN7siIEYC5PoJQBi+P/Fg42xm7bUpewIbbGmizOMN0d0+OWVc2V1IFg9bbA0oZbpg==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/core-win32-x64-msvc": {
+            "version": "1.2.143",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.143.tgz",
+            "integrity": "sha512-IBJ4DLOtMOAzW1+fFkdoj0e85l+CLj+Zn3jjUtdlYKroEunA3xNGci5+Ak/NRvt4lnlPlyVyw+2JXsfpnV2FCA==",
+            "dev": true,
+            "optional": true
+        },
+        "@swc/jest": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.17.tgz",
+            "integrity": "sha512-n/g989+O8xxMcTZnP0phDrrgezGZBQBf7cX4QuzEsn07QkWbqmMsfaCxdF0kzajXublXWJ8yk5vRe3VNk1tczA==",
+            "dev": true,
+            "requires": {
+                "@jest/create-cache-key-function": "^27.4.2"
             }
         },
         "@tootallnate/once": {
@@ -9429,15 +7560,6 @@
                 "slash": "^3.0.0"
             }
         },
-        "babel-plugin-dynamic-import-node": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-            "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-            "dev": true,
-            "requires": {
-                "object.assign": "^4.1.0"
-            }
-        },
         "babel-plugin-istanbul": {
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -9461,44 +7583,6 @@
                 "@babel/types": "^7.3.3",
                 "@types/babel__core": "^7.0.0",
                 "@types/babel__traverse": "^7.0.6"
-            }
-        },
-        "babel-plugin-polyfill-corejs2": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
-            "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
-            "dev": true,
-            "requires": {
-                "@babel/compat-data": "^7.13.11",
-                "@babel/helper-define-polyfill-provider": "^0.3.0",
-                "semver": "^6.1.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
-        },
-        "babel-plugin-polyfill-corejs3": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.0.tgz",
-            "integrity": "sha512-Hcrgnmkf+4JTj73GbK3bBhlVPiLL47owUAnoJIf69Hakl3q+KfodbDXiZWGMM7iqCZTxCG3Z2VRfPNYES4rXqQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-define-polyfill-provider": "^0.3.0",
-                "core-js-compat": "^3.20.0"
-            }
-        },
-        "babel-plugin-polyfill-regenerator": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
-            "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-define-polyfill-provider": "^0.3.0"
             }
         },
         "babel-preset-current-node-syntax": {
@@ -9592,16 +7676,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-        },
-        "call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
-            }
         },
         "callsites": {
             "version": "3.1.0",
@@ -9807,24 +7881,6 @@
                 "safe-buffer": "~5.1.1"
             }
         },
-        "core-js-compat": {
-            "version": "3.20.2",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.20.2.tgz",
-            "integrity": "sha512-qZEzVQ+5Qh6cROaTPFLNS4lkvQ6mBzE3R6A6EEpssj7Zr2egMHgsy4XapdifqJDGC9CBiNv7s+ejI96rLNQFdg==",
-            "dev": true,
-            "requires": {
-                "browserslist": "^4.19.1",
-                "semver": "7.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-                    "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-                    "dev": true
-                }
-            }
-        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -9907,15 +7963,6 @@
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
             "dev": true
-        },
-        "define-properties": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
-            "requires": {
-                "object-keys": "^1.0.12"
-            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -10475,17 +8522,6 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
-        "get-intrinsic": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-            "dev": true,
-            "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
-            }
-        },
         "get-package-type": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -10576,12 +8612,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "has-symbols": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-            "dev": true
         },
         "html-encoding-sniffer": {
             "version": "2.0.1",
@@ -11550,12 +9580,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "lodash.debounce": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-            "dev": true
-        },
         "lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -11767,24 +9791,6 @@
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
             "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
             "dev": true
-        },
-        "object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true
-        },
-        "object.assign": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3",
-                "has-symbols": "^1.0.1",
-                "object-keys": "^1.1.1"
-            }
         },
         "once": {
             "version": "1.4.0",
@@ -12000,77 +10006,16 @@
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
         },
-        "regenerate": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-            "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-            "dev": true
-        },
-        "regenerate-unicode-properties": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
-            "integrity": "sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==",
-            "dev": true,
-            "requires": {
-                "regenerate": "^1.4.2"
-            }
-        },
         "regenerator-runtime": {
             "version": "0.13.9",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
             "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
             "dev": true
         },
-        "regenerator-transform": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
-            "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.8.4"
-            }
-        },
         "regexpp": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
             "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
-        },
-        "regexpu-core": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.8.0.tgz",
-            "integrity": "sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==",
-            "dev": true,
-            "requires": {
-                "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^9.0.0",
-                "regjsgen": "^0.5.2",
-                "regjsparser": "^0.7.0",
-                "unicode-match-property-ecmascript": "^2.0.0",
-                "unicode-match-property-value-ecmascript": "^2.0.0"
-            }
-        },
-        "regjsgen": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-            "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
-            "dev": true
-        },
-        "regjsparser": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.7.0.tgz",
-            "integrity": "sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==",
-            "dev": true,
-            "requires": {
-                "jsesc": "~0.5.0"
-            },
-            "dependencies": {
-                "jsesc": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-                    "dev": true
-                }
-            }
         },
         "require-directory": {
             "version": "2.1.1",
@@ -12617,34 +10562,6 @@
             "version": "4.5.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
-        },
-        "unicode-canonical-property-names-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
-            "dev": true
-        },
-        "unicode-match-property-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
-            "dev": true,
-            "requires": {
-                "unicode-canonical-property-names-ecmascript": "^2.0.0",
-                "unicode-property-aliases-ecmascript": "^2.0.0"
-            }
-        },
-        "unicode-match-property-value-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==",
-            "dev": true
-        },
-        "unicode-property-aliases-ecmascript": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
-            "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
-            "dev": true
         },
         "universalify": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,8 @@
         "typescript": "4.5.5"
     },
     "devDependencies": {
-        "@babel/core": "7.17.5",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "7.16.7",
-        "@babel/preset-env": "7.16.11",
-        "@babel/preset-typescript": "7.16.7",
+        "@swc/core": "^1.2.143",
+        "@swc/jest": "^0.2.17",
         "@types/eslint-config-prettier": "6.11.0",
         "@types/glob": "7.2.0",
         "@types/jest": "27.4.0",
@@ -37,13 +34,13 @@
         "@typescript-eslint/eslint-plugin": "5.12.0",
         "@typescript-eslint/parser": "5.12.0",
         "ansi-regex": "6.0.1",
-        "babel-jest": "27.5.1",
         "eslint": "8.9.0",
         "eslint-plugin-simple-import-sort": "7.0.0",
         "husky": "7.0.4",
         "jest": "27.5.1",
         "lint-staged": "12.3.4",
-        "prettier": "2.5.1"
+        "prettier": "2.5.1",
+        "regenerator-runtime": "^0.13.9"
     },
     "homepage": "https://github.com/typescript-eslint/tslint-to-eslint-config#readme",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
         "husky": "7.0.4",
         "jest": "27.5.1",
         "lint-staged": "12.3.4",
-        "prettier": "2.5.1",
-        "regenerator-runtime": "^0.13.9"
+        "prettier": "2.5.1"
     },
     "homepage": "https://github.com/typescript-eslint/tslint-to-eslint-config#readme",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "typescript": "4.5.5"
     },
     "devDependencies": {
-        "@swc/core": "^1.2.143",
         "@swc/jest": "^0.2.17",
         "@types/eslint-config-prettier": "6.11.0",
         "@types/glob": "7.2.0",


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1366
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Uses `@swc/jest` instead of `babel-jest`.

-   Execution: `jest --clearCache` before each command. Terminal was in focus and no actions taken on open programs during test runs.
-   Hardware: Surface Laptop 4, 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz.
-   Reporting: Time ranges are rounded numbers from 7 runs with the highest and lowest values removed.
-   Software: WSL 2.0 in an Ubuntu drive via a VS Code terminal.

| Command                          | Babel Time    | SWC Time      | (old - new) / old x 100% |
| -------------------------------- | ------------- | ------------- | ------------------------ |
| `jest`                           | 18-20 seconds | 11-14 seconds | **30-40%** faster        |
| `jest --coverage --maxWorkers=2` | 23-28 seconds | 20-25 seconds | **10-13%** faster        |


Sorted raw time data:

* Babel:
    * `jest`: 16.151, 17.686, 18.548, 18.738, 19.278, 19.676, 20.091
    * `jest --coverage --maxWorkers=2`: 22.320, 23.239, 24.898, 25.109, 27.087, 27.724, 28.649
* SWC:
    * `jest`: 11.488, 11.862, 12.709, 13.558, 13.932, 14.215, 14.351
    * `jest --coverage --maxWorkers=2`: 19.839, 20.708, 22.430, 23.670, 24.704, 25.013, 25.248