### PR TITLE
Switched tsconfig.json back to module: commonjs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,25 @@ jobs:
                       - package-lock.json
                       - src
 
+    compile:
+        docker:
+            - image: circleci/node:latest
+
+        working_directory: ~/repo
+
+        steps:
+            - checkout
+
+            - attach_workspace:
+                  at: "."
+
+            - run: npm run compile
+
+            - persist_to_workspace:
+                  root: "."
+                  paths:
+                      - src
+
     eslint:
         docker:
             - image: circleci/node:latest
@@ -87,25 +106,6 @@ jobs:
 
             - run: npm run test:ci
 
-    tsc:
-        docker:
-            - image: circleci/node:latest
-
-        working_directory: ~/repo
-
-        steps:
-            - checkout
-
-            - attach_workspace:
-                  at: "."
-
-            - run: npm run tsc
-
-            - persist_to_workspace:
-                  root: "."
-                  paths:
-                      - src
-
 workflows:
     version: 2
     commit:
@@ -119,13 +119,13 @@ workflows:
                       branches:
                           only: main
                   requires:
-                      - tsc
+                      - compile
             - prettier:
                   requires:
                       - build
             - test:
                   requires:
                       - build
-            - tsc:
+            - compile:
                   requires:
                       - build

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,7 +14,7 @@ module.exports = {
     ],
     parser: "@typescript-eslint/parser",
     parserOptions: {
-        project: "tsconfig.json",
+        project: "tsconfig.eslint.json",
     },
     plugins: ["simple-import-sort", "@typescript-eslint"],
     rules: {

--- a/package.json
+++ b/package.json
@@ -61,14 +61,14 @@
         "url": "github:typescript-eslint/tslint-to-eslint-config"
     },
     "scripts": {
+        "compile": "tsc -b",
         "eslint": "eslint \"./src/*.ts\" \"./src/**/*.ts\" --report-unused-disable-directives",
         "precommit": "lint-staged",
         "prepare": "husky install",
         "prettier": "prettier \"./src/*.{js,json,ts,xml,yaml}\" \"./src/**/*.{js,json,ts,xml,yaml}\" --ignore-path .prettierignore",
         "prettier:write": "npm run prettier -- --write",
         "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
-        "test:ci": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage --maxWorkers=2",
-        "tsc": "tsc"
+        "test:ci": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage --maxWorkers=2"
     },
     "type": "module",
     "version": "3.0.0-alpha.0"

--- a/src/cli/runCli.test.ts
+++ b/src/cli/runCli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest } from "@jest/globals";
-import { EOL } from "os";
 import path from "node:path";
+import { EOL } from "os";
 import { fileURLToPath } from "url";
 
 import { createStubLogger, expectEqualWrites } from "../adapters/logger.stubs";

--- a/src/cli/runCli.test.ts
+++ b/src/cli/runCli.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 import { EOL } from "os";
+import path from "node:path";
+import { fileURLToPath } from "url";
 
 import { createStubLogger, expectEqualWrites } from "../adapters/logger.stubs";
 import { createStubOriginalConfigurationsData } from "../settings.stubs";
@@ -19,14 +21,23 @@ const createStubRunCliDependencies = (overrides: Partial<RunCliDependencies> = {
     logger: createStubLogger(),
 });
 
+Object.defineProperty(global, "__dirname", {
+    value: path.join(fileURLToPath(import.meta.url), ".."),
+    writable: true,
+});
+
+jest.mock("fs", () => ({
+    promises: {
+        readFile: async () => JSON.stringify(jest.requireActual("../../package.json")),
+    },
+}));
+
 describe("runCli", () => {
     it("prints the package version when --version is provided", async () => {
         // Arrange
         const rawArgv = createStubArgv(["--version"]);
         const dependencies = createStubRunCliDependencies();
-        const {
-            default: { version },
-        } = await import("../../package.json");
+        const { version } = jest.requireActual("../../package.json") as { version: string };
 
         // Act
         await runCli(dependencies, rawArgv);

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -3,10 +3,6 @@ import { Command } from "commander";
 import { promises as fs } from "fs";
 import { EOL } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 import { Logger } from "../adapters/logger";
 import { SansDependencies } from "../binding";

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
         "esModuleInterop": true,
         "incremental": true,
         "lib": [],
-        "module": "commonjs",
         "moduleResolution": "node",
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "alwaysStrict": true,
+        "declaration": true,
+        "esModuleInterop": true,
+        "incremental": true,
+        "lib": [],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "resolveJsonModule": true,
+        "sourceMap": true,
+        "strict": true,
+        "strictBindCallApply": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+        "strictPropertyInitialization": true,
+        "target": "es2018"
+    }
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.base.json",
+    "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "esModuleInterop": true,
         "incremental": true,
         "lib": [],
-        "module": "esnext",
+        "module": "commonjs",
         "moduleResolution": "node",
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,7 @@
 {
     "compilerOptions": {
-        "alwaysStrict": true,
-        "declaration": true,
-        "esModuleInterop": true,
-        "incremental": true,
-        "lib": [],
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "resolveJsonModule": true,
-        "sourceMap": true,
-        "strict": true,
-        "strictBindCallApply": true,
-        "strictFunctionTypes": true,
-        "strictNullChecks": true,
-        "strictPropertyInitialization": true,
-        "target": "es2018"
+        "composite": true
     },
-    "exclude": ["test/tests/**/*"],
-    "include": ["src/**/*"]
+    "files": [],
+    "references": [{ "path": "./tsconfig.source.json" }, { "path": "./tsconfig.test.json" }]
 }

--- a/tsconfig.source.json
+++ b/tsconfig.source.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "composite": true,
         "module": "commonjs"
     },
     "exclude": ["**/*.test.*"],

--- a/tsconfig.source.json
+++ b/tsconfig.source.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "module": "commonjs"
+    },
+    "exclude": ["**/*.test.*"],
+    "extends": "./tsconfig.base.json",
+    "include": ["src"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "module": "esnext",
+        "noEmit": true
+    },
+    "extends": "./tsconfig.base.json",
+    "include": ["**/*.test.*"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,8 +1,10 @@
 {
     "compilerOptions": {
+        "composite": true,
         "module": "esnext",
         "noEmit": true
     },
     "extends": "./tsconfig.base.json",
-    "include": ["**/*.test.*"]
+    "include": ["**/*.test.*"],
+    "references": [{ "path": "./tsconfig.source.json" }]
 }


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1398
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Creates a composite tsconfig setup so that source files are built with `"module": "commonjs"` and tests are built with `"module": "esnext"`. Added a nice little `"noEmit": true` for test files, too, since they don't need to be.