### PR TITLE
Use @jest/globals

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
     },
     "prettier.ignorePath": ".prettierignore",
     "typescript.tsdk": "node_modules/typescript/lib",
-    "editor.tabSize": 4
+    "editor.tabSize": 4,
+    "eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
                 "@swc/jest": "0.2.17",
                 "@types/eslint-config-prettier": "6.11.0",
                 "@types/glob": "7.2.0",
-                "@types/jest": "27.4.1",
                 "@types/json5": "0.0.30",
                 "@types/lodash": "4.14.178",
                 "@types/minimatch": "3.0.5",
@@ -1367,16 +1366,6 @@
             "dev": true,
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
-            }
-        },
-        "node_modules/@types/jest": {
-            "version": "27.4.1",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-            "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
-            "dev": true,
-            "dependencies": {
-                "jest-matcher-utils": "^27.0.0",
-                "pretty-format": "^27.0.0"
             }
         },
         "node_modules/@types/json-schema": {
@@ -7162,16 +7151,6 @@
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-report": "*"
-            }
-        },
-        "@types/jest": {
-            "version": "27.4.1",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-            "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
-            "dev": true,
-            "requires": {
-                "jest-matcher-utils": "^27.0.0",
-                "pretty-format": "^27.0.0"
             }
         },
         "@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "@swc/jest": "0.2.17",
         "@types/eslint-config-prettier": "6.11.0",
         "@types/glob": "7.2.0",
-        "@types/jest": "27.4.1",
         "@types/json5": "0.0.30",
         "@types/lodash": "4.14.178",
         "@types/minimatch": "3.0.5",

--- a/src/adapters/exec.stubs.ts
+++ b/src/adapters/exec.stubs.ts
@@ -1,10 +1,16 @@
+import { fn } from "../fn";
+import { Exec } from "./exec";
+
 export type CreateStubExecSettings = {
     stderr: string;
     stdout: string;
 };
 
 export const createStubExec = ({ stderr = "", stdout = "" } = {}) =>
-    jest.fn().mockReturnValue(Promise.resolve({ stderr, stdout }));
+    fn<Exec>().mockResolvedValue({ stderr, stdout });
 
-export const createStubThrowingExec = ({ stderr = "" } = {}) =>
-    jest.fn().mockRejectedValue(new Error(stderr));
+export const createStubThrowingExec =
+    ({ stderr = "" } = {}) =>
+    async () => {
+        throw new Error(stderr);
+    };

--- a/src/adapters/fileSystem.stub.ts
+++ b/src/adapters/fileSystem.stub.ts
@@ -1,5 +1,8 @@
+import { FileSystem } from "../adapters/fileSystem";
+import { fn } from "../fn";
+
 export const createStubFileSystem = ({ data = {}, exists = true } = {}) => ({
-    fileExists: jest.fn().mockReturnValue(exists),
-    readFile: jest.fn().mockReturnValue(Promise.resolve(data)),
-    writeFile: jest.fn(),
+    fileExists: async () => exists,
+    readFile: async () => data,
+    writeFile: fn<FileSystem["writeFile"]>(),
 });

--- a/src/adapters/logger.stubs.ts
+++ b/src/adapters/logger.stubs.ts
@@ -1,28 +1,31 @@
+import { expect } from "@jest/globals";
+import { Mock } from "jest-mock";
 import { EOL } from "os";
 
