### PR TITLE
Bumped minimum Node version to 14 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The `tslint-to-eslint-config` command reads in any existing linter, TypeScript, 
 For any TSLint rules with corresponding ESLint equivalents, those equivalents will be used in the new configuration.
 TSLint rules without ESLint equivalents will be wrapped with [eslint-plugin-tslint](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin-tslint).
 
-> Requires Node 12+ (LTS) and TSLint 5.18+
+> Requires Node 14+ (LTS) and TSLint 5.18+
 
 ### FAQs
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -9,7 +9,7 @@ Please do file issues if you find bugs or lacking features!
 
 ## Local Setup
 
-After installing [Node >= 12 (latest LTS)](https://nodejs.org/en/download), clone and install packages locally with:
+After installing [Node >= 14 (latest LTS)](https://nodejs.org/en/download), clone and install packages locally with:
 
 ```shell
 git clone https://github.com/typescript-eslint/tslint-to-eslint-config

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "prettier": "2.5.1"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "description": "Converts your TSLint configuration to the closest reasonable ESLint equivalent.",
     "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
     },
     "dependencies": {
         "chalk": "4.1.2",


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1375
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Switches the engine to >14.0.0.