### PR TITLE
Lower jsc.target to es2019

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,7 @@ module.exports = {
             "@swc/jest",
             {
                 jsc: {
-                    target: "es2021",
+                    target: "es2019",
                 },
             },
         ],


### PR DESCRIPTION
## PR Checklist

-   ~[ ] Addresses an existing issue: fixes #000~
-   ~[ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)~

## Overview

Node 12 is still in LTS for a couple more months. See https://github.com/typescript-eslint/tslint-to-eslint-config/pull/1370. Follows up on #1367 