+import { fn } from "../fn";
 import { stripAnsi } from "./stripAnsi.stubs";
 
 const debugFileName = "stub-output.log";
 
 const createStubWritableStream = () => ({
     writable: true,
-    addListener: jest.fn(),
-    emit: jest.fn(),
-    end: jest.fn(),
-    eventNames: jest.fn(),
-    getMaxListeners: jest.fn(),
-    listenerCount: jest.fn(),
-    listeners: jest.fn(),
-    off: jest.fn(),
-    on: jest.fn(),
-    once: jest.fn(),
-    prependListener: jest.fn(),
-    prependOnceListener: jest.fn(),
-    rawListeners: jest.fn(),
-    removeAllListeners: jest.fn(),
-    removeListener: jest.fn(),
-    setMaxListeners: jest.fn(),
-    write: jest.fn(),
+    addListener: fn<NodeJS.WritableStream["addListener"]>(),
+    emit: fn<NodeJS.WritableStream["emit"]>(),
+    end: fn<NodeJS.WritableStream["end"]>(),
+    eventNames: fn<NodeJS.WritableStream["eventNames"]>(),
+    getMaxListeners: fn<NodeJS.WritableStream["getMaxListeners"]>(),
+    listenerCount: fn<NodeJS.WritableStream["listenerCount"]>(),
+    listeners: fn<NodeJS.WritableStream["listeners"]>(),
+    off: fn<NodeJS.WritableStream["off"]>(),
+    on: fn<NodeJS.WritableStream["on"]>(),
+    once: fn<NodeJS.WritableStream["once"]>(),
+    prependListener: fn<NodeJS.WritableStream["prependListener"]>(),
+    prependOnceListener: fn<NodeJS.WritableStream["prependOnceListener"]>(),
+    rawListeners: fn<NodeJS.WritableStream["rawListeners"]>(),
+    removeAllListeners: fn<NodeJS.WritableStream["removeAllListeners"]>(),
+    removeListener: fn<NodeJS.WritableStream["removeListener"]>(),
+    setMaxListeners: fn<NodeJS.WritableStream["setMaxListeners"]>(),
+    write: fn<NodeJS.WritableStream["write"]>(),
 });
 
 export const createStubLogger = () => ({
@@ -40,9 +43,9 @@ const removeOddCharactersAndTrim = (text: string) =>
         )
         .trim();
 
-export const expectEqualWrites = (fn: jest.Mock, ...actual: string[]) => {
+export const expectEqualWrites = (writer: Mock<any, any>, ...actual: string[]) => {
     const realCalls = removeOddCharactersAndTrim(
-        fn.mock.calls.map((args) => args.join("")).join(""),
+        writer.mock.calls.map((args) => args.join("")).join(""),
     );
     const actualCalls = removeOddCharactersAndTrim(actual.join(EOL) + EOL);
 

--- a/src/binding.test.ts
+++ b/src/binding.test.ts
@@ -6,7 +6,7 @@ describe("bind", () => {
     it("calls the original method with bound dependencies when called", () => {
         // Arrange
         const dependencies = { original: true };
-        const method = jest.fn<void, [unknown, string, string]>();
+        const method = jest.fn<undefined, [unknown, string, string]>();
         const bound = bind(method, dependencies);
 
         // Act

--- a/src/binding.test.ts
+++ b/src/binding.test.ts
@@ -1,10 +1,12 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
 import { bind } from "./binding";
 
 describe("bind", () => {
     it("calls the original method with bound dependencies when called", () => {
         // Arrange
         const dependencies = { original: true };
-        const method = jest.fn();
+        const method = jest.fn<void, [unknown, string, string]>();
         const bound = bind(method, dependencies);
 
         // Act

--- a/src/cli/runCli.test.ts
+++ b/src/cli/runCli.test.ts
@@ -1,19 +1,21 @@
+import { describe, expect, it } from "@jest/globals";
 import { EOL } from "os";
 
 import { version } from "../../package.json";
 import { createStubLogger, expectEqualWrites } from "../adapters/logger.stubs";
 import { createStubOriginalConfigurationsData } from "../settings.stubs";
-import { ResultStatus, TSLintToESLintResult } from "../types";
+import { ConfigurationErrorResult, ResultStatus, TSLintToESLintResult } from "../types";
 import { runCli, RunCliDependencies } from "./runCli";
 
 const createStubArgv = (argv: string[] = []) => ["node", "some/path/bin/file", ...argv];
 
 const createStubRunCliDependencies = (overrides: Partial<RunCliDependencies> = {}) => ({
     converters: [async (): Promise<TSLintToESLintResult> => ({ status: ResultStatus.Succeeded })],
-    findOriginalConfigurations: jest.fn().mockResolvedValue({
-        data: createStubOriginalConfigurationsData(),
-        status: ResultStatus.Succeeded,
-    }),
+    findOriginalConfigurations: async () =>
+        ({
+            data: createStubOriginalConfigurationsData(),
+            status: ResultStatus.Succeeded,
+        } as const),
     ...overrides,
     logger: createStubLogger(),
 });
@@ -35,9 +37,9 @@ describe("runCli", () => {
         // Arrange
         const message = "Oh no";
         const dependencies = createStubRunCliDependencies({
-            findOriginalConfigurations: jest.fn().mockResolvedValue({
-                errors: [new Error(message)],
-                status: ResultStatus.Failed,
+            findOriginalConfigurations: async (): Promise<ConfigurationErrorResult> => ({
+                complaints: [message],
+                status: ResultStatus.ConfigurationError,
             }),
         });
 
@@ -48,7 +50,7 @@ describe("runCli", () => {
         expect(dependencies.logger.stderr.write).toHaveBeenLastCalledWith(
             expect.stringMatching(message),
         );
-        expect(status).toBe(ResultStatus.Failed);
+        expect(status).toBe(ResultStatus.ConfigurationError);
     });
 
     it("logs an error when a converter fails", async () => {

--- a/src/comments/collectCommentFileNames.test.ts
+++ b/src/comments/collectCommentFileNames.test.ts
@@ -1,8 +1,14 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { collectCommentFileNames } from "./collectCommentFileNames";
+
+const stubFoundConfiguration = {
+    include: ["a.ts"],
+};
 
 describe("collectCommentFileNames", () => {
     it("returns an error result when filePathGlobs is true and typescriptConfiguration is undefined", async () => {
-        const findTypeScriptConfiguration = jest.fn();
+        const findTypeScriptConfiguration = async () => stubFoundConfiguration;
 
         const result = await collectCommentFileNames({ findTypeScriptConfiguration }, true);
 
@@ -10,7 +16,7 @@ describe("collectCommentFileNames", () => {
     });
 
     it("returns the typescript configuration when filePathGlobs is true and typescriptConfiguration exists", async () => {
-        const findTypeScriptConfiguration = jest.fn();
+        const findTypeScriptConfiguration = async () => stubFoundConfiguration;
         const typescriptConfiguration = {
             include: ["a.ts"],
         };
@@ -25,7 +31,7 @@ describe("collectCommentFileNames", () => {
     });
 
     it("returns the input file paths when filePathGlobs is an array", async () => {
-        const findTypeScriptConfiguration = jest.fn();
+        const findTypeScriptConfiguration = async () => stubFoundConfiguration;
         const filePathGlobs = ["a.ts"];
 
         const result = await collectCommentFileNames(
@@ -39,7 +45,9 @@ describe("collectCommentFileNames", () => {
     });
 
     it("returns the input file path when filePathGlobs is a source file path string", async () => {
-        const findTypeScriptConfiguration = jest.fn();
+        const findTypeScriptConfiguration = async () => ({
+            include: ["a.ts"],
+        });
         const filePathGlobs = "a.ts";
 
         const result = await collectCommentFileNames(
@@ -54,7 +62,7 @@ describe("collectCommentFileNames", () => {
 
     it("returns the failure when filePathGlobs is a config file path string and reading it fails", async () => {
         const error = new Error("Failure!");
-        const findTypeScriptConfiguration = jest.fn().mockResolvedValue(error);
+        const findTypeScriptConfiguration = async () => error;
 
         const result = await collectCommentFileNames(
             { findTypeScriptConfiguration },
@@ -65,9 +73,7 @@ describe("collectCommentFileNames", () => {
     });
 
     it("returns the typescript configuration from disk when filePathGlobs is a config path string and reading it succeeds", async () => {
-        const findTypeScriptConfiguration = jest.fn().mockResolvedValue({
-            include: ["a.ts"],
-        });
+        const findTypeScriptConfiguration = async () => stubFoundConfiguration;
 
         const result = await collectCommentFileNames(
             { findTypeScriptConfiguration },

--- a/src/converters/comments/convertComments.test.ts
+++ b/src/converters/comments/convertComments.test.ts
@@ -1,6 +1,10 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { fn } from "../../fn";
 import { createStubOriginalConfigurationsData } from "../../settings.stubs";
 import { ResultStatus } from "../../types";
 import { convertComments, ConvertCommentsDependencies } from "./convertComments";
+import { convertFileComments } from "./convertFileComments";
 
 const createStubDependencies = (
     overrides: Partial<ConvertCommentsDependencies> = {},
@@ -9,7 +13,7 @@ const createStubDependencies = (
         include: ["a.ts"],
     }),
     convertFileComments: jest.fn(),
-    extractGlobPaths: jest.fn().mockResolvedValue({
+    extractGlobPaths: async () => ({
         data: ["a.ts", "b.ts"],
         status: ResultStatus.Succeeded,
     }),
@@ -63,7 +67,7 @@ describe("convertComments", () => {
         // Arrange
         const globAsyncError = new Error();
         const dependencies = createStubDependencies({
-            extractGlobPaths: jest.fn().mockResolvedValueOnce({
+            extractGlobPaths: async () => ({
                 errors: [globAsyncError],
                 status: ResultStatus.Failed,
             }),
@@ -88,7 +92,8 @@ describe("convertComments", () => {
         // Arrange
         const fileConversionError = new Error("Failure!");
         const dependencies = createStubDependencies({
-            convertFileComments: jest.fn().mockResolvedValueOnce(fileConversionError),
+            convertFileComments:
+                fn<typeof convertFileComments>().mockResolvedValueOnce(fileConversionError),
         });
 
         // Act

--- a/src/converters/comments/convertFileComments.test.ts
+++ b/src/converters/comments/convertFileComments.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { createStubFileSystem } from "../../adapters/fileSystem.stub";
 import { ConversionError } from "../../errors/conversionError";
 import { createStubConverter } from "../lintConfigs/rules/ruleConverter.stubs";
@@ -13,7 +15,7 @@ const createStubDependencies = (
     ]),
     fileSystem: {
         ...createStubFileSystem(),
-        readFile: jest.fn().mockResolvedValueOnce(readFileResult),
+        readFile: async () => readFileResult,
     },
 });
 

--- a/src/converters/comments/extractGlobPaths.test.ts
+++ b/src/converters/comments/extractGlobPaths.test.ts
@@ -1,10 +1,12 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { ResultStatus } from "../../types";
 import { extractGlobPaths, ExtractGlobPathsDependencies } from "./extractGlobPaths";
 
 const createStubDependencies = (
     overrides: Partial<ExtractGlobPathsDependencies> = {},
 ): ExtractGlobPathsDependencies => ({
-    globAsync: jest.fn().mockResolvedValue(["a.ts", "b.ts"]),
+    globAsync: async () => ["a.ts", "b.ts"],
     ...overrides,
 });
 
@@ -13,7 +15,7 @@ describe("extractGlobPaths", () => {
         // Arrange
         const globAsyncError = new Error();
         const dependencies = createStubDependencies({
-            globAsync: jest.fn().mockResolvedValueOnce(globAsyncError),
+            globAsync: async () => globAsyncError,
         });
 
         // Act
@@ -31,7 +33,7 @@ describe("extractGlobPaths", () => {
     it("returns an error when there are no resultant file paths", async () => {
         // Arrange
         const dependencies = createStubDependencies({
-            globAsync: jest.fn().mockResolvedValueOnce([]),
+            globAsync: async () => [],
         });
 
         // Act
@@ -49,7 +51,7 @@ describe("extractGlobPaths", () => {
     it("returns an error when all globbed file paths are excluded", async () => {
         // Arrange
         const dependencies = createStubDependencies({
-            globAsync: jest.fn().mockResolvedValueOnce(["a.ts"]),
+            globAsync: async () => ["a.ts"],
         });
 
         // Act
@@ -68,7 +70,7 @@ describe("extractGlobPaths", () => {
     it("returns the paths when unique file paths are not excluded", async () => {
         // Arrange
         const dependencies = createStubDependencies({
-            globAsync: jest.fn().mockResolvedValueOnce(["a.ts"]),
+            globAsync: async () => ["a.ts"],
         });
 
         // Act

--- a/src/converters/comments/reporting/reportCommentResults.test.ts
+++ b/src/converters/comments/reporting/reportCommentResults.test.ts
@@ -1,3 +1,5 @@
+import { describe, it } from "@jest/globals";
+
 import { createStubLogger, expectEqualWrites } from "../../../adapters/logger.stubs";
 import { reportCommentResults } from "./reportCommentResults";
 

--- a/src/converters/editorConfigs/convertEditorConfig.test.ts
+++ b/src/converters/editorConfigs/convertEditorConfig.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
 import { convertEditorConfig } from "./convertEditorConfig";
 
 const stubPath = "./vscode/settings.json";
@@ -12,8 +14,8 @@ describe("convertEditorConfig", () => {
         const error = new Error("Oh no");
         const dependencies = {
             fileSystem: {
-                readFile: jest.fn().mockResolvedValue(error),
-                writeFile: jest.fn(),
+                readFile: async () => error,
+                writeFile: async () => undefined,
             },
         };
 
@@ -34,8 +36,8 @@ describe("convertEditorConfig", () => {
         });
         const dependencies = {
             fileSystem: {
-                readFile: jest.fn().mockResolvedValue(originalFileContents),
-                writeFile: jest.fn().mockResolvedValue(error),
+                readFile: async () => originalFileContents,
+                writeFile: async () => error,
             },
         };
 
@@ -55,8 +57,8 @@ describe("convertEditorConfig", () => {
         });
         const dependencies = {
             fileSystem: {
-                readFile: jest.fn().mockResolvedValue(originalFileContents),
-                writeFile: jest.fn().mockResolvedValue(undefined),
+                readFile: async () => originalFileContents,
+                writeFile: async () => undefined,
             },
         };
 

--- a/src/converters/editorConfigs/convertEditorConfigs.test.ts
+++ b/src/converters/editorConfigs/convertEditorConfigs.test.ts
@@ -1,14 +1,20 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { fn } from "../../fn";
 import { ResultStatus } from "../../types";
+import { convertEditorConfig } from "./convertEditorConfig";
 import { convertEditorConfigs, ConvertEditorConfigsDependencies } from "./convertEditorConfigs";
+import { reportEditorConfigConversionResults } from "./reporting/reportEditorConfigConversionResults";
+import { EditorConfigConverter } from "./types";
 
 const stubConfigPath = "stub.json";
 
-const stubEditorConfigDescriptors = [[stubConfigPath, jest.fn()]] as const;
+const stubEditorConfigDescriptors = [[stubConfigPath, fn<EditorConfigConverter>()]] as const;
 
 const createStubDependencies = (overrides: Partial<ConvertEditorConfigsDependencies> = {}) => ({
-    convertEditorConfig: jest.fn(),
+    convertEditorConfig: fn<typeof convertEditorConfig>(),
     editorConfigDescriptors: stubEditorConfigDescriptors,
-    reportEditorConfigConversionResults: jest.fn(),
+    reportEditorConfigConversionResults: fn<typeof reportEditorConfigConversionResults>(),
     ...overrides,
 });
 
@@ -45,7 +51,7 @@ describe("convertEditorConfigs", () => {
         // Arrange
         const error = new Error("Oh no!");
         const dependencies = createStubDependencies({
-            convertEditorConfig: jest.fn().mockResolvedValue(error),
+            convertEditorConfig: async () => error,
         });
         const settings = createSettings(stubConfigPath);
 
@@ -70,7 +76,7 @@ describe("convertEditorConfigs", () => {
             missing: [],
         };
         const dependencies = createStubDependencies({
-            convertEditorConfig: jest.fn().mockResolvedValue(success),
+            convertEditorConfig: async () => success,
         });
         const settings = createSettings(stubConfigPath);
 

--- a/src/converters/editorConfigs/converters/convertAtomConfig.test.ts
+++ b/src/converters/editorConfigs/converters/convertAtomConfig.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "@jest/globals";
-
 import * as CsonParser from "cson-parser";
 
 import { convertAtomConfig } from "./convertAtomConfig";

--- a/src/converters/editorConfigs/converters/convertAtomConfig.test.ts
+++ b/src/converters/editorConfigs/converters/convertAtomConfig.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import * as CsonParser from "cson-parser";
 
 import { convertAtomConfig } from "./convertAtomConfig";

--- a/src/converters/editorConfigs/converters/convertVSCodeConfig.test.ts
+++ b/src/converters/editorConfigs/converters/convertVSCodeConfig.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { convertVSCodeConfig } from "./convertVSCodeConfig";
 
 const stubSettings = {

--- a/src/converters/editorConfigs/reporting/reportEditorConfigConversionResults.test.ts
+++ b/src/converters/editorConfigs/reporting/reportEditorConfigConversionResults.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "@jest/globals";
 import { EOL } from "os";
 
 import { createStubLogger, expectEqualWrites } from "../../../adapters/logger.stubs";

--- a/src/converters/lintConfigs/convertLintConfig.test.ts
+++ b/src/converters/lintConfigs/convertLintConfig.test.ts
@@ -1,3 +1,7 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { jest } from "@jest/globals";
+
 import { createStubOriginalConfigurationsData } from "../../settings.stubs";
 import { ResultStatus } from "../../types";
 import { createEmptyConfigConversionResults } from "./configConversionResults.stubs";
@@ -13,10 +17,10 @@ const createStubDependencies = (
     const ruleConversionResults = createEmptyConfigConversionResults();
 
     return {
-        createESLintConfiguration: jest.fn().mockResolvedValue(ruleConversionResults),
+        createESLintConfiguration: async () => ruleConversionResults,
         fileSystem: { writeFile: jest.fn() },
-        logMissingPackages: jest.fn().mockResolvedValue(undefined),
-        reportConfigConversionResults: jest.fn().mockResolvedValue(undefined),
+        logMissingPackages: async () => undefined,
+        reportConfigConversionResults: async () => undefined,
         ...overrides,
     };
 };
@@ -27,7 +31,7 @@ describe("convertLintConfig", () => {
         const fileWriteError = new Error();
         const dependencies = createStubDependencies({
             fileSystem: {
-                writeFile: jest.fn().mockResolvedValue(fileWriteError),
+                writeFile: async () => fileWriteError,
             },
         });
 
@@ -53,7 +57,7 @@ describe("convertLintConfig", () => {
         };
         const dependencies = createStubDependencies({
             fileSystem: {
-                writeFile: jest.fn().mockResolvedValue(undefined),
+                writeFile: async () => undefined,
             },
         });
 

--- a/src/converters/lintConfigs/convertLintConfig.test.ts
+++ b/src/converters/lintConfigs/convertLintConfig.test.ts
@@ -1,6 +1,4 @@
-import { describe, expect, it } from "@jest/globals";
-
-import { jest } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 
 import { createStubOriginalConfigurationsData } from "../../settings.stubs";
 import { ResultStatus } from "../../types";

--- a/src/converters/lintConfigs/createESLintConfiguration.test.ts
+++ b/src/converters/lintConfigs/createESLintConfiguration.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { createStubOriginalConfigurationsData } from "../../settings.stubs";
 import { createEmptyConfigConversionResults } from "./configConversionResults.stubs";
 import { createESLintConfiguration } from "./createESLintConfiguration";
@@ -7,8 +9,8 @@ describe("createESLintConfiguration", () => {
         // Arrange
         const summarizedResults = createEmptyConfigConversionResults();
         const dependencies = {
-            convertRules: jest.fn().mockReturnValue(summarizedResults),
-            summarizePackageRules: jest.fn().mockReturnValue(summarizedResults),
+            convertRules: () => summarizedResults,
+            summarizePackageRules: async () => summarizedResults,
         };
         const originalConfigurations = createStubOriginalConfigurationsData();
 

--- a/src/converters/lintConfigs/eslint/createEnv.test.ts
+++ b/src/converters/lintConfigs/eslint/createEnv.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { TypeScriptConfiguration } from "../../../input/findTypeScriptConfiguration";
 import { createEnv } from "./createEnv";
 

--- a/src/converters/lintConfigs/formatConvertedRules.test.ts
+++ b/src/converters/lintConfigs/formatConvertedRules.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { createEmptyConfigConversionResults } from "./configConversionResults.stubs";
 import { formatConvertedRules } from "./formatConvertedRules";
 

--- a/src/converters/lintConfigs/formatMissingRules.test.ts
+++ b/src/converters/lintConfigs/formatMissingRules.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { formatMissingRules } from "./formatMissingRules";
 import { TSLintRuleOptions } from "./rules/types";
 

--- a/src/converters/lintConfigs/formatting/formatOutput.test.ts
+++ b/src/converters/lintConfigs/formatting/formatOutput.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { EOL } from "os";
 
 import { formatOutput } from "./formatOutput";

--- a/src/converters/lintConfigs/formatting/formatOutput.test.ts
+++ b/src/converters/lintConfigs/formatting/formatOutput.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "@jest/globals";
-
 import { EOL } from "os";
 
 import { formatOutput } from "./formatOutput";

--- a/src/converters/lintConfigs/joinConfigConversionResults.test.ts
+++ b/src/converters/lintConfigs/joinConfigConversionResults.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { AllOriginalConfigurations } from "../../input/findOriginalConfigurations";
 import { createEmptyConfigConversionResults } from "./configConversionResults.stubs";
 import { joinConfigConversionResults } from "./joinConfigConversionResults";

--- a/src/converters/lintConfigs/pruning/normalizeExtensions.test.ts
+++ b/src/converters/lintConfigs/pruning/normalizeExtensions.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { ESLintConfigurationRuleValue } from "../../../input/findESLintConfiguration";
 import { normalizeExtensions } from "./normalizeExtensions";
 

--- a/src/converters/lintConfigs/pruning/normalizeRawESLintRuleSeverity.test.ts
+++ b/src/converters/lintConfigs/pruning/normalizeRawESLintRuleSeverity.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { normalizeRawESLintRuleSeverity } from "./normalizeRawESLintRuleSeverity";
 
 describe("normalizeRawESLintRuleSeverity", () => {

--- a/src/converters/lintConfigs/pruning/removeExtendsDuplicatedRules.test.ts
+++ b/src/converters/lintConfigs/pruning/removeExtendsDuplicatedRules.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { ESLintRuleOptions, ESLintRuleOptionsWithArguments } from "../rules/types";
 import { removeExtendsDuplicatedRules } from "./removeExtendsDuplicatedRules";
 

--- a/src/converters/lintConfigs/reporting/packages/choosePackageManager.test.ts
+++ b/src/converters/lintConfigs/reporting/packages/choosePackageManager.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { choosePackageManager } from "./choosePackageManager";
 import { PackageManager } from "./packageManagers";
 

--- a/src/converters/lintConfigs/reporting/packages/logMissingPackages.test.ts
+++ b/src/converters/lintConfigs/reporting/packages/logMissingPackages.test.ts
@@ -1,3 +1,5 @@
+import { describe, it } from "@jest/globals";
+
 import { createStubLogger, expectEqualWrites } from "../../../../adapters/logger.stubs";
 import { createEmptyConfigConversionResults } from "../../configConversionResults.stubs";
 import { logMissingPackages } from "./logMissingPackages";

--- a/src/converters/lintConfigs/reporting/reportConfigConversionResults.test.ts
+++ b/src/converters/lintConfigs/reporting/reportConfigConversionResults.test.ts
@@ -1,3 +1,4 @@
+import { describe, it } from "@jest/globals";
 import { EOL } from "os";
 
 import { createStubLogger, expectEqualWrites } from "../../../adapters/logger.stubs";

--- a/src/converters/lintConfigs/rules/convertRule.test.ts
+++ b/src/converters/lintConfigs/rules/convertRule.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { ConversionError } from "../../../errors/conversionError";
 import { convertRule } from "./convertRule";
 import { RuleConverter } from "./ruleConverter";

--- a/src/converters/lintConfigs/rules/convertRules.test.ts
+++ b/src/converters/lintConfigs/rules/convertRules.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, test } from "@jest/globals";
+
 import { ConversionError } from "../../../errors/conversionError";
 import { convertRules } from "./convertRules";
 import { ConversionResult, RuleConverter } from "./ruleConverter";

--- a/src/converters/lintConfigs/rules/formatRawTslintRule.test.ts
+++ b/src/converters/lintConfigs/rules/formatRawTslintRule.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { formatRawTslintRule } from "./formats/formatRawTslintRule";
 
 describe("formatRawTslintRule", () => {

--- a/src/converters/lintConfigs/rules/formats/convertTSLintRuleSeverity.test.ts
+++ b/src/converters/lintConfigs/rules/formats/convertTSLintRuleSeverity.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { convertTSLintRuleSeverity } from "./convertTSLintRuleSeverity";
 
 describe("convertRuleSeverity", () => {

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/adjacent-overload-signatures.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/adjacent-overload-signatures.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertAdjacentOverloadSignatures } from "../adjacent-overload-signatures";
 
-describe(convertAdjacentOverloadSignatures, () => {
+describe("convertAdjacentOverloadSignatures", () => {
     test("conversion without arguments", () => {
         const result = convertAdjacentOverloadSignatures({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/align.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/align.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertAlign } from "../align";
 
-describe(convertAlign, () => {
+describe("convertAlign", () => {
     test("conversion without arguments", () => {
         const result = convertAlign({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/angular-whitespace.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/angular-whitespace.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertAngularWhitespace } from "../angular-whitespace";
 
-describe(convertAngularWhitespace, () => {
+describe("convertAngularWhitespace", () => {
     test("conversion without arguments", () => {
         const result = convertAngularWhitespace({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/array-type.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/array-type.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertArrayType } from "../array-type";
 
-describe(convertArrayType, () => {
+describe("convertArrayType", () => {
     test("conversion without arguments", () => {
         const result = convertArrayType({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/arrow-parens.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/arrow-parens.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertArrowParens } from "../arrow-parens";
 
-describe(convertArrowParens, () => {
+describe("convertArrowParens", () => {
     test("conversion without arguments", () => {
         const result = convertArrowParens({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/arrow-return-shorthand.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/arrow-return-shorthand.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { ARROW_RETURN_NOTICE, convertArrowReturnShorthand } from "../arrow-return-shorthand";
 
-describe(convertArrowReturnShorthand, () => {
+describe("convertArrowReturnShorthand", () => {
     test("conversion without arguments", () => {
         const result = convertArrowReturnShorthand({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/await-promise.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/await-promise.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertAwaitPromise } from "../await-promise";
 
-describe(convertAwaitPromise, () => {
+describe("convertAwaitPromise", () => {
     test("conversion without arguments", () => {
         const result = convertAwaitPromise({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ban-comma-operator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ban-comma-operator.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertBanCommaOperator } from "../ban-comma-operator";
 
-describe(convertBanCommaOperator, () => {
+describe("convertBanCommaOperator", () => {
     test("conversion without arguments", () => {
         const result = convertBanCommaOperator({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ban-ts-ignore.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ban-ts-ignore.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { BAN_TS_IGNORE_NOTICE, convertBanTsIgnore } from "../ban-ts-ignore";
 
-describe(convertBanTsIgnore, () => {
+describe("convertBanTsIgnore", () => {
     test("conversion without arguments", () => {
         const result = convertBanTsIgnore({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ban-types.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ban-types.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertBanTypes } from "../ban-types";
 
-describe(convertBanTypes, () => {
+describe("convertBanTypes", () => {
     test("conversion without arguments", () => {
         const result = convertBanTypes({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/binary-expression-operand-order.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/binary-expression-operand-order.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertBinaryExpressionOperandOrder } from "../binary-expression-operand-order";
 
-describe(convertBinaryExpressionOperandOrder, () => {
+describe("convertBinaryExpressionOperandOrder", () => {
     test("conversion without arguments", () => {
         const result = convertBinaryExpressionOperandOrder({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/callable-types.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/callable-types.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertCallableTypes } from "../callable-types";
 
-describe(convertCallableTypes, () => {
+describe("convertCallableTypes", () => {
     test("conversion without arguments", () => {
         const result = convertCallableTypes({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/class-method-newlines.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/class-method-newlines.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertClassMethodNewlines } from "../class-method-newlines";
 
-describe(convertClassMethodNewlines, () => {
+describe("convertClassMethodNewlines", () => {
     test("conversion without arguments", () => {
         const result = convertClassMethodNewlines({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/class-name.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/class-name.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertClassName } from "../class-name";
 
-describe(convertClassName, () => {
+describe("convertClassName", () => {
     test("conversion without arguments", () => {
         const result = convertClassName({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/cognitive-complexity.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/cognitive-complexity.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertCognitiveComplexity } from "../cognitive-complexity";
 
-describe(convertCognitiveComplexity, () => {
+describe("convertCognitiveComplexity", () => {
     test("conversion without arguments", () => {
         const result = convertCognitiveComplexity({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/comment-format.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/comment-format.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { CapitalizedIgnoreMessage, convertCommentFormat } from "../comment-format";
 
-describe(convertCommentFormat, () => {
+describe("convertCommentFormat", () => {
     test("conversion without arguments", () => {
         const result = convertCommentFormat({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/component-class-suffix.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/component-class-suffix.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertComponentClassSuffix } from "../component-class-suffix";
 
-describe(convertComponentClassSuffix, () => {
+describe("convertComponentClassSuffix", () => {
     test("conversion without arguments", () => {
         const result = convertComponentClassSuffix({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/component-max-inline-declarations.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/component-max-inline-declarations.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertComponentMaxInlineDeclarations } from "../component-max-inline-declarations";
 
-describe(convertComponentMaxInlineDeclarations, () => {
+describe("convertComponentMaxInlineDeclarations", () => {
     test("conversion without arguments", () => {
         const result = convertComponentMaxInlineDeclarations({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/component-selector.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/component-selector.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertComponentSelector } from "../component-selector";
 
-describe(convertComponentSelector, () => {
+describe("convertComponentSelector", () => {
     test("conversion with arguments of same type", () => {
         const result = convertComponentSelector({
             ruleArguments: ["attribute", "myPrefix", "camelCase"],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/consecutive-overloads.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/consecutive-overloads.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertConsecutiveOverloads } from "../consecutive-overloads";
 
-describe(convertConsecutiveOverloads, () => {
+describe("convertConsecutiveOverloads", () => {
     test("conversion without arguments", () => {
         const result = convertConsecutiveOverloads({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/contextual-decorator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/contextual-decorator.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertContextualDecorator } from "../contextual-decorator";
 
-describe(convertContextualDecorator, () => {
+describe("convertContextualDecorator", () => {
     test("conversion without arguments", () => {
         const result = convertContextualDecorator({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/contextual-lifecycle.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/contextual-lifecycle.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertContextualLifecycle } from "../contextual-lifecycle";
 
-describe(convertContextualLifecycle, () => {
+describe("convertContextualLifecycle", () => {
     test("conversion without arguments", () => {
         const result = convertContextualLifecycle({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/curly.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/curly.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertCurly } from "../curly";
 
-describe(convertCurly, () => {
+describe("convertCurly", () => {
     test("conversion without arguments", () => {
         const result = convertCurly({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/cyclomatic-complexity.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/cyclomatic-complexity.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertCyclomaticComplexity } from "../cyclomatic-complexity";
 
-describe(convertCyclomaticComplexity, () => {
+describe("convertCyclomaticComplexity", () => {
     test("conversion without arguments", () => {
         const result = convertCyclomaticComplexity({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/deprecation.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/deprecation.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertDeprecation } from "../deprecation";
 
-describe(convertDeprecation, () => {
+describe("convertDeprecation", () => {
     test("conversion without arguments", () => {
         const result = convertDeprecation({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/directive-class-suffix.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/directive-class-suffix.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertDirectiveClassSuffix } from "../directive-class-suffix";
 
-describe(convertDirectiveClassSuffix, () => {
+describe("convertDirectiveClassSuffix", () => {
     test("conversion without arguments", () => {
         const result = convertDirectiveClassSuffix({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/directive-selector.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/directive-selector.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertDirectiveSelector } from "../directive-selector";
 
-describe(convertDirectiveSelector, () => {
+describe("convertDirectiveSelector", () => {
     test("conversion with arguments of same type", () => {
         const result = convertDirectiveSelector({
             ruleArguments: ["attribute", "myPrefix", "camelCase"],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/eofline.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/eofline.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertEofline } from "../eofline";
 
-describe(convertEofline, () => {
+describe("convertEofline", () => {
     test("conversion without arguments", () => {
         const result = convertEofline({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/file-name-casing.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/file-name-casing.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertFileNameCasing } from "../file-name-casing";
 
-describe(convertFileNameCasing, () => {
+describe("convertFileNameCasing", () => {
     test("conversion without parameter", () => {
         const result = convertFileNameCasing({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/forin.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/forin.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertForin } from "../forin";
 
-describe(convertForin, () => {
+describe("convertForin", () => {
     test("conversion without arguments", () => {
         const result = convertForin({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/function-constructor.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/function-constructor.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertFunctionConstructor } from "../function-constructor";
 
-describe(convertFunctionConstructor, () => {
+describe("convertFunctionConstructor", () => {
     test("conversion without arguments", () => {
         const result = convertFunctionConstructor({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/import-blacklist.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/import-blacklist.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertImportBlacklist } from "../import-blacklist";
 
-describe(convertImportBlacklist, () => {
+describe("convertImportBlacklist", () => {
     test.each([
         [[], []],
         [["rxjs"], ["rxjs"]],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/import-destructuring-spacing.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/import-destructuring-spacing.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertImportDestructuringSpacing } from "../import-destructuring-spacing";
 
-describe(convertImportDestructuringSpacing, () => {
+describe("convertImportDestructuringSpacing", () => {
     test("conversion without arguments", () => {
         const result = convertImportDestructuringSpacing({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/increment-decrement.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/increment-decrement.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertIncrementDecrement } from "../increment-decrement";
 
-describe(convertIncrementDecrement, () => {
+describe("convertIncrementDecrement", () => {
     test("conversion without arguments", () => {
         const result = convertIncrementDecrement({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/indent.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/indent.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertIndent } from "../indent";
 
-describe(convertIndent, () => {
+describe("convertIndent", () => {
     test("conversion without arguments", () => {
         const result = convertIndent({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/interface-name.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/interface-name.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertInterfaceName } from "../interface-name";
 
-describe(convertInterfaceName, () => {
+describe("convertInterfaceName", () => {
     test("conversion without arguments", () => {
         const result = convertInterfaceName({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/interface-over-type-literal.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/interface-over-type-literal.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertInterfaceOverTypeLiteral } from "../interface-over-type-literal";
 
-describe(convertInterfaceOverTypeLiteral, () => {
+describe("convertInterfaceOverTypeLiteral", () => {
     test("conversion without arguments", () => {
         const result = convertInterfaceOverTypeLiteral({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsdoc-format.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsdoc-format.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJSDocFormat, JSDocNoticeMsg } from "../jsdoc-format";
 
-describe(convertJSDocFormat, () => {
+describe("convertJSDocFormat", () => {
     test("conversion without arguments", () => {
         const result = convertJSDocFormat({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-ban-props.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-ban-props.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxBanProps } from "../jsx-ban-props";
 
-describe(convertJsxBanProps, () => {
+describe("convertJsxBanProps", () => {
     test("conversion without arguments", () => {
         const result = convertJsxBanProps({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-boolean-value.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-boolean-value.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxBooleanValue } from "../jsx-boolean-value";
 
-describe(convertJsxBooleanValue, () => {
+describe("convertJsxBooleanValue", () => {
     test("conversion without arguments", () => {
         const result = convertJsxBooleanValue({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-curly-spacing.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-curly-spacing.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxCurlySpacing } from "../jsx-curly-spacing";
 
-describe(convertJsxCurlySpacing, () => {
+describe("convertJsxCurlySpacing", () => {
     test("conversion without arguments", () => {
         const result = convertJsxCurlySpacing({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-equals-spacing.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-equals-spacing.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxEqualsSpacing } from "../jsx-equals-spacing";
 
-describe(convertJsxEqualsSpacing, () => {
+describe("convertJsxEqualsSpacing", () => {
     test("conversion without arguments", () => {
         const result = convertJsxEqualsSpacing({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-key.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-key.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxKey } from "../jsx-key";
 
-describe(convertJsxKey, () => {
+describe("convertJsxKey", () => {
     test("conversion without arguments", () => {
         const result = convertJsxKey({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-no-bind.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-no-bind.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxNoBind } from "../jsx-no-bind";
 
-describe(convertJsxNoBind, () => {
+describe("convertJsxNoBind", () => {
     test("conversion without arguments", () => {
         const result = convertJsxNoBind({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-no-lambda.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-no-lambda.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxNoLambda } from "../jsx-no-lambda";
 
-describe(convertJsxNoLambda, () => {
+describe("convertJsxNoLambda", () => {
     test("conversion without arguments", () => {
         const result = convertJsxNoLambda({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-self-close.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-self-close.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxSelfClose } from "../jsx-self-close";
 
-describe(convertJsxSelfClose, () => {
+describe("convertJsxSelfClose", () => {
     test("conversion without arguments", () => {
         const result = convertJsxSelfClose({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-space-before-trailing-slash.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-space-before-trailing-slash.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxSpaceBeforeTrailingSlash } from "../jsx-space-before-trailing-slash";
 
-describe(convertJsxSpaceBeforeTrailingSlash, () => {
+describe("convertJsxSpaceBeforeTrailingSlash", () => {
     test("conversion without arguments", () => {
         const result = convertJsxSpaceBeforeTrailingSlash({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-wrap-multiline.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/jsx-wrap-multiline.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertJsxWrapMultiline } from "../jsx-wrap-multiline";
 
-describe(convertJsxWrapMultiline, () => {
+describe("convertJsxWrapMultiline", () => {
     test("conversion without arguments", () => {
         const result = convertJsxWrapMultiline({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/label-position.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/label-position.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertLabelPosition } from "../label-position";
 
-describe(convertLabelPosition, () => {
+describe("convertLabelPosition", () => {
     test("conversion without arguments", () => {
         const result = convertLabelPosition({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/linebreak-style.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/linebreak-style.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertLinebreakStyle } from "../linebreak-style";
 
-describe(convertLinebreakStyle, () => {
+describe("convertLinebreakStyle", () => {
     test("conversion without arguments", () => {
         const result = convertLinebreakStyle({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/max-classes-per-file.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/max-classes-per-file.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertMaxClassesPerFile } from "../max-classes-per-file";
 
-describe(convertMaxClassesPerFile, () => {
+describe("convertMaxClassesPerFile", () => {
     test("conversion without arguments", () => {
         const result = convertMaxClassesPerFile({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/max-file-line-count.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/max-file-line-count.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertMaxFileLineCount } from "../max-file-line-count";
 
-describe(convertMaxFileLineCount, () => {
+describe("convertMaxFileLineCount", () => {
     test("conversion without arguments", () => {
         const result = convertMaxFileLineCount({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/max-func-body-length.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/max-func-body-length.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertMaxFuncBodyLength } from "../max-func-body-length";
 
-describe(convertMaxFuncBodyLength, () => {
+describe("convertMaxFuncBodyLength", () => {
     test("conversion without arguments", () => {
         const result = convertMaxFuncBodyLength({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/max-line-length.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/max-line-length.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertMaxLineLength } from "../max-line-length";
 
-describe(convertMaxLineLength, () => {
+describe("convertMaxLineLength", () => {
     test("conversion without arguments", () => {
         const result = convertMaxLineLength({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/max-switch-cases.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/max-switch-cases.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertMaxSwitchCases } from "../max-switch-cases";
 
-describe(convertMaxSwitchCases, () => {
+describe("convertMaxSwitchCases", () => {
     test("conversion without arguments", () => {
         const result = convertMaxSwitchCases({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/member-access.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/member-access.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { AccessibilityLevel, convertMemberAccess } from "../member-access";
 
-describe(convertMemberAccess, () => {
+describe("convertMemberAccess", () => {
     test("conversion without arguments", () => {
         const result = convertMemberAccess({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/member-ordering.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/member-ordering.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertMemberOrdering } from "../member-ordering";
 
-describe(convertMemberOrdering, () => {
+describe("convertMemberOrdering", () => {
     test("conversion without arguments", () => {
         const result = convertMemberOrdering({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/mocha-avoid-only.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/mocha-avoid-only.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertMochaAvoidOnly } from "../mocha-avoid-only";
 
-describe(convertMochaAvoidOnly, () => {
+describe("convertMochaAvoidOnly", () => {
     test("conversion without arguments", () => {
         const result = convertMochaAvoidOnly({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/new-parens.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/new-parens.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNewParens } from "../new-parens";
 
-describe(convertNewParens, () => {
+describe("convertNewParens", () => {
     test("conversion without arguments", () => {
         const result = convertNewParens({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/newline-before-return.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/newline-before-return.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNewlineBeforeReturn } from "../newline-before-return";
 
-describe(convertNewlineBeforeReturn, () => {
+describe("convertNewlineBeforeReturn", () => {
     test("conversion without arguments", () => {
         const result = convertNewlineBeforeReturn({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/newline-per-chained-call.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/newline-per-chained-call.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNewlinePerChainedCall } from "../newline-per-chained-call";
 
-describe(convertNewlinePerChainedCall, () => {
+describe("convertNewlinePerChainedCall", () => {
     test("conversion without arguments", () => {
         const result = convertNewlinePerChainedCall({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-action-hygiene.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-action-hygiene.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxActionHygiene } from "../ngrx-action-hygiene";
 
-describe(convertNgrxActionHygiene, () => {
+describe("convertNgrxActionHygiene", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxActionHygiene({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-avoid-dispatching-multiple-actions-sequentially.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-avoid-dispatching-multiple-actions-sequentially.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxAvoidDispatchingMultipleActionsSequentially } from "../ngrx-avoid-dispatching-multiple-actions-sequentially";
 
-describe(convertNgrxAvoidDispatchingMultipleActionsSequentially, () => {
+describe("convertNgrxAvoidDispatchingMultipleActionsSequentially", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxAvoidDispatchingMultipleActionsSequentially({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-effect-creator-and-decorator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-effect-creator-and-decorator.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxEffectCreatorAndDecorator } from "../ngrx-effect-creator-and-decorator";
 
-describe(convertNgrxEffectCreatorAndDecorator, () => {
+describe("convertNgrxEffectCreatorAndDecorator", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxEffectCreatorAndDecorator({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-dispatch-in-effects.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-dispatch-in-effects.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxNoDispatchInEffects } from "../ngrx-no-dispatch-in-effects";
 
-describe(convertNgrxNoDispatchInEffects, () => {
+describe("convertNgrxNoDispatchInEffects", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxNoDispatchInEffects({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-duplicate-action-types.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-duplicate-action-types.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxNoDuplicateActionTypes } from "../ngrx-no-duplicate-action-types";
 
-describe(convertNgrxNoDuplicateActionTypes, () => {
+describe("convertNgrxNoDuplicateActionTypes", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxNoDuplicateActionTypes({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-effect-decorator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-effect-decorator.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxNoEffectDecorator } from "../ngrx-no-effect-decorator";
 
-describe(convertNgrxNoEffectDecorator, () => {
+describe("convertNgrxNoEffectDecorator", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxNoEffectDecorator({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-effects-in-providers.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-effects-in-providers.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxNoEffectsInProviders } from "../ngrx-no-effects-in-providers";
 
-describe(convertNgrxNoEffectsInProviders, () => {
+describe("convertNgrxNoEffectsInProviders", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxNoEffectsInProviders({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-multiple-actions-in-effects.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-multiple-actions-in-effects.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxNoMultipleActionsInEffects } from "../ngrx-no-multiple-actions-in-effects";
 
-describe(convertNgrxNoMultipleActionsInEffects, () => {
+describe("convertNgrxNoMultipleActionsInEffects", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxNoMultipleActionsInEffects({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-reducer-in-key-names.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-reducer-in-key-names.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxNoReducerInKeyNames } from "../ngrx-no-reducer-in-key-names";
 
-describe(convertNgrxNoReducerInKeyNames, () => {
+describe("convertNgrxNoReducerInKeyNames", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxNoReducerInKeyNames({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-typed-store.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-no-typed-store.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxNoTypedStore } from "../ngrx-no-typed-store";
 
-describe(convertNgrxNoTypedStore, () => {
+describe("convertNgrxNoTypedStore", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxNoTypedStore({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-on-reducer-explicit-return-type.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-on-reducer-explicit-return-type.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxOnReducerExplicitReturnType } from "../ngrx-on-reducer-explicit-return-type";
 
-describe(convertNgrxOnReducerExplicitReturnType, () => {
+describe("convertNgrxOnReducerExplicitReturnType", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxOnReducerExplicitReturnType({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-selector-for-select.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ngrx-selector-for-select.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNgrxSelectorForSelect } from "../ngrx-selector-for-select";
 
-describe(convertNgrxSelectorForSelect, () => {
+describe("convertNgrxSelectorForSelect", () => {
     test("conversion without arguments", () => {
         const result = convertNgrxSelectorForSelect({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-all-duplicated-branches.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-all-duplicated-branches.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoAllDuplicatedBranches } from "../no-all-duplicated-branches";
 
-describe(convertNoAllDuplicatedBranches, () => {
+describe("convertNoAllDuplicatedBranches", () => {
     test("conversion without arguments", () => {
         const result = convertNoAllDuplicatedBranches({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-alphabetical-sort.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-alphabetical-sort.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoAlphabeticalSort } from "../no-alphabetical-sort";
 
-describe(convertNoAlphabeticalSort, () => {
+describe("convertNoAlphabeticalSort", () => {
     test("conversion without arguments", () => {
         const result = convertNoAlphabeticalSort({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-angle-bracket-type-assertion.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-angle-bracket-type-assertion.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoAngleBracketTypeAssertion } from "../no-angle-bracket-type-assertion";
 
-describe(convertNoAngleBracketTypeAssertion, () => {
+describe("convertNoAngleBracketTypeAssertion", () => {
     test("conversion without arguments", () => {
         const result = convertNoAngleBracketTypeAssertion({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-arg.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-arg.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoArg } from "../no-arg";
 
-describe(convertNoArg, () => {
+describe("convertNoArg", () => {
     test("conversion without arguments", () => {
         const result = convertNoArg({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-async-without-await.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-async-without-await.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoAsyncWithoutAwait } from "../no-async-without-await";
 
-describe(convertNoAsyncWithoutAwait, () => {
+describe("convertNoAsyncWithoutAwait", () => {
     test("conversion without arguments", () => {
         const result = convertNoAsyncWithoutAwait({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-attribute-decorator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-attribute-decorator.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoAttributeDecorator } from "../no-attribute-decorator";
 
-describe(convertNoAttributeDecorator, () => {
+describe("convertNoAttributeDecorator", () => {
     test("conversion without arguments", () => {
         const result = convertNoAttributeDecorator({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-banned-terms.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-banned-terms.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoBannedTerms } from "../no-banned-terms";
 
-describe(convertNoBannedTerms, () => {
+describe("convertNoBannedTerms", () => {
     test("conversion without arguments", () => {
         const result = convertNoBannedTerms({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-big-function.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-big-function.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoBigFunction } from "../no-big-function";
 
-describe(convertNoBigFunction, () => {
+describe("convertNoBigFunction", () => {
     test("conversion without arguments", () => {
         const result = convertNoBigFunction({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-bitwise.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-bitwise.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoBitwise } from "../no-bitwise";
 
-describe(convertNoBitwise, () => {
+describe("convertNoBitwise", () => {
     test("conversion without arguments", () => {
         const result = convertNoBitwise({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-boolean-literal-compare.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-boolean-literal-compare.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoBooleanLiteralCompare } from "../no-boolean-literal-compare";
 
-describe(convertNoBooleanLiteralCompare, () => {
+describe("convertNoBooleanLiteralCompare", () => {
     test("conversion without arguments", () => {
         const result = convertNoBooleanLiteralCompare({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-collapsible-if.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-collapsible-if.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoCollapsibleIf } from "../no-collapsible-if";
 
-describe(convertNoCollapsibleIf, () => {
+describe("convertNoCollapsibleIf", () => {
     test("conversion without arguments", () => {
         const result = convertNoCollapsibleIf({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-collection-size-mischeck.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-collection-size-mischeck.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoCollectionSizeMischeck } from "../no-collection-size-mischeck";
 
-describe(convertNoCollectionSizeMischeck, () => {
+describe("convertNoCollectionSizeMischeck", () => {
     test("conversion without arguments", () => {
         const result = convertNoCollectionSizeMischeck({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-conditional-assignment.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-conditional-assignment.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoConditionalAssignment } from "../no-conditional-assignment";
 
-describe(convertNoConditionalAssignment, () => {
+describe("convertNoConditionalAssignment", () => {
     test("conversion without arguments", () => {
         const result = convertNoConditionalAssignment({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-conflicting-lifecycle.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-conflicting-lifecycle.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoConflictingLifecycle } from "../no-conflicting-lifecycle";
 
-describe(convertNoConflictingLifecycle, () => {
+describe("convertNoConflictingLifecycle", () => {
     test("conversion without arguments", () => {
         const result = convertNoConflictingLifecycle({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-consecutive-blank-lines.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-consecutive-blank-lines.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoConsecutiveBlankLines } from "../no-consecutive-blank-lines";
 
-describe(convertNoConsecutiveBlankLines, () => {
+describe("convertNoConsecutiveBlankLines", () => {
     test("conversion without arguments", () => {
         const result = convertNoConsecutiveBlankLines({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-console.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-console.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoConsole } from "../no-console";
 
 const consoleKeysExcluding = (...keys: string[]) => {
@@ -10,7 +12,7 @@ const consoleKeysExcluding = (...keys: string[]) => {
     return Array.from(knownConsoleKeys);
 };
 
-describe(convertNoConsole, () => {
+describe("convertNoConsole", () => {
     test("conversion without arguments", () => {
         const result = convertNoConsole({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-constant-condition.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-constant-condition.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoConstantCondition } from "../no-constant-condition";
 
-describe(convertNoConstantCondition, () => {
+describe("convertNoConstantCondition", () => {
     test("conversion without arguments", () => {
         const result = convertNoConstantCondition({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-construct.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-construct.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoConstruct } from "../no-construct";
 
-describe(convertNoConstruct, () => {
+describe("convertNoConstruct", () => {
     test("conversion without arguments", () => {
         const result = convertNoConstruct({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-control-regex.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-control-regex.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoControlRegex } from "../no-control-regex";
 
-describe(convertNoControlRegex, () => {
+describe("convertNoControlRegex", () => {
     test("conversion without arguments", () => {
         const result = convertNoControlRegex({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-cookies.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-cookies.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoCookies } from "../no-cookies";
 
-describe(convertNoCookies, () => {
+describe("convertNoCookies", () => {
     test("conversion without arguments", () => {
         const result = convertNoCookies({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-debugger.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-debugger.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDebugger } from "../no-debugger";
 
-describe(convertNoDebugger, () => {
+describe("convertNoDebugger", () => {
     test("conversion without arguments", () => {
         const result = convertNoDebugger({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-default-export.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-default-export.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDefaultExport } from "../no-default-export";
 
-describe(convertNoDefaultExport, () => {
+describe("convertNoDefaultExport", () => {
     test("conversion without arguments", () => {
         const result = convertNoDefaultExport({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-delete-expression.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-delete-expression.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDeleteExpression } from "../no-delete-expression";
 
-describe(convertNoDeleteExpression, () => {
+describe("convertNoDeleteExpression", () => {
     test("conversion", () => {
         const result = convertNoDeleteExpression({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-document-domain.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-document-domain.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDocumentDomain } from "../no-document-domain";
 
-describe(convertNoDocumentDomain, () => {
+describe("convertNoDocumentDomain", () => {
     test("conversion without arguments", () => {
         const result = convertNoDocumentDomain({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-document-write.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-document-write.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDocumentWrite } from "../no-document-write";
 
-describe(convertNoDocumentWrite, () => {
+describe("convertNoDocumentWrite", () => {
     test("conversion without arguments", () => {
         const result = convertNoDocumentWrite({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-imports.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-imports.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDuplicateImports } from "../no-duplicate-imports";
 
-describe(convertNoDuplicateImports, () => {
+describe("convertNoDuplicateImports", () => {
     test("conversion without arguments", () => {
         const result = convertNoDuplicateImports({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-string.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-string.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDuplicateString } from "../no-duplicate-string";
 
-describe(convertNoDuplicateString, () => {
+describe("convertNoDuplicateString", () => {
     test("conversion without arguments", () => {
         const result = convertNoDuplicateString({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-super.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-super.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDuplicateSuper } from "../no-duplicate-super";
 
-describe(convertNoDuplicateSuper, () => {
+describe("convertNoDuplicateSuper", () => {
     test("conversion without arguments", () => {
         const result = convertNoDuplicateSuper({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-switch-case.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-switch-case.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDuplicateSwitchCase } from "../no-duplicate-switch-case";
 
-describe(convertNoDuplicateSwitchCase, () => {
+describe("convertNoDuplicateSwitchCase", () => {
     test("conversion without arguments", () => {
         const result = convertNoDuplicateSwitchCase({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-variable.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicate-variable.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDuplicateVariable } from "../no-duplicate-variable";
 
-describe(convertNoDuplicateVariable, () => {
+describe("convertNoDuplicateVariable", () => {
     test("conversion without arguments", () => {
         const result = convertNoDuplicateVariable({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicated-branches.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-duplicated-branches.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDuplicatedBranches } from "../no-duplicated-branches";
 
-describe(convertNoDuplicatedBranches, () => {
+describe("convertNoDuplicatedBranches", () => {
     test("conversion without arguments", () => {
         const result = convertNoDuplicatedBranches({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-dynamic-delete.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-dynamic-delete.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoDynamicDelete } from "../no-dynamic-delete";
 
-describe(convertNoDynamicDelete, () => {
+describe("convertNoDynamicDelete", () => {
     test("conversion without arguments", () => {
         const result = convertNoDynamicDelete({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-element-overwrite.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-element-overwrite.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoElementOverwrite } from "../no-element-overwrite";
 
-describe(convertNoElementOverwrite, () => {
+describe("convertNoElementOverwrite", () => {
     test("conversion without arguments", () => {
         const result = convertNoElementOverwrite({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-destructuring.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-destructuring.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoEmptyDestructuring } from "../no-empty-destructuring";
 
-describe(convertNoEmptyDestructuring, () => {
+describe("convertNoEmptyDestructuring", () => {
     test("conversion without arguments", () => {
         const result = convertNoEmptyDestructuring({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-interface.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-interface.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoEmptyInterface } from "../no-empty-interface";
 
-describe(convertNoEmptyInterface, () => {
+describe("convertNoEmptyInterface", () => {
     test("conversion without arguments", () => {
         const result = convertNoEmptyInterface({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-line-after-opening-brace.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-line-after-opening-brace.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoEmptyLineAfterOpeningBrace } from "../no-empty-line-after-opening-brace";
 
-describe(convertNoEmptyLineAfterOpeningBrace, () => {
+describe("convertNoEmptyLineAfterOpeningBrace", () => {
     test("conversion ", () => {
         const result = convertNoEmptyLineAfterOpeningBrace({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-nested-blocks.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty-nested-blocks.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoEmptyNestedBlocks } from "../no-empty-nested-blocks";
 
-describe(convertNoEmptyNestedBlocks, () => {
+describe("convertNoEmptyNestedBlocks", () => {
     test("conversion without arguments", () => {
         const result = convertNoEmptyNestedBlocks({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-empty.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoEmpty } from "../no-empty";
 
-describe(convertNoEmpty, () => {
+describe("convertNoEmpty", () => {
     test("conversion without arguments", () => {
         const result = convertNoEmpty({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-eval.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-eval.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoEval } from "../no-eval";
 
-describe(convertNoEval, () => {
+describe("convertNoEval", () => {
     test("conversion without arguments", () => {
         const result = convertNoEval({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-exec-script.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-exec-script.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoExecScript } from "../no-exec-script";
 
-describe(convertNoExecScript, () => {
+describe("convertNoExecScript", () => {
     test("conversion without arguments", () => {
         const result = convertNoExecScript({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-explicit-any.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-explicit-any.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoExplicitAny } from "../no-explicit-any";
 
-describe(convertNoExplicitAny, () => {
+describe("convertNoExplicitAny", () => {
     test("conversion without arguments", () => {
         const result = convertNoExplicitAny({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-extra-semicolon.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-extra-semicolon.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoExtraSemicolon } from "../no-extra-semicolon";
 
-describe(convertNoExtraSemicolon, () => {
+describe("convertNoExtraSemicolon", () => {
     test("conversion without arguments", () => {
         const result = convertNoExtraSemicolon({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-floating-promises.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-floating-promises.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoFloatingPromises } from "../no-floating-promises";
 
-describe(convertNoFloatingPromises, () => {
+describe("convertNoFloatingPromises", () => {
     test("conversion without arguments", () => {
         const result = convertNoFloatingPromises({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-for-in-array.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-for-in-array.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoForInArray } from "../no-for-in-array";
 
-describe(convertNoForInArray, () => {
+describe("convertNoForInArray", () => {
     test("conversion without arguments", () => {
         const result = convertNoForInArray({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-for-in.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-for-in.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoForIn } from "../no-for-in";
 
-describe(convertNoForIn, () => {
+describe("convertNoForIn", () => {
     test("conversion without arguments", () => {
         const result = convertNoForIn({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-forward-ref.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-forward-ref.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoForwardRef } from "../no-forward-ref";
 
-describe(convertNoForwardRef, () => {
+describe("convertNoForwardRef", () => {
     test("conversion without arguments", () => {
         const result = convertNoForwardRef({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-function-expression.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-function-expression.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoFunctionExpression } from "../no-function-expression";
 
-describe(convertNoFunctionExpression, () => {
+describe("convertNoFunctionExpression", () => {
     test("conversion without arguments", () => {
         const result = convertNoFunctionExpression({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-host-metadata-property.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-host-metadata-property.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoHostMetadataProperty } from "../no-host-metadata-property";
 
-describe(convertNoHostMetadataProperty, () => {
+describe("convertNoHostMetadataProperty", () => {
     test("conversion without arguments", () => {
         const result = convertNoHostMetadataProperty({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-identical-conditions.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-identical-conditions.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoIdenticalConditions } from "../no-identical-conditions";
 
-describe(convertNoIdenticalConditions, () => {
+describe("convertNoIdenticalConditions", () => {
     test("conversion without arguments", () => {
         const result = convertNoIdenticalConditions({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-identical-expressions.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-identical-expressions.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoIdenticalExpressions } from "../no-identical-expressions";
 
-describe(convertNoIdenticalExpressions, () => {
+describe("convertNoIdenticalExpressions", () => {
     test("conversion without arguments", () => {
         const result = convertNoIdenticalExpressions({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-identical-functions.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-identical-functions.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoIdenticalFunctions } from "../no-identical-functions";
 
-describe(convertNoIdenticalFunctions, () => {
+describe("convertNoIdenticalFunctions", () => {
     test("conversion without arguments", () => {
         const result = convertNoIdenticalFunctions({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-implicit-dependencies.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-implicit-dependencies.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoImplicitDependencies } from "../no-implicit-dependencies";
 
-describe(convertNoImplicitDependencies, () => {
+describe("convertNoImplicitDependencies", () => {
     test("conversion without arguments", () => {
         const result = convertNoImplicitDependencies({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-import-side-effect.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-import-side-effect.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoImportSideEffect } from "../no-import-side-effect";
 
-describe(convertNoImportSideEffect, () => {
+describe("convertNoImportSideEffect", () => {
     test("conversion without arguments", () => {
         const result = convertNoImportSideEffect({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-in-misuse.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-in-misuse.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInMisuse } from "../no-in-misuse";
 
-describe(convertNoInMisuse, () => {
+describe("convertNoInMisuse", () => {
     test("conversion without arguments", () => {
         const result = convertNoInMisuse({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-inferrable-types.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-inferrable-types.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInferrableTypes } from "../no-inferrable-types";
 
-describe(convertNoInferrableTypes, () => {
+describe("convertNoInferrableTypes", () => {
     test("conversion without arguments", () => {
         const result = convertNoInferrableTypes({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-input-prefix.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-input-prefix.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInputPrefix } from "../no-input-prefix";
 
-describe(convertNoInputPrefix, () => {
+describe("convertNoInputPrefix", () => {
     test("conversion without arguments", () => {
         const result = convertNoInputPrefix({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-input-rename.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-input-rename.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInputRename } from "../no-input-rename";
 
-describe(convertNoInputRename, () => {
+describe("convertNoInputRename", () => {
     test("conversion without arguments", () => {
         const result = convertNoInputRename({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-inputs-metadata-property.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-inputs-metadata-property.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInputsMetadataProperty } from "../no-inputs-metadata-property";
 
-describe(convertNoInputsMetadataProperty, () => {
+describe("convertNoInputsMetadataProperty", () => {
     test("conversion without arguments", () => {
         const result = convertNoInputsMetadataProperty({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-internal-module.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-internal-module.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInternalModule } from "../no-internal-module";
 
-describe(convertNoInternalModule, () => {
+describe("convertNoInternalModule", () => {
     test("conversion without arguments", () => {
         const result = convertNoInternalModule({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-invalid-await.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-invalid-await.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInvalidAwait } from "../no-invalid-await";
 
-describe(convertNoInvalidAwait, () => {
+describe("convertNoInvalidAwait", () => {
     test("conversion without arguments", () => {
         const result = convertNoInvalidAwait({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-invalid-regexp.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-invalid-regexp.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInvalidRegexp } from "../no-invalid-regexp";
 
-describe(convertNoInvalidRegexp, () => {
+describe("convertNoInvalidRegexp", () => {
     test("conversion without arguments", () => {
         const result = convertNoInvalidRegexp({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-invalid-template-strings.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-invalid-template-strings.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInvalidTemplateStrings } from "../no-invalid-template-strings";
 
-describe(convertNoInvalidTemplateStrings, () => {
+describe("convertNoInvalidTemplateStrings", () => {
     test("conversion without arguments", () => {
         const result = convertNoInvalidTemplateStrings({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-invalid-this.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-invalid-this.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInvalidThis } from "../no-invalid-this";
 
-describe(convertNoInvalidThis, () => {
+describe("convertNoInvalidThis", () => {
     test("conversion without arguments", () => {
         const result = convertNoInvalidThis({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-inverted-boolean-check.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-inverted-boolean-check.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoInvertedBooleanCheck } from "../no-inverted-boolean-check";
 
-describe(convertNoInvertedBooleanCheck, () => {
+describe("convertNoInvertedBooleanCheck", () => {
     test("conversion without arguments", () => {
         const result = convertNoInvertedBooleanCheck({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-irregular-whitespace.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-irregular-whitespace.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoIrregularWhitespace } from "../no-irregular-whitespace";
 
-describe(convertNoIrregularWhitespace, () => {
+describe("convertNoIrregularWhitespace", () => {
     test("conversion without arguments", () => {
         const result = convertNoIrregularWhitespace({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-lifecycle-call.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-lifecycle-call.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoLifecycleCall } from "../no-lifecycle-call";
 
-describe(convertNoLifecycleCall, () => {
+describe("convertNoLifecycleCall", () => {
     test("conversion without arguments", () => {
         const result = convertNoLifecycleCall({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-magic-numbers.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-magic-numbers.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoMagicNumbers } from "../no-magic-numbers";
 
-describe(convertNoMagicNumbers, () => {
+describe("convertNoMagicNumbers", () => {
     test("conversion without arguments", () => {
         const result = convertNoMagicNumbers({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-misused-new.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-misused-new.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoMisusedNew } from "../no-misused-new";
 
-describe(convertNoMisusedNew, () => {
+describe("convertNoMisusedNew", () => {
     test("conversion without arguments", () => {
         const result = convertNoMisusedNew({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-multiline-string-literals.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-multiline-string-literals.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoMultilineStringLiterals } from "../no-multiline-string-literals";
 
-describe(convertNoMultilineStringLiterals, () => {
+describe("convertNoMultilineStringLiterals", () => {
     test("conversion without arguments", () => {
         const result = convertNoMultilineStringLiterals({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-multiline-string.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-multiline-string.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoMultilineString } from "../no-multiline-string";
 
-describe(convertNoMultilineString, () => {
+describe("convertNoMultilineString", () => {
     test("conversion without arguments", () => {
         const result = convertNoMultilineString({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-multiple-stores.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-multiple-stores.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoMultipleStores } from "../no-multiple-stores";
 
-describe(convertNoMultipleStores, () => {
+describe("convertNoMultipleStores", () => {
     test("conversion without arguments", () => {
         const result = convertNoMultipleStores({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-namespace.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-namespace.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoNamespace } from "../no-namespace";
 
-describe(convertNoNamespace, () => {
+describe("convertNoNamespace", () => {
     test("conversion without arguments", () => {
         const result = convertNoNamespace({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-non-null-assertion.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-non-null-assertion.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoNonNullAssertion } from "../no-non-null-assertion";
 
-describe(convertNoNonNullAssertion, () => {
+describe("convertNoNonNullAssertion", () => {
     test("conversion without arguments", () => {
         const result = convertNoNonNullAssertion({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-null-keyword.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-null-keyword.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoNullKeyword } from "../no-null-keyword";
 
-describe(convertNoNullKeyword, () => {
+describe("convertNoNullKeyword", () => {
     test("conversion without arguments", () => {
         const result = convertNoNullKeyword({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-object-literal-type-assertion.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-object-literal-type-assertion.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoObjectLiteralTypeAssertion } from "../no-object-literal-type-assertion";
 
-describe(convertNoObjectLiteralTypeAssertion, () => {
+describe("convertNoObjectLiteralTypeAssertion", () => {
     test("conversion without arguments", () => {
         const result = convertNoObjectLiteralTypeAssertion({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-octal-literal.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-octal-literal.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoOctalLiteral } from "../no-octal-literal";
 
-describe(convertNoOctalLiteral, () => {
+describe("convertNoOctalLiteral", () => {
     test("conversion without arguments", () => {
         const result = convertNoOctalLiteral({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-output-native.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-output-native.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoOutputNative } from "../no-output-native";
 
-describe(convertNoOutputNative, () => {
+describe("convertNoOutputNative", () => {
     test("conversion without arguments", () => {
         const result = convertNoOutputNative({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-output-on-prefix.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-output-on-prefix.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoOutputOnPrefix } from "../no-output-on-prefix";
 
-describe(convertNoOutputOnPrefix, () => {
+describe("convertNoOutputOnPrefix", () => {
     test("conversion without arguments", () => {
         const result = convertNoOutputOnPrefix({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-output-rename.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-output-rename.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoOutputRename } from "../no-output-rename";
 
-describe(convertNoOutputRename, () => {
+describe("convertNoOutputRename", () => {
     test("conversion without arguments", () => {
         const result = convertNoOutputRename({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-outputs-metadata-property.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-outputs-metadata-property.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoOutputsMetadataProperty } from "../no-outputs-metadata-property";
 
-describe(convertNoOutputsMetadataProperty, () => {
+describe("convertNoOutputsMetadataProperty", () => {
     test("conversion without arguments", () => {
         const result = convertNoOutputsMetadataProperty({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-parameter-properties.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-parameter-properties.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoParameterProperties } from "../no-parameter-properties";
 
-describe(convertNoParameterProperties, () => {
+describe("convertNoParameterProperties", () => {
     test("conversion without arguments", () => {
         const result = convertNoParameterProperties({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-parameter-reassignment.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-parameter-reassignment.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoParameterReassignment } from "../no-parameter-reassignment";
 
-describe(convertNoParameterReassignment, () => {
+describe("convertNoParameterReassignment", () => {
     test("conversion without arguments", () => {
         const result = convertNoParameterReassignment({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-pipe-impure.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-pipe-impure.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoPipeImpure } from "../no-pipe-impure";
 
-describe(convertNoPipeImpure, () => {
+describe("convertNoPipeImpure", () => {
     test("conversion without arguments", () => {
         const result = convertNoPipeImpure({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-queries-metadata-property.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-queries-metadata-property.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoQueriesMetadataProperty } from "../no-queries-metadata-property";
 
-describe(convertNoQueriesMetadataProperty, () => {
+describe("convertNoQueriesMetadataProperty", () => {
     test("conversion without arguments", () => {
         const result = convertNoQueriesMetadataProperty({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-redundant-boolean.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-redundant-boolean.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoRedundantBoolean } from "../no-redundant-boolean";
 
-describe(convertNoRedundantBoolean, () => {
+describe("convertNoRedundantBoolean", () => {
     test("conversion without arguments", () => {
         const result = convertNoRedundantBoolean({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-redundant-jsdoc.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-redundant-jsdoc.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoRedundantJsdoc } from "../no-redundant-jsdoc";
 
-describe(convertNoRedundantJsdoc, () => {
+describe("convertNoRedundantJsdoc", () => {
     test("conversion without arguments", () => {
         const result = convertNoRedundantJsdoc({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-redundant-jump.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-redundant-jump.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoRedundantJump } from "../no-redundant-jump";
 
-describe(convertNoRedundantJump, () => {
+describe("convertNoRedundantJump", () => {
     test("conversion without arguments", () => {
         const result = convertNoRedundantJump({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-redundant-parentheses.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-redundant-parentheses.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoRedundantParentheses } from "../no-redundant-parentheses";
 
-describe(convertNoRedundantParentheses, () => {
+describe("convertNoRedundantParentheses", () => {
     test("conversion without arguments", () => {
         const result = convertNoRedundantParentheses({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-reference-import.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-reference-import.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoReferenceImport } from "../no-reference-import";
 
-describe(convertNoReferenceImport, () => {
+describe("convertNoReferenceImport", () => {
     test("conversion without arguments", () => {
         const result = convertNoReferenceImport({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-reference.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-reference.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoReference } from "../no-reference";
 
-describe(convertNoReference, () => {
+describe("convertNoReference", () => {
     test("conversion without arguments", () => {
         const result = convertNoReference({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-regex-spaces.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-regex-spaces.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoRegexSpaces } from "../no-regex-spaces";
 
-describe(convertNoRegexSpaces, () => {
+describe("convertNoRegexSpaces", () => {
     test("conversion without arguments", () => {
         const result = convertNoRegexSpaces({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-require-imports.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-require-imports.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoRequireImports } from "../no-require-imports";
 
-describe(convertNoRequireImports, () => {
+describe("convertNoRequireImports", () => {
     test("conversion without arguments", () => {
         const result = convertNoRequireImports({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-return-await.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-return-await.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoReturnAwait } from "../no-return-await";
 
-describe(convertNoReturnAwait, () => {
+describe("convertNoReturnAwait", () => {
     test("conversion without arguments", () => {
         const result = convertNoReturnAwait({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-same-line-conditional.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-same-line-conditional.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoSameLineConditional } from "../no-same-line-conditional";
 
-describe(convertNoSameLineConditional, () => {
+describe("convertNoSameLineConditional", () => {
     test("conversion without arguments", () => {
         const result = convertNoSameLineConditional({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-self-assignment.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-self-assignment.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoSelfAssignment } from "../no-self-assignment";
 
-describe(convertNoSelfAssignment, () => {
+describe("convertNoSelfAssignment", () => {
     test("conversion without arguments", () => {
         const result = convertNoSelfAssignment({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-shadowed-variable.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-shadowed-variable.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoShadowedVariable } from "../no-shadowed-variable";
 
-describe(convertNoShadowedVariable, () => {
+describe("convertNoShadowedVariable", () => {
     test("conversion without parameter", () => {
         const result = convertNoShadowedVariable({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-small-switch.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-small-switch.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoSmallSwitch } from "../no-small-switch";
 
-describe(convertNoSmallSwitch, () => {
+describe("convertNoSmallSwitch", () => {
     test("conversion without arguments", () => {
         const result = convertNoSmallSwitch({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-sparse-arrays.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-sparse-arrays.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoSparseArrays } from "../no-sparse-arrays";
 
-describe(convertNoSparseArrays, () => {
+describe("convertNoSparseArrays", () => {
     test("conversion without arguments", () => {
         const result = convertNoSparseArrays({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-string-literal.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-string-literal.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoStringLiteral } from "../no-string-literal";
 
-describe(convertNoStringLiteral, () => {
+describe("convertNoStringLiteral", () => {
     test("conversion without arguments", () => {
         const result = convertNoStringLiteral({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-string-throw.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-string-throw.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoStringThrow } from "../no-string-throw";
 
-describe(convertNoStringThrow, () => {
+describe("convertNoStringThrow", () => {
     test("conversion without arguments", () => {
         const result = convertNoStringThrow({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-submodule-imports.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-submodule-imports.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoSubmoduleImports } from "../no-submodule-imports";
 
-describe(convertNoSubmoduleImports, () => {
+describe("convertNoSubmoduleImports", () => {
     test("conversion without arguments", () => {
         const result = convertNoSubmoduleImports({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-suspicious-comment.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-suspicious-comment.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoSuspiciousComment } from "../no-suspicious-comment";
 
-describe(convertNoSuspiciousComment, () => {
+describe("convertNoSuspiciousComment", () => {
     test("conversion without arguments", () => {
         const result = convertNoSuspiciousComment({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-switch-case-fall-through.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-switch-case-fall-through.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoSwitchCaseFallThrough } from "../no-switch-case-fall-through";
 
-describe(convertNoSwitchCaseFallThrough, () => {
+describe("convertNoSwitchCaseFallThrough", () => {
     test("conversion without arguments", () => {
         const result = convertNoSwitchCaseFallThrough({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-this-assignment.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-this-assignment.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoThisAssignment } from "../no-this-assignment";
 
-describe(convertNoThisAssignment, () => {
+describe("convertNoThisAssignment", () => {
     test("conversion without arguments", () => {
         const result = convertNoThisAssignment({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-trailing-whitespace.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-trailing-whitespace.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoTrailingWhitespace } from "../no-trailing-whitespace";
 
-describe(convertNoTrailingWhitespace, () => {
+describe("convertNoTrailingWhitespace", () => {
     test("conversion without arguments", () => {
         const result = convertNoTrailingWhitespace({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unbound-method.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unbound-method.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnboundMethod } from "../no-unbound-method";
 
-describe(convertNoUnboundMethod, () => {
+describe("convertNoUnboundMethod", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnboundMethod({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unconditional-jump.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unconditional-jump.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnconditionalJump } from "../no-unconditional-jump";
 
-describe(convertNoUnconditionalJump, () => {
+describe("convertNoUnconditionalJump", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnconditionalJump({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-class.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-class.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnnecessaryClass } from "../no-unnecessary-class";
 
-describe(convertNoUnnecessaryClass, () => {
+describe("convertNoUnnecessaryClass", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnnecessaryClass({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-field-initialization.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-field-initialization.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnnecessaryFieldInitialization } from "../no-unnecessary-field-initialization";
 
-describe(convertNoUnnecessaryFieldInitialization, () => {
+describe("convertNoUnnecessaryFieldInitialization", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnnecessaryFieldInitialization({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-initializer.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-initializer.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnnecessaryInitializer } from "../no-unnecessary-initializer";
 
-describe(convertNoUnnecessaryInitializer, () => {
+describe("convertNoUnnecessaryInitializer", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnnecessaryInitializer({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-qualifier.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-qualifier.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnnecessaryQualifier } from "../no-unnecessary-qualifier";
 
-describe(convertNoUnnecessaryQualifier, () => {
+describe("convertNoUnnecessaryQualifier", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnnecessaryQualifier({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-semicolons.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-semicolons.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnnecessarySemicolons } from "../no-unnecessary-semicolons";
 
-describe(convertNoUnnecessarySemicolons, () => {
+describe("convertNoUnnecessarySemicolons", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnnecessarySemicolons({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-type-assertion.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unnecessary-type-assertion.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnnecessaryTypeAssertion } from "../no-unnecessary-type-assertion";
 
-describe(convertNoUnnecessaryTypeAssertion, () => {
+describe("convertNoUnnecessaryTypeAssertion", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnnecessaryTypeAssertion({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unsafe-finally.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unsafe-finally.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnsafeFinally } from "../no-unsafe-finally";
 
-describe(convertNoUnsafeFinally, () => {
+describe("convertNoUnsafeFinally", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnsafeFinally({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unused-array.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unused-array.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnusedArray } from "../no-unused-array";
 
-describe(convertNoUnusedArray, () => {
+describe("convertNoUnusedArray", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnusedArray({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unused-expression.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unused-expression.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnusedExpression } from "../no-unused-expression";
 
-describe(convertNoUnusedExpression, () => {
+describe("convertNoUnusedExpression", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnusedExpression({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-unused-variable.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-unused-variable.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUnusedVariable, NO_UNUSED_VARIABLE_NOTICE } from "../no-unused-variable";
 
-describe(convertNoUnusedVariable, () => {
+describe("convertNoUnusedVariable", () => {
     test("conversion without arguments", () => {
         const result = convertNoUnusedVariable({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-use-before-declare.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-use-before-declare.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUseBeforeDeclare } from "../no-use-before-declare";
 
-describe(convertNoUseBeforeDeclare, () => {
+describe("convertNoUseBeforeDeclare", () => {
     test("conversion without arguments", () => {
         const result = convertNoUseBeforeDeclare({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-use-of-empty-return-value.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-use-of-empty-return-value.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUseOfEmptyReturnValue } from "../no-use-of-empty-return-value";
 
-describe(convertNoUseOfEmptyReturnValue, () => {
+describe("convertNoUseOfEmptyReturnValue", () => {
     test("conversion without arguments", () => {
         const result = convertNoUseOfEmptyReturnValue({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-useless-cast.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-useless-cast.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUselessCast } from "../no-useless-cast";
 
-describe(convertNoUselessCast, () => {
+describe("convertNoUselessCast", () => {
     test("conversion without arguments", () => {
         const result = convertNoUselessCast({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-useless-catch.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-useless-catch.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoUselessCatch } from "../no-useless-catch";
 
-describe(convertNoUselessCatch, () => {
+describe("convertNoUselessCatch", () => {
     test("conversion without arguments", () => {
         const result = convertNoUselessCatch({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-var-keyword.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-var-keyword.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoVarKeyword } from "../no-var-keyword";
 
-describe(convertNoVarKeyword, () => {
+describe("convertNoVarKeyword", () => {
     test("conversion without arguments", () => {
         const result = convertNoVarKeyword({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-var-requires.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-var-requires.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoVarRequires } from "../no-var-requires";
 
-describe(convertNoVarRequires, () => {
+describe("convertNoVarRequires", () => {
     test("conversion without arguments", () => {
         const result = convertNoVarRequires({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-variable-usage-before-declaration.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-variable-usage-before-declaration.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoVariableUsageBeforeDeclaration } from "../no-variable-usage-before-declaration";
 
-describe(convertNoVariableUsageBeforeDeclaration, () => {
+describe("convertNoVariableUsageBeforeDeclaration", () => {
     test("conversion without arguments", () => {
         const result = convertNoVariableUsageBeforeDeclaration({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-void-expression.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-void-expression.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoVoidExpression } from "../no-void-expression";
 
-describe(convertNoVoidExpression, () => {
+describe("convertNoVoidExpression", () => {
     test("conversion without arguments", () => {
         const result = convertNoVoidExpression({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/no-with-statement.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/no-with-statement.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNoWithStatement } from "../no-with-statement";
 
-describe(convertNoWithStatement, () => {
+describe("convertNoWithStatement", () => {
     test("conversion without arguments", () => {
         const result = convertNoWithStatement({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/non-literal-fs-path.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/non-literal-fs-path.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNonLiteralFsPath } from "../non-literal-fs-path";
 
-describe(convertNonLiteralFsPath, () => {
+describe("convertNonLiteralFsPath", () => {
     test("conversion without arguments", () => {
         const result = convertNonLiteralFsPath({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/non-literal-require.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/non-literal-require.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertNonLiteralRequire } from "../non-literal-require";
 
-describe(convertNonLiteralRequire, () => {
+describe("convertNonLiteralRequire", () => {
     test("conversion without arguments", () => {
         const result = convertNonLiteralRequire({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/object-literal-key-quotes.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/object-literal-key-quotes.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertObjectLiteralKeyQuotes } from "../object-literal-key-quotes";
 
-describe(convertObjectLiteralKeyQuotes, () => {
+describe("convertObjectLiteralKeyQuotes", () => {
     test("conversion without arguments", () => {
         const result = convertObjectLiteralKeyQuotes({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/object-literal-shorthand.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/object-literal-shorthand.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertObjectLiteralShorthand } from "../object-literal-shorthand";
 
-describe(convertObjectLiteralShorthand, () => {
+describe("convertObjectLiteralShorthand", () => {
     test("conversion without arguments", () => {
         const result = convertObjectLiteralShorthand({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/one-line.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/one-line.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { CheckAllTokensMsg, convertOneLine } from "../one-line";
 
-describe(convertOneLine, () => {
+describe("convertOneLine", () => {
     test("conversion without arguments", () => {
         const result = convertOneLine({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/one-variable-per-declaration.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/one-variable-per-declaration.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertOneVariablePerDeclaration } from "../one-variable-per-declaration";
 
-describe(convertOneVariablePerDeclaration, () => {
+describe("convertOneVariablePerDeclaration", () => {
     test("conversion without arguments", () => {
         const result = convertOneVariablePerDeclaration({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/only-arrow-functions.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/only-arrow-functions.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertOnlyArrowFunctions } from "../only-arrow-functions";
 
-describe(convertOnlyArrowFunctions, () => {
+describe("convertOnlyArrowFunctions", () => {
     test("conversion without arguments", () => {
         const result = convertOnlyArrowFunctions({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ordered-imports.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ordered-imports.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertOrderedImports } from "../ordered-imports";
 
-describe(convertOrderedImports, () => {
+describe("convertOrderedImports", () => {
     test("conversion without arguments", () => {
         const result = convertOrderedImports({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/parameters-max-number.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/parameters-max-number.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertParametersMaxNumber } from "../parameters-max-number";
 
-describe(convertParametersMaxNumber, () => {
+describe("convertParametersMaxNumber", () => {
     test("conversion without arguments", () => {
         const result = convertParametersMaxNumber({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/pipe-prefix.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/pipe-prefix.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPipePrefix } from "../pipe-prefix";
 
-describe(convertPipePrefix, () => {
+describe("convertPipePrefix", () => {
     test("conversion without arguments", () => {
         const result = convertPipePrefix({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/possible-timing-attacks.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/possible-timing-attacks.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPossibleTimingAttack } from "../possible-timing-attack";
 
-describe(convertPossibleTimingAttack, () => {
+describe("convertPossibleTimingAttack", () => {
     test("conversion without arguments", () => {
         const result = convertPossibleTimingAttack({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-array-literal.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-array-literal.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferArrayLiteral } from "../prefer-array-literal";
 
-describe(convertPreferArrayLiteral, () => {
+describe("convertPreferArrayLiteral", () => {
     test("conversion without arguments", () => {
         const result = convertPreferArrayLiteral({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-conditional-expression.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-conditional-expression.test.ts
@@ -1,9 +1,11 @@
+import { describe, expect, test } from "@jest/globals";
+
 import {
     convertPreferConditionalExpression,
     PREFER_CONDITIONAL_EXPRESSION_NOTICE,
 } from "../prefer-conditional-expression";
 
-describe(convertPreferConditionalExpression, () => {
+describe("convertPreferConditionalExpression", () => {
     test("conversion without arguments", () => {
         const result = convertPreferConditionalExpression({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-const.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-const.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferConst } from "../prefer-const";
 
-describe(convertPreferConst, () => {
+describe("convertPreferConst", () => {
     test("conversion without arguments", () => {
         const result = convertPreferConst({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-default-last.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-default-last.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferDefaultLast } from "../prefer-default-last";
 
-describe(convertPreferDefaultLast, () => {
+describe("convertPreferDefaultLast", () => {
     test("conversion without arguments", () => {
         const result = convertPreferDefaultLast({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-for-of.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-for-of.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferForOf } from "../prefer-for-of";
 
-describe(convertPreferForOf, () => {
+describe("convertPreferForOf", () => {
     test("conversion without arguments", () => {
         const result = convertPreferForOf({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-function-over-method.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-function-over-method.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferFunctionOverMethod } from "../prefer-function-over-method";
 
-describe(convertPreferFunctionOverMethod, () => {
+describe("convertPreferFunctionOverMethod", () => {
     test("conversion without arguments", () => {
         const result = convertPreferFunctionOverMethod({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-immediate-return.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-immediate-return.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferImmediateReturn } from "../prefer-immediate-return";
 
-describe(convertPreferImmediateReturn, () => {
+describe("convertPreferImmediateReturn", () => {
     test("conversion without arguments", () => {
         const result = convertPreferImmediateReturn({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-inline-decorator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-inline-decorator.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferInlineDecorator } from "../prefer-inline-decorator";
 
-describe(convertPreferInlineDecorator, () => {
+describe("convertPreferInlineDecorator", () => {
     test("conversion without arguments", () => {
         const result = convertPreferInlineDecorator({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-object-spread.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-object-spread.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferObjectSpread } from "../prefer-object-spread";
 
-describe(convertPreferObjectSpread, () => {
+describe("convertPreferObjectSpread", () => {
     test("conversion without arguments", () => {
         const result = convertPreferObjectSpread({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-on-push-component-change-detection.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-on-push-component-change-detection.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferOnPushComponentChangeDetection } from "../prefer-on-push-component-change-detection";
 
-describe(convertPreferOnPushComponentChangeDetection, () => {
+describe("convertPreferOnPushComponentChangeDetection", () => {
     test("conversion without arguments", () => {
         const result = convertPreferOnPushComponentChangeDetection({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-output-readonly.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-output-readonly.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferOutputReadonly } from "../prefer-output-readonly";
 
-describe(convertPreferOutputReadonly, () => {
+describe("convertPreferOutputReadonly", () => {
     test("conversion without arguments", () => {
         const result = convertPreferOutputReadonly({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-readonly.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-readonly.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferReadonly } from "../prefer-readonly";
 
-describe(convertPreferReadonly, () => {
+describe("convertPreferReadonly", () => {
     test("conversion without arguments", () => {
         const result = convertPreferReadonly({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-switch.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-switch.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferSwitch } from "../prefer-switch";
 
-describe(convertPreferSwitch, () => {
+describe("convertPreferSwitch", () => {
     test("conversion without arguments", () => {
         const result = convertPreferSwitch({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-template.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/prefer-template.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPreferTemplate } from "../prefer-template";
 
-describe(convertPreferTemplate, () => {
+describe("convertPreferTemplate", () => {
     test("conversion without arguments", () => {
         const result = convertPreferTemplate({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/promise-function-async.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/promise-function-async.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertPromiseFunctionAsync } from "../promise-function-async";
 
-describe(convertPromiseFunctionAsync, () => {
+describe("convertPromiseFunctionAsync", () => {
     test("conversion without arguments", () => {
         const result = convertPromiseFunctionAsync({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/quotemark.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/quotemark.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertQuotemark } from "../quotemark";
 
-describe(convertQuotemark, () => {
+describe("convertQuotemark", () => {
     test("conversion without arguments", () => {
         const result = convertQuotemark({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/radix.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/radix.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRadix } from "../radix";
 
-describe(convertRadix, () => {
+describe("convertRadix", () => {
     test("conversion without arguments", () => {
         const result = convertRadix({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-accessible-headings.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-accessible-headings.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yAccessibleHeadings } from "../react-a11y-accessible-headings";
 
-describe(convertReactA11yAccessibleHeadings, () => {
+describe("convertReactA11yAccessibleHeadings", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yAccessibleHeadings({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-anchors.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-anchors.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yAnchors } from "../react-a11y-anchors";
 
-describe(convertReactA11yAnchors, () => {
+describe("convertReactA11yAnchors", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yAnchors({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-aria-unsupported-elements.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-aria-unsupported-elements.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yAriaUnsupportedElements } from "../react-a11y-aria-unsupported-elements";
 
-describe(convertReactA11yAriaUnsupportedElements, () => {
+describe("convertReactA11yAriaUnsupportedElements", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yAriaUnsupportedElements({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-event-has-role.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-event-has-role.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yEventHasRole } from "../react-a11y-event-has-role";
 
-describe(convertReactA11yEventHasRole, () => {
+describe("convertReactA11yEventHasRole", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yEventHasRole({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-image-button-has-alt.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-image-button-has-alt.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yImageButtonHasAlt } from "../react-a11y-image-button-has-alt";
 
-describe(convertReactA11yImageButtonHasAlt, () => {
+describe("convertReactA11yImageButtonHasAlt", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yImageButtonHasAlt({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-img-has-alt.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-img-has-alt.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yImgHasAlt } from "../react-a11y-img-has-alt";
 
-describe(convertReactA11yImgHasAlt, () => {
+describe("convertReactA11yImgHasAlt", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yImgHasAlt({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-lang.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-lang.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yLang } from "../react-a11y-lang";
 
-describe(convertReactA11yLang, () => {
+describe("convertReactA11yLang", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yLang({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-no-onchange.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-no-onchange.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yNoOnchange } from "../react-a11y-no-onchange";
 
-describe(convertReactA11yNoOnchange, () => {
+describe("convertReactA11yNoOnchange", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yNoOnchange({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-props.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-props.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yProps } from "../react-a11y-props";
 
-describe(convertReactA11yProps, () => {
+describe("convertReactA11yProps", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yProps({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-proptypes.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-proptypes.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yProptypes } from "../react-a11y-proptypes";
 
-describe(convertReactA11yProptypes, () => {
+describe("convertReactA11yProptypes", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yProptypes({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-role-has-required-aria-props.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-role-has-required-aria-props.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yRoleHasRequiredAriaProps } from "../react-a11y-role-has-required-aria-props";
 
-describe(convertReactA11yRoleHasRequiredAriaProps, () => {
+describe("convertReactA11yRoleHasRequiredAriaProps", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yRoleHasRequiredAriaProps({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-role-supports-aria-props.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-role-supports-aria-props.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yRoleSupportsAriaProps } from "../react-a11y-role-supports-aria-props";
 
-describe(convertReactA11yRoleSupportsAriaProps, () => {
+describe("convertReactA11yRoleSupportsAriaProps", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yRoleSupportsAriaProps({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-role.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-role.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yRole } from "../react-a11y-role";
 
-describe(convertReactA11yRole, () => {
+describe("convertReactA11yRole", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yRole({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-tabindex-no-positive.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-a11y-tabindex-no-positive.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactA11yTabIndexNoPositive } from "../react-a11y-tabindex-no-positive";
 
-describe(convertReactA11yTabIndexNoPositive, () => {
+describe("convertReactA11yTabIndexNoPositive", () => {
     test("conversion without arguments", () => {
         const result = convertReactA11yTabIndexNoPositive({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-no-dangerous-html.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-no-dangerous-html.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactNoDangerousHtml } from "../react-no-dangerous-html";
 
-describe(convertReactNoDangerousHtml, () => {
+describe("convertReactNoDangerousHtml", () => {
     test("conversion without arguments", () => {
         const result = convertReactNoDangerousHtml({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-tsx-curly-spacing.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-tsx-curly-spacing.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactTsxCurlySpacing } from "../react-tsx-curly-spacing";
 
-describe(convertReactTsxCurlySpacing, () => {
+describe("convertReactTsxCurlySpacing", () => {
     test("conversion with 'always'", () => {
         const result = convertReactTsxCurlySpacing({
             ruleArguments: ["always"],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/react-unused-props-and-state.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/react-unused-props-and-state.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertReactUnusedPropsAndState } from "../react-unused-props-and-state";
 
-describe(convertReactUnusedPropsAndState, () => {
+describe("convertReactUnusedPropsAndState", () => {
     test("conversion without arguments", () => {
         const result = convertReactUnusedPropsAndState({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/relative-url-prefix.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/relative-url-prefix.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRelativeUrlPrefix } from "../relative-url-prefix";
 
-describe(convertRelativeUrlPrefix, () => {
+describe("convertRelativeUrlPrefix", () => {
     test("conversion without arguments", () => {
         const result = convertRelativeUrlPrefix({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/restrict-plus-operands.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/restrict-plus-operands.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRestrictPlusOperands } from "../restrict-plus-operands";
 
-describe(convertRestrictPlusOperands, () => {
+describe("convertRestrictPlusOperands", () => {
     test("conversion without arguments", () => {
         const result = convertRestrictPlusOperands({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-add.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-add.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsAdd } from "../rxjs-add";
 
-describe(convertRxjsAdd, () => {
+describe("convertRxjsAdd", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsAdd({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-ban-observables.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-ban-observables.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsBanObservables } from "../rxjs-ban-observables";
 
-describe(convertRxjsBanObservables, () => {
+describe("convertRxjsBanObservables", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsBanObservables({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-ban-operators.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-ban-operators.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsBanOperators } from "../rxjs-ban-operators";
 
-describe(convertRxjsBanOperators, () => {
+describe("convertRxjsBanOperators", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsBanOperators({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-deep-operators.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-deep-operators.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsDeepOperators } from "../rxjs-deep-operators";
 
-describe(convertRxjsDeepOperators, () => {
+describe("convertRxjsDeepOperators", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsDeepOperators({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-finnish.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-finnish.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsFinnish } from "../rxjs-finnish";
 
-describe(convertRxjsFinnish, () => {
+describe("convertRxjsFinnish", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsFinnish({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-just.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-just.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsJust } from "../rxjs-just";
 
-describe(convertRxjsJust, () => {
+describe("convertRxjsJust", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsJust({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-add.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-add.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoAdd } from "../rxjs-no-add";
 
-describe(convertRxjsNoAdd, () => {
+describe("convertRxjsNoAdd", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoAdd({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-async-subscribe.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-async-subscribe.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoAsyncSubscribe } from "../rxjs-no-async-subscribe";
 
-describe(convertRxjsNoAsyncSubscribe, () => {
+describe("convertRxjsNoAsyncSubscribe", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoAsyncSubscribe({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-compat.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-compat.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoCompat } from "../rxjs-no-compat";
 
-describe(convertRxjsNoCompat, () => {
+describe("convertRxjsNoCompat", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoCompat({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-connectable.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-connectable.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoConnectable } from "../rxjs-no-connectable";
 
-describe(convertRxjsNoConnectable, () => {
+describe("convertRxjsNoConnectable", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoConnectable({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-create.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-create.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoCreate } from "../rxjs-no-create";
 
-describe(convertRxjsNoCreate, () => {
+describe("convertRxjsNoCreate", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoCreate({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-deep-operators.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-deep-operators.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoDeepOperators } from "../rxjs-no-deep-operators";
 
-describe(convertRxjsNoDeepOperators, () => {
+describe("convertRxjsNoDeepOperators", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoDeepOperators({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-explicit-generics.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-explicit-generics.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoExplicitGenerics } from "../rxjs-no-explicit-generics";
 
-describe(convertRxjsNoExplicitGenerics, () => {
+describe("convertRxjsNoExplicitGenerics", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoExplicitGenerics({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-exposed-subjects.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-exposed-subjects.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoExposedSubjects } from "../rxjs-no-exposed-subjects";
 
-describe(convertRxjsNoExposedSubjects, () => {
+describe("convertRxjsNoExposedSubjects", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoExposedSubjects({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-finnish.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-finnish.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoFinnish } from "../rxjs-no-finnish";
 
-describe(convertRxjsNoFinnish, () => {
+describe("convertRxjsNoFinnish", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoFinnish({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-error.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-error.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoIgnoredError } from "../rxjs-no-ignored-error";
 
-describe(convertRxjsNoIgnoredError, () => {
+describe("convertRxjsNoIgnoredError", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoIgnoredError({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-notifier.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-notifier.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoIgnoredNotifier } from "../rxjs-no-ignored-notifier";
 
-describe(convertRxjsNoIgnoredNotifier, () => {
+describe("convertRxjsNoIgnoredNotifier", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoIgnoredNotifier({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-observable.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-observable.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoIgnoredObservable } from "../rxjs-no-ignored-observable";
 
-describe(convertRxjsNoIgnoredObservable, () => {
+describe("convertRxjsNoIgnoredObservable", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoIgnoredObservable({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-replay-buffer.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-replay-buffer.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoIgnoredReplayBuffer } from "../rxjs-no-ignored-replay-buffer";
 
-describe(convertRxjsNoIgnoredReplayBuffer, () => {
+describe("convertRxjsNoIgnoredReplayBuffer", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoIgnoredReplayBuffer({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-subscribe.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-subscribe.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoIgnoredSubscribe } from "../rxjs-no-ignored-subscribe";
 
-describe(convertRxjsNoIgnoredSubscribe, () => {
+describe("convertRxjsNoIgnoredSubscribe", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoIgnoredSubscribe({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-subscription.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-subscription.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoIgnoredSubscription } from "../rxjs-no-ignored-subscription";
 
-describe(convertRxjsNoIgnoredSubscription, () => {
+describe("convertRxjsNoIgnoredSubscription", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoIgnoredSubscription({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-takewhile-value.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-ignored-takewhile-value.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoIgnoredTakeWhileValue } from "../rxjs-no-ignored-takewhile-value";
 
-describe(convertRxjsNoIgnoredTakeWhileValue, () => {
+describe("convertRxjsNoIgnoredTakeWhileValue", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoIgnoredTakeWhileValue({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-implicit-any-catch.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-implicit-any-catch.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoImplicitAnyCatch } from "../rxjs-no-implicit-any-catch";
 
-describe(convertRxjsNoImplicitAnyCatch, () => {
+describe("convertRxjsNoImplicitAnyCatch", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoImplicitAnyCatch({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-index.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-index.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoIndex } from "../rxjs-no-index";
 
-describe(convertRxjsNoIndex, () => {
+describe("convertRxjsNoIndex", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoIndex({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-internal.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-internal.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoInternal } from "../rxjs-no-internal";
 
-describe(convertRxjsNoInternal, () => {
+describe("convertRxjsNoInternal", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoInternal({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-nested-subscribe.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-nested-subscribe.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoNestedSubscribe } from "../rxjs-no-nested-subscribe";
 
-describe(convertRxjsNoNestedSubscribe, () => {
+describe("convertRxjsNoNestedSubscribe", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoNestedSubscribe({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-operator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-operator.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoOperator } from "../rxjs-no-operator";
 
-describe(convertRxjsNoOperator, () => {
+describe("convertRxjsNoOperator", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoOperator({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-patched.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-patched.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoPatched } from "../rxjs-no-patched";
 
-describe(convertRxjsNoPatched, () => {
+describe("convertRxjsNoPatched", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoPatched({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-redundant-notify.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-redundant-notify.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoRedundantNotify } from "../rxjs-no-redundant-notify";
 
-describe(convertRxjsNoRedundantNotify, () => {
+describe("convertRxjsNoRedundantNotify", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoRedundantNotify({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-sharereplay.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-sharereplay.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoShareReplay } from "../rxjs-no-sharereplay";
 
-describe(convertRxjsNoShareReplay, () => {
+describe("convertRxjsNoShareReplay", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoShareReplay({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-subclass.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-subclass.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoSubclass } from "../rxjs-no-subclass";
 
-describe(convertRxjsNoSubclass, () => {
+describe("convertRxjsNoSubclass", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoSubclass({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-subject-unsubscribe.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-subject-unsubscribe.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoSubjectUnubscribe } from "../rxjs-no-subject-unsubscribe";
 
-describe(convertRxjsNoSubjectUnubscribe, () => {
+describe("convertRxjsNoSubjectUnubscribe", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoSubjectUnubscribe({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-subject-value.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-subject-value.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoSubjectValue } from "../rxjs-no-subject-value";
 
-describe(convertRxjsNoSubjectValue, () => {
+describe("convertRxjsNoSubjectValue", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoSubjectValue({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-tap.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-tap.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoTap } from "../rxjs-no-tap";
 
-describe(convertRxjsNoTap, () => {
+describe("convertRxjsNoTap", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoTap({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-topromise.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-topromise.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoToPromise } from "../rxjs-no-topromise";
 
-describe(convertRxjsNoToPromise, () => {
+describe("convertRxjsNoToPromise", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoToPromise({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unbound-methods.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unbound-methods.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoUnboundMethods } from "../rxjs-no-unbound-methods";
 
-describe(convertRxjsNoUnboundMethods, () => {
+describe("convertRxjsNoUnboundMethods", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoUnboundMethods({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-catch.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-catch.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoUnsafeCatch } from "../rxjs-no-unsafe-catch";
 
-describe(convertRxjsNoUnsafeCatch, () => {
+describe("convertRxjsNoUnsafeCatch", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoUnsafeCatch({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-first.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-first.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoUnsafeFirst } from "../rxjs-no-unsafe-first";
 
-describe(convertRxjsNoUnsafeFirst, () => {
+describe("convertRxjsNoUnsafeFirst", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoUnsafeFirst({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-scope.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-scope.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoUnsafeScope } from "../rxjs-no-unsafe-scope";
 
-describe(convertRxjsNoUnsafeScope, () => {
+describe("convertRxjsNoUnsafeScope", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoUnsafeScope({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-subject-next.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-subject-next.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoUnsafeSubjectNext } from "../rxjs-no-unsafe-subject-next";
 
-describe(convertRxjsNoUnsafeSubjectNext, () => {
+describe("convertRxjsNoUnsafeSubjectNext", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoUnsafeSubjectNext({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-switchmap.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-switchmap.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoUnsafeSwitchmap } from "../rxjs-no-unsafe-switchmap";
 
-describe(convertRxjsNoUnsafeSwitchmap, () => {
+describe("convertRxjsNoUnsafeSwitchmap", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoUnsafeSwitchmap({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-takeuntil.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-takeuntil.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoUnsafeTakeUntil } from "../rxjs-no-unsafe-takeuntil";
 
-describe(convertRxjsNoUnsafeTakeUntil, () => {
+describe("convertRxjsNoUnsafeTakeUntil", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoUnsafeTakeUntil({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-takewhile.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unsafe-takewhile.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoUnsafeTakewhile } from "../rxjs-no-unsafe-takewhile";
 
-describe(convertRxjsNoUnsafeTakewhile, () => {
+describe("convertRxjsNoUnsafeTakewhile", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoUnsafeTakewhile({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unused-add.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-unused-add.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoUnusedAdd } from "../rxjs-no-unused-add";
 
-describe(convertRxjsNoUnusedAdd, () => {
+describe("convertRxjsNoUnusedAdd", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoUnusedAdd({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-wholesale.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-no-wholesale.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsNoWholesale } from "../rxjs-no-wholesale";
 
-describe(convertRxjsNoWholesale, () => {
+describe("convertRxjsNoWholesale", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsNoWholesale({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-add.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-add.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsPreferAdd } from "../rxjs-prefer-add";
 
-describe(convertRxjsPreferAdd, () => {
+describe("convertRxjsPreferAdd", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsPreferAdd({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-angular-async-pipe.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-angular-async-pipe.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsPreferAngularAsyncPipe } from "../rxjs-prefer-angular-async-pipe";
 
-describe(convertRxjsPreferAngularAsyncPipe, () => {
+describe("convertRxjsPreferAngularAsyncPipe", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsPreferAngularAsyncPipe({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-angular-composition.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-angular-composition.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsPreferAngularComposition } from "../rxjs-prefer-angular-composition";
 
-describe(convertRxjsPreferAngularComposition, () => {
+describe("convertRxjsPreferAngularComposition", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsPreferAngularComposition({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-angular-takeuntil.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-angular-takeuntil.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsPreferAngularTakeuntil } from "../rxjs-prefer-angular-takeuntil";
 
-describe(convertRxjsPreferAngularTakeuntil, () => {
+describe("convertRxjsPreferAngularTakeuntil", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsPreferAngularTakeuntil({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-observer.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-prefer-observer.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsPreferObserver } from "../rxjs-prefer-observer";
 
-describe(convertRxjsPreferObserver, () => {
+describe("convertRxjsPreferObserver", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsPreferObserver({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-suffix-subjects.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-suffix-subjects.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsSuffixSubjects } from "../rxjs-suffix-subjects";
 
-describe(convertRxjsSuffixSubjects, () => {
+describe("convertRxjsSuffixSubjects", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsSuffixSubjects({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-throw-error.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/rxjs-throw-error.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertRxjsThrowError } from "../rxjs-throw-error";
 
-describe(convertRxjsThrowError, () => {
+describe("convertRxjsThrowError", () => {
     test("conversion without arguments", () => {
         const result = convertRxjsThrowError({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/semicolon.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/semicolon.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertSemicolon } from "../semicolon";
 
-describe(convertSemicolon, () => {
+describe("convertSemicolon", () => {
     test("conversion with always", () => {
         const result = convertSemicolon({
             ruleArguments: ["always"],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/space-before-function-paren.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/space-before-function-paren.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertSpaceBeforeFunctionParen } from "../space-before-function-paren";
 
-describe(convertSpaceBeforeFunctionParen, () => {
+describe("convertSpaceBeforeFunctionParen", () => {
     test("conversion without arguments", () => {
         const result = convertSpaceBeforeFunctionParen({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/space-within-parens.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/space-within-parens.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertSpaceWithinParens } from "../space-within-parens";
 
-describe(convertSpaceWithinParens, () => {
+describe("convertSpaceWithinParens", () => {
     test("conversion without arguments", () => {
         const result = convertSpaceWithinParens({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/strict-boolean-expressions.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/strict-boolean-expressions.test.ts
@@ -1,9 +1,11 @@
+import { describe, expect, test } from "@jest/globals";
+
 import {
     convertStrictBooleanExpressions,
     ForbiddenOtherNonBooleanTypes,
 } from "../strict-boolean-expressions";
 
-describe(convertStrictBooleanExpressions, () => {
+describe("convertStrictBooleanExpressions", () => {
     test("conversion without arguments", () => {
         const result = convertStrictBooleanExpressions({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/switch-default.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/switch-default.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertSwitchDefault } from "../switch-default";
 
-describe(convertSwitchDefault, () => {
+describe("convertSwitchDefault", () => {
     test("conversion without arguments", () => {
         const result = convertSwitchDefault({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-alt-text.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-alt-text.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateAccessibilityAltText } from "../template-accessibility-alt-text";
 
-describe(convertTemplateAccessibilityAltText, () => {
+describe("convertTemplateAccessibilityAltText", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateAccessibilityAltText({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-elements-content.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-elements-content.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateAccessibilityElementsContent } from "../template-accessibility-elements-content";
 
-describe(convertTemplateAccessibilityElementsContent, () => {
+describe("convertTemplateAccessibilityElementsContent", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateAccessibilityElementsContent({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-label-for.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-label-for.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateAccessibilityLabelFor } from "../template-accessibility-label-for";
 
-describe(convertTemplateAccessibilityLabelFor, () => {
+describe("convertTemplateAccessibilityLabelFor", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateAccessibilityLabelFor({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-tabindex-no-positive.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-tabindex-no-positive.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateAccessibilityTabindexNoPositive } from "../template-accessibility-tabindex-no-positive";
 
-describe(convertTemplateAccessibilityTabindexNoPositive, () => {
+describe("convertTemplateAccessibilityTabindexNoPositive", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateAccessibilityTabindexNoPositive({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-table-scope.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-table-scope.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateAccessibilityTableScope } from "../template-accessibility-table-scope";
 
-describe(convertTemplateAccessibilityTableScope, () => {
+describe("convertTemplateAccessibilityTableScope", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateAccessibilityTableScope({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-valid-aria.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-accessibility-valid-aria.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateAccessibilityValidAria } from "../template-accessibility-valid-aria";
 
-describe(convertTemplateAccessibilityValidAria, () => {
+describe("convertTemplateAccessibilityValidAria", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateAccessibilityValidAria({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-banana-in-box.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-banana-in-box.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateBananaInBox } from "../template-banana-in-box";
 
-describe(convertTemplateBananaInBox, () => {
+describe("convertTemplateBananaInBox", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateBananaInBox({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-click-events-have-key-events.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-click-events-have-key-events.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateClickEventsHaveKeyEvents } from "../template-click-events-have-key-events";
 
-describe(convertTemplateClickEventsHaveKeyEvents, () => {
+describe("convertTemplateClickEventsHaveKeyEvents", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateClickEventsHaveKeyEvents({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-conditional-complexity.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-conditional-complexity.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateConditionalComplexity } from "../template-conditional-complexity";
 
-describe(convertTemplateConditionalComplexity, () => {
+describe("convertTemplateConditionalComplexity", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateConditionalComplexity({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-cyclomatic-complexity.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-cyclomatic-complexity.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateCyclomaticComplexity } from "../template-cyclomatic-complexity";
 
-describe(convertTemplateCyclomaticComplexity, () => {
+describe("convertTemplateCyclomaticComplexity", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateCyclomaticComplexity({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-i18n.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-i18n.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateI18N } from "../template-i18n";
 
-describe(convertTemplateI18N, () => {
+describe("convertTemplateI18N", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateI18N({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-mouse-events-have-key-events.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-mouse-events-have-key-events.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateMouseEventsHaveKeyEvents } from "../template-mouse-events-have-key-events";
 
-describe(convertTemplateMouseEventsHaveKeyEvents, () => {
+describe("convertTemplateMouseEventsHaveKeyEvents", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateMouseEventsHaveKeyEvents({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-any.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-any.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateNoAny } from "../template-no-any";
 
-describe(convertTemplateNoAny, () => {
+describe("convertTemplateNoAny", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateNoAny({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-autofocus.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-autofocus.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateNoAutofocus } from "../template-no-autofocus";
 
-describe(convertTemplateNoAutofocus, () => {
+describe("convertTemplateNoAutofocus", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateNoAutofocus({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-call-expression.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-call-expression.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateNoCallExpression } from "../template-no-call-expression";
 
-describe(convertTemplateNoCallExpression, () => {
+describe("convertTemplateNoCallExpression", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateNoCallExpression({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-distracting-elements.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-distracting-elements.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateNoDistractingElements } from "../template-no-distracting-elements";
 
-describe(convertTemplateNoDistractingElements, () => {
+describe("convertTemplateNoDistractingElements", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateNoDistractingElements({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-negated-async.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-no-negated-async.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateNoNegatedAsync } from "../template-no-negated-async";
 
-describe(convertTemplateNoNegatedAsync, () => {
+describe("convertTemplateNoNegatedAsync", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateNoNegatedAsync({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/template-use-track-by-function.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/template-use-track-by-function.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTemplateUseTrackByFunction } from "../template-use-track-by-function";
 
-describe(convertTemplateUseTrackByFunction, () => {
+describe("convertTemplateUseTrackByFunction", () => {
     test("conversion without arguments", () => {
         const result = convertTemplateUseTrackByFunction({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/trailing-comma.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/trailing-comma.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTrailingComma } from "../trailing-comma";
 
-describe(convertTrailingComma, () => {
+describe("convertTrailingComma", () => {
     test("conversion without arguments", () => {
         const result = convertTrailingComma({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/triple-equals.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/triple-equals.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTripleEquals } from "../triple-equals";
 
-describe(convertTripleEquals, () => {
+describe("convertTripleEquals", () => {
     test("conversion without arguments", () => {
         const result = convertTripleEquals({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/type-literal-delimiter.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/type-literal-delimiter.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTypeLiteralDelimiter } from "../type-literal-delimiter";
 
-describe(convertTypeLiteralDelimiter, () => {
+describe("convertTypeLiteralDelimiter", () => {
     test("conversion without arguments", () => {
         const result = convertTypeLiteralDelimiter({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/typedef-whitespace.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/typedef-whitespace.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTypedefWhitespace } from "../typedef-whitespace";
 
-describe(convertTypedefWhitespace, () => {
+describe("convertTypedefWhitespace", () => {
     test("conversion without arguments", () => {
         const result = convertTypedefWhitespace({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/typeof-compare.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/typeof-compare.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertTypeofCompare } from "../typeof-compare";
 
-describe(convertTypeofCompare, () => {
+describe("convertTypeofCompare", () => {
     test("conversion without arguments", () => {
         const result = convertTypeofCompare({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/underscore-consistent-invocation.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/underscore-consistent-invocation.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUnderscoreConsistentInvocation } from "../underscore-consistent-invocation";
 
-describe(convertUnderscoreConsistentInvocation, () => {
+describe("convertUnderscoreConsistentInvocation", () => {
     test("conversion without arguments", () => {
         const result = convertUnderscoreConsistentInvocation({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/unified-signatures.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/unified-signatures.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUnifiedSignatures } from "../unified-signatures";
 
-describe(convertUnifiedSignatures, () => {
+describe("convertUnifiedSignatures", () => {
     test("conversion without arguments", () => {
         const result = convertUnifiedSignatures({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/unnecessary-bind.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/unnecessary-bind.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUnnecessaryBind } from "../unnecessary-bind";
 
-describe(convertUnnecessaryBind, () => {
+describe("convertUnnecessaryBind", () => {
     test("conversion without arguments", () => {
         const result = convertUnnecessaryBind({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/unnecessary-constructor.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/unnecessary-constructor.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUnnecessaryConstructor } from "../unnecessary-constructor";
 
-describe(convertUnnecessaryConstructor, () => {
+describe("convertUnnecessaryConstructor", () => {
     test("conversion without arguments", () => {
         const result = convertUnnecessaryConstructor({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/use-component-selector.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/use-component-selector.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUseComponentSelector } from "../use-component-selector";
 
-describe(convertUseComponentSelector, () => {
+describe("convertUseComponentSelector", () => {
     test("conversion without arguments", () => {
         const result = convertUseComponentSelector({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/use-component-view-encapsulation.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/use-component-view-encapsulation.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUseComponentViewEncapsulation } from "../use-component-view-encapsulation";
 
-describe(convertUseComponentViewEncapsulation, () => {
+describe("convertUseComponentViewEncapsulation", () => {
     test("conversion without arguments", () => {
         const result = convertUseComponentViewEncapsulation({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/use-default-type-parameter.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/use-default-type-parameter.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUseDefaultTypeParameter } from "../use-default-type-parameter";
 
-describe(convertUseDefaultTypeParameter, () => {
+describe("convertUseDefaultTypeParameter", () => {
     test("conversion without arguments", () => {
         const result = convertUseDefaultTypeParameter({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/use-injectable-provided-in.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/use-injectable-provided-in.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUseInjectableProvidedIn } from "../use-injectable-provided-in";
 
-describe(convertUseInjectableProvidedIn, () => {
+describe("convertUseInjectableProvidedIn", () => {
     test("conversion without arguments", () => {
         const result = convertUseInjectableProvidedIn({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/use-isnan.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/use-isnan.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUseIsnan } from "../use-isnan";
 
-describe(convertUseIsnan, () => {
+describe("convertUseIsnan", () => {
     test("conversion without arguments", () => {
         const result = convertUseIsnan({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/use-lifecycle-interface.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/use-lifecycle-interface.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUseLifecycleInterface } from "../use-lifecycle-interface";
 
-describe(convertUseLifecycleInterface, () => {
+describe("convertUseLifecycleInterface", () => {
     test("conversion without arguments", () => {
         const result = convertUseLifecycleInterface({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/use-pipe-decorator.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/use-pipe-decorator.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUsePipeDecorator } from "../use-pipe-decorator";
 
-describe(convertUsePipeDecorator, () => {
+describe("convertUsePipeDecorator", () => {
     test("conversion without arguments", () => {
         const result = convertUsePipeDecorator({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/use-pipe-transform-interface.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/use-pipe-transform-interface.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUsePipeTransformInterface } from "../use-pipe-transform-interface";
 
-describe(convertUsePipeTransformInterface, () => {
+describe("convertUsePipeTransformInterface", () => {
     test("conversion without arguments", () => {
         const result = convertUsePipeTransformInterface({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/use-primitive-type.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/use-primitive-type.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { convertUsePrimitiveType } from "../use-primitive-type";
 
-describe(convertUsePrimitiveType, () => {
+describe("convertUsePrimitiveType", () => {
     test("conversion without arguments", () => {
         const result = convertUsePrimitiveType({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/variable-name.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/variable-name.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from "@jest/globals";
+
 import {
     ConstRequiredForAllCapsMsg,
     convertVariableName,
@@ -5,7 +7,7 @@ import {
     IgnoreLeadingTrailingIdentifierMsg,
 } from "../variable-name";
 
-describe(convertVariableName, () => {
+describe("convertVariableName", () => {
     test("conversion without arguments", () => {
         const result = convertVariableName({
             ruleArguments: [],

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/ban-operators.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/ban-operators.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeBanOperators } from "../ban-operators";
 
-describe(mergeBanOperators, () => {
+describe("mergeBanOperators", () => {
     test("neither operators existing", () => {
         const result = mergeBanOperators(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/ban-types.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/ban-types.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeBanTypes } from "../ban-types";
 
-describe(mergeBanTypes, () => {
+describe("mergeBanTypes", () => {
     test("neither types existing", () => {
         const result = mergeBanTypes(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/consistent-type-assertions.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/consistent-type-assertions.test.ts
@@ -1,10 +1,12 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeConsistentTypeAssertions } from "../consistent-type-assertions";
 
 const option = {
     assertionStyle: "never",
 };
 
-describe(mergeConsistentTypeAssertions, () => {
+describe("mergeConsistentTypeAssertions", () => {
     test("neither options existing", () => {
         const result = mergeConsistentTypeAssertions(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/indent.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/indent.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeIndent } from "../indent";
 
-describe(mergeIndent, () => {
+describe("mergeIndent", () => {
     test("neither options existing", () => {
         const result = mergeIndent(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/jsx-a11y-alt-text.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/jsx-a11y-alt-text.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeJsxA11yAltText } from "../jsx-a11y-alt-text";
 
-describe(mergeJsxA11yAltText, () => {
+describe("mergeJsxA11yAltText", () => {
     test("neither options existing", () => {
         const result = mergeJsxA11yAltText(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/member-delimiter-style.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/member-delimiter-style.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeNoMemberDelimiterStyle } from "../member-delimiter-style";
 
-describe(mergeNoMemberDelimiterStyle, () => {
+describe("mergeNoMemberDelimiterStyle", () => {
     test("neither options existing", () => {
         const result = mergeNoMemberDelimiterStyle(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/naming-convention.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/naming-convention.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeNamingConvention } from "../naming-convention";
 
-describe(mergeNamingConvention, () => {
+describe("mergeNamingConvention", () => {
     test("neither options existing", () => {
         const result = mergeNamingConvention(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/no-empty.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/no-empty.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeNoEmpty } from "../no-empty";
 
-describe(mergeNoEmpty, () => {
+describe("mergeNoEmpty", () => {
     test("neither options existing", () => {
         const result = mergeNoEmpty(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/no-eval.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/no-eval.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeNoEval } from "../no-eval";
 
-describe(mergeNoEval, () => {
+describe("mergeNoEval", () => {
     test("neither options existing", () => {
         const result = mergeNoEval(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/no-unnecessary-type-assertion.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/no-unnecessary-type-assertion.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeNoUnnecessaryTypeAssertion } from "../no-unnecessary-type-assertion";
 
-describe(mergeNoUnnecessaryTypeAssertion, () => {
+describe("mergeNoUnnecessaryTypeAssertion", () => {
     test("neither options existing", () => {
         const result = mergeNoUnnecessaryTypeAssertion(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/no-use-before-define.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/no-use-before-define.test.ts
@@ -1,6 +1,8 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeNoUseBeforeDefine } from "../no-use-before-define";
 
-describe(mergeNoUseBeforeDefine, () => {
+describe("mergeNoUseBeforeDefine", () => {
     test("neither options existing", () => {
         const result = mergeNoUseBeforeDefine(undefined, undefined);
 

--- a/src/converters/lintConfigs/rules/ruleMergers/tests/triple-slash-reference.test.ts
+++ b/src/converters/lintConfigs/rules/ruleMergers/tests/triple-slash-reference.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, test } from "@jest/globals";
+
 import { mergeTripleSlashReference } from "../triple-slash-reference";
 
 const option = {
@@ -6,7 +8,7 @@ const option = {
     lib: "always",
 };
 
-describe(mergeTripleSlashReference, () => {
+describe("mergeTripleSlashReference", () => {
     test("neither options existing", () => {
         const result = mergeTripleSlashReference(undefined, undefined);
 

--- a/src/converters/lintConfigs/summarization/collectTSLintRulesets.test.ts
+++ b/src/converters/lintConfigs/summarization/collectTSLintRulesets.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { collectTSLintRulesets } from "./collectTSLintRulesets";
 
 describe("collectTSLintRulesets", () => {

--- a/src/converters/lintConfigs/summarization/normalizeESLintRules.test.ts
+++ b/src/converters/lintConfigs/summarization/normalizeESLintRules.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { ESLintConfigurationRules } from "../../../input/findESLintConfiguration";
 import { normalizeESLintRules } from "./normalizeESLintRules";
 

--- a/src/converters/lintConfigs/summarization/prettier/checkPrettierExtension.test.ts
+++ b/src/converters/lintConfigs/summarization/prettier/checkPrettierExtension.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { createEmptyConfigConversionResults } from "../../configConversionResults.stubs";
 import { checkPrettierExtension } from "./checkPrettierExtension";
 

--- a/src/converters/lintConfigs/summarization/resolveExtensionNames.test.ts
+++ b/src/converters/lintConfigs/summarization/resolveExtensionNames.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { resolveExtensionNames } from "./resolveExtensionNames";
 
 describe("resolveExtensionNames", () => {

--- a/src/converters/lintConfigs/summarization/retrieveExtendsValues.test.ts
+++ b/src/converters/lintConfigs/summarization/retrieveExtendsValues.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { retrieveExtendsValues } from "./retrieveExtendsValues";
 
 describe("retrieveExtendsValues", () => {

--- a/src/converters/lintConfigs/summarization/summarizePackageRules.test.ts
+++ b/src/converters/lintConfigs/summarization/summarizePackageRules.test.ts
@@ -1,10 +1,14 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { ConfigurationError } from "../../../errors/configurationError";
+import { fn } from "../../../fn";
 import { createEmptyConfigConversionResults } from "../configConversionResults.stubs";
 import { ESLintRuleOptionsWithArguments } from "../rules/types";
+import { checkPrettierExtension } from "./prettier/checkPrettierExtension";
 import { summarizePackageRules, SummarizePackageRulesDependencies } from "./summarizePackageRules";
 
 const createStubDependencies = (overrides: Partial<SummarizePackageRulesDependencies> = {}) => ({
-    checkPrettierExtension: jest.fn(),
+    checkPrettierExtension: fn<typeof checkPrettierExtension>(),
     removeExtendsDuplicatedRules: () => ({
         differentRules: new Map(),
         extensionRules: new Map(),

--- a/src/errors/configurationError.test.ts
+++ b/src/errors/configurationError.test.ts
@@ -1,8 +1,10 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { EOL } from "os";
 
 import { ConfigurationError } from "./configurationError";
 
-describe(ConfigurationError, () => {
+describe("ConfigurationError", () => {
     describe("getSummary", () => {
         it("creates a summary for the error", () => {
             // Arrange

--- a/src/errors/configurationError.test.ts
+++ b/src/errors/configurationError.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "@jest/globals";
-
 import { EOL } from "os";
 
 import { ConfigurationError } from "./configurationError";

--- a/src/errors/conversionError.test.ts
+++ b/src/errors/conversionError.test.ts
@@ -1,9 +1,11 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { EOL } from "os";
 
 import { TSLintRuleOptions } from "../converters/lintConfigs/rules/types";
 import { ConversionError } from "./conversionError";
 
-describe(ConversionError, () => {
+describe("ConversionError", () => {
     describe("getSummary", () => {
         it("prints the error stack when created for an error", () => {
             // Arrange

--- a/src/errors/conversionError.test.ts
+++ b/src/errors/conversionError.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "@jest/globals";
-
 import { EOL } from "os";
 
 import { TSLintRuleOptions } from "../converters/lintConfigs/rules/types";

--- a/src/fn.ts
+++ b/src/fn.ts
@@ -1,0 +1,4 @@
+import { jest } from "@jest/globals";
+
+export const fn = <Reference extends (...args: any) => any>(reference?: Reference) =>
+    jest.fn(reference);

--- a/src/input/findESLintConfiguration.test.ts
+++ b/src/input/findESLintConfiguration.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { createStubExec, createStubThrowingExec } from "../adapters/exec.stubs";
 import { TSLintToESLintSettings } from "../types";
 import {

--- a/src/input/findOriginalConfigurations.test.ts
+++ b/src/input/findOriginalConfigurations.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { ResultStatus, TSLintToESLintSettings } from "../types";
 import { ESLintConfiguration } from "./findESLintConfiguration";
 import {

--- a/src/input/findPackagesConfiguration.test.ts
+++ b/src/input/findPackagesConfiguration.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { createStubExec } from "../adapters/exec.stubs";
 import { findPackagesConfiguration } from "./findPackagesConfiguration";
 

--- a/src/input/findReportedConfiguration.test.ts
+++ b/src/input/findReportedConfiguration.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { createStubExec, createStubThrowingExec } from "../adapters/exec.stubs";
 import { findReportedConfiguration } from "./findReportedConfiguration";
 

--- a/src/input/findTslintConfiguration.test.ts
+++ b/src/input/findTslintConfiguration.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { createStubExec, createStubThrowingExec } from "../adapters/exec.stubs";
 import {
     findTSLintConfiguration,

--- a/src/input/findTypeScriptConfiguration.test.ts
+++ b/src/input/findTypeScriptConfiguration.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { createStubExec, createStubThrowingExec } from "../adapters/exec.stubs";
 import { findTypeScriptConfiguration } from "./findTypeScriptConfiguration";
 

--- a/src/input/importer.test.ts
+++ b/src/input/importer.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "@jest/globals";
-
 import * as path from "path";
 
 import { importer } from "./importer";

--- a/src/input/importer.test.ts
+++ b/src/input/importer.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import * as path from "path";
 
 import { importer } from "./importer";

--- a/src/input/mergeLintConfigurations.test.ts
+++ b/src/input/mergeLintConfigurations.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import { ESLintConfiguration } from "./findESLintConfiguration";
 import { OriginalConfigurations } from "./findOriginalConfigurations";
 import { TSLintConfiguration } from "./findTSLintConfiguration";

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "@jest/globals";
+
 import {
     asError,
     isDefined,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "incremental": true,
         "lib": [],
         "module": "commonjs",
+        "moduleResolution": "node",
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: starts on #1364
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Switches from `@types/jest` typings to using imports from `@jest/globals`.

The built-in `jest.fn()` `Mock` types are a bit more strict than those on DefinitelyTyped: they default to `unknown` rather than `any`.