### PR TITLE
No longer extend from removed/deprected Prettier ESLint configs

### DIFF
--- a/src/converters/lintConfigs/reporting/reportConfigConversionResults.test.ts
+++ b/src/converters/lintConfigs/reporting/reportConfigConversionResults.test.ts
@@ -6,7 +6,7 @@ import { createEmptyConfigConversionResults } from "../configConversionResults.s
 import { ESLintRuleOptions } from "../rules/types";
 import { reportConfigConversionResults } from "./reportConfigConversionResults";
 
-const basicExtends = ["prettier", "prettier/@typescript-eslint"];
+const basicExtends = ["prettier"];
 
 describe("reportConfigConversionResults", () => {
     it("logs a successful conversion without notices when there is one converted rule without notices", async () => {

--- a/src/converters/lintConfigs/summarization/retrieveExtendsValues.ts
+++ b/src/converters/lintConfigs/summarization/retrieveExtendsValues.ts
@@ -21,10 +21,6 @@ const builtInExtensions = new Map([
 const pluginExtensions = new Map([
     ["eslint-plugin-prettier", "node_modules/eslint-config-prettier/index.js"],
     [
-        "eslint-plugin-prettier/@typescript-eslint",
-        "node_modules/eslint-config-prettier/@typescript-eslint.js",
-    ],
-    [
         "plugin:@typescript-eslint/all",
         "node_modules/@typescript-eslint/eslint-plugin/dist/configs/all.json",
     ],

--- a/src/converters/lintConfigs/summarization/summarizePackageRules.test.ts
+++ b/src/converters/lintConfigs/summarization/summarizePackageRules.test.ts
@@ -75,7 +75,7 @@ describe("summarizePackageRules", () => {
         expect(summarizedResults).toEqual({
             ...ruleConversionResults,
             converted: new Map(),
-            extends: ["prettier", "prettier/@typescript-eslint"],
+            extends: ["prettier"],
         });
     });
 

--- a/src/converters/lintConfigs/summarization/summarizePackageRules.ts
+++ b/src/converters/lintConfigs/summarization/summarizePackageRules.ts
@@ -35,7 +35,7 @@ export const summarizePackageRules = async (
 
     // 3a. If no output rules conflict with `eslint-config-prettier`, it's added in
     if (dependencies.checkPrettierExtension(ruleConversionResults, prettierRequested)) {
-        allExtensions.push("prettier", "prettier/@typescript-eslint");
+        allExtensions.push("prettier");
     }
 
     if (allExtensions.length === 0) {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1396 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Since `v8.0.0` of `eslint-config-prettier`, [all configs have merged](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21) into `prettier` and supplying the extraneous configs like `"prettier/@typescript-eslint"`, etc. results in error

This fix simply removes the no-longer-needed configs to extend from