### PR TITLE
feat: Support `ordered-imports` option

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/ordered-imports.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/ordered-imports.ts
@@ -1,21 +1,125 @@
 import { RuleConverter } from "../ruleConverter";
 
-const unsupportedTSLintOptions = [
-    "import-sources-order",
-    "module-source-path",
-    "named-imports-order",
-];
-
 export const convertOrderedImports: RuleConverter = (tslintRule) => {
-    const notices = unsupportedTSLintOptions
-        .filter((option) => tslintRule.ruleArguments.includes(option))
-        .map((option) => `Option "${option}" is not supported by ESLint.`);
+    const argument = { ...tslintRule.ruleArguments[0] };
+    const notices: string[] = [];
+
+    const patternOptions = {
+        nocomment: true,
+        dot: true,
+    };
+
+    const importOrderRule = {
+        alphabetize: {
+            caseInsensitive: true,
+            order: "asc",
+        },
+        "newlines-between": "ignore",
+        groups: [
+            ["builtin", "external", "internal", "unknown", "object", "type"],
+            "parent",
+            ["sibling", "index"],
+        ],
+        pathGroupsNaturalNewlines: false,
+        pathGroupsExcludedImportTypes: [],
+        pathGroups: [
+            {
+                pattern: "./",
+                patternOptions,
+                group: "sibling",
+                position: "before",
+            },
+
+            {
+                pattern: ".",
+                patternOptions,
+                group: "sibling",
+                position: "before",
+            },
+            {
+                pattern: "..",
+                patternOptions,
+                group: "parent",
+                position: "before",
+            },
+            {
+                pattern: "../",
+                patternOptions,
+                group: "parent",
+                position: "before",
+            },
+        ],
+    };
+
+    switch (argument["import-sources-order"]) {
+        case "case-insensitive":
+        case "case-insensitive-legacy":
+            importOrderRule.alphabetize.caseInsensitive = true;
+            importOrderRule.alphabetize.order = "asc";
+            break;
+        case "lowercase-first":
+            importOrderRule.alphabetize.caseInsensitive = false;
+            importOrderRule.alphabetize.order = "asc";
+            importOrderRule.pathGroups = importOrderRule.pathGroups.concat([
+                {
+                    pattern: "[a-z]*",
+                    patternOptions,
+                    group: "external",
+                    position: "before",
+                },
+                {
+                    pattern: "../[a-z]*",
+                    patternOptions,
+                    group: "parent",
+                    position: "before",
+                },
+                {
+                    pattern: "./[a-z]*",
+                    patternOptions,
+                    group: "sibling",
+                    position: "before",
+                },
+            ]);
+            break;
+        case "lowercase-last":
+            importOrderRule.alphabetize.caseInsensitive = false;
+            importOrderRule.alphabetize.order = "asc";
+            break;
+        case "any":
+            importOrderRule.alphabetize.caseInsensitive = false;
+            importOrderRule.alphabetize.order = "ignore";
+            break;
+    }
+
+    if (argument["grouped-imports"] === true) {
+        importOrderRule["newlines-between"] = "always";
+        importOrderRule.pathGroupsNaturalNewlines = true;
+    }
+
+    if ("groups" in argument) {
+        notices.push(
+            "Option 'groups' is too bespoke to be converted to ESLint plugin 'eslint-plugin-import'",
+        );
+    }
+
+    if ("named-imports-order" in argument) {
+        notices.push(
+            "Option 'named-imports-order' is not supported by ESLint plugin 'eslint-plugin-import'",
+        );
+    }
+
+    if (argument["module-source-path"] === "basename") {
+        notices.push(
+            "Option 'module-source-path' with a value of 'basename' is not supported by ESLint plugin 'eslint-plugin-import'. The behavior will fallback to 'full'",
+        );
+    }
 
     return {
         plugins: ["eslint-plugin-import"],
         rules: [
             {
                 ...(notices.length !== 0 && { notices }),
+                ruleArguments: [importOrderRule],
                 ruleName: "import/order",
             },
         ],

--- a/src/converters/lintConfigs/rules/ruleConverters/ordered-imports.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/ordered-imports.ts
@@ -20,7 +20,7 @@ export const convertOrderedImports: RuleConverter = (tslintRule) => {
             "parent",
             ["sibling", "index"],
         ],
-        pathGroupsNaturalNewlines: false,
+        distinctGroup: false,
         pathGroupsExcludedImportTypes: [],
         pathGroups: [
             {
@@ -93,7 +93,6 @@ export const convertOrderedImports: RuleConverter = (tslintRule) => {
 
     if (argument["grouped-imports"] === true) {
         importOrderRule["newlines-between"] = "always";
-        importOrderRule.pathGroupsNaturalNewlines = true;
     }
 
     if ("groups" in argument) {

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ordered-imports.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ordered-imports.test.ts
@@ -12,47 +12,928 @@ describe("convertOrderedImports", () => {
             plugins: ["eslint-plugin-import"],
             rules: [
                 {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "ignore",
+                            alphabetize: {
+                                caseInsensitive: true,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: false,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
                     ruleName: "import/order",
                 },
             ],
         });
     });
 
-    test("conversion with allow-declarations argument", () => {
+    test("conversion with option import-sources-order as case-insensitive", () => {
         const result = convertOrderedImports({
-            ruleArguments: ["import-sources-order"],
+            ruleArguments: [
+                {
+                    "import-sources-order": "case-insensitive",
+                },
+            ],
         });
 
         expect(result).toEqual({
             plugins: ["eslint-plugin-import"],
             rules: [
                 {
-                    notices: ['Option "import-sources-order" is not supported by ESLint.'],
+                    ruleArguments: [
+                        {
+                            "newlines-between": "ignore",
+                            alphabetize: {
+                                caseInsensitive: true,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: false,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
                     ruleName: "import/order",
                 },
             ],
         });
     });
 
-    test("conversion with allow-declarations argument", () => {
+    test("conversion with option import-sources-order as case-insensitive-legacy", () => {
         const result = convertOrderedImports({
-            ruleArguments: ["named-imports-order"],
+            ruleArguments: [
+                {
+                    "import-sources-order": "case-insensitive-legacy",
+                },
+            ],
         });
 
         expect(result).toEqual({
             plugins: ["eslint-plugin-import"],
             rules: [
                 {
-                    notices: ['Option "named-imports-order" is not supported by ESLint.'],
+                    ruleArguments: [
+                        {
+                            "newlines-between": "ignore",
+                            alphabetize: {
+                                caseInsensitive: true,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: false,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
                     ruleName: "import/order",
                 },
             ],
         });
     });
 
-    test("conversion with unsupported arguments", () => {
+    test("conversion with option import-sources-order as lowercase-first", () => {
         const result = convertOrderedImports({
-            ruleArguments: ["import-sources-order", "named-imports-order", "module-source-path"],
+            ruleArguments: [{ "import-sources-order": "lowercase-first" }],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "ignore",
+                            alphabetize: {
+                                caseInsensitive: false,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: false,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "[a-z]*",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "external",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../[a-z]*",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "./[a-z]*",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("conversion with option import-sources-order as lowercase-last", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [{ "import-sources-order": "lowercase-last" }],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "ignore",
+                            alphabetize: {
+                                caseInsensitive: false,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: false,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("conversion with option import-sources-order as any", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [{ "import-sources-order": "any" }],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "ignore",
+                            alphabetize: {
+                                caseInsensitive: false,
+                                order: "ignore",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: false,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("conversion with option import-sources-order as case-insensitive (with grouped-imports)", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [
+                {
+                    "import-sources-order": "case-insensitive",
+                    "grouped-imports": true,
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "always",
+                            alphabetize: {
+                                caseInsensitive: true,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: true,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("conversion with option import-sources-order as case-insensitive-legacy (with grouped-imports)", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [
+                {
+                    "import-sources-order": "case-insensitive-legacy",
+                    "grouped-imports": true,
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "always",
+                            alphabetize: {
+                                caseInsensitive: true,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: true,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("conversion with option import-sources-order as lowercase-first (with grouped-imports)", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [
+                {
+                    "import-sources-order": "lowercase-first",
+                    "grouped-imports": true,
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "always",
+                            alphabetize: {
+                                caseInsensitive: false,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: true,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "[a-z]*",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "external",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../[a-z]*",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "./[a-z]*",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("conversion with option import-sources-order as lowercase-last (with grouped-imports)", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [
+                {
+                    "import-sources-order": "lowercase-last",
+                    "grouped-imports": true,
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "always",
+                            alphabetize: {
+                                caseInsensitive: false,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: true,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("conversion with option import-sources-order as any (with grouped-imports)", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [
+                {
+                    "import-sources-order": "any",
+                    "grouped-imports": true,
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "always",
+                            alphabetize: {
+                                caseInsensitive: false,
+                                order: "ignore",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: true,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("conversion with grouped-imports as true", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [
+                {
+                    "grouped-imports": true,
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    ruleArguments: [
+                        {
+                            "newlines-between": "always",
+                            alphabetize: {
+                                caseInsensitive: true,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: true,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("fails with option groups", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [
+                {
+                    groups: [],
+                },
+            ],
         });
 
         expect(result).toEqual({
@@ -60,9 +941,213 @@ describe("convertOrderedImports", () => {
             rules: [
                 {
                     notices: [
-                        'Option "import-sources-order" is not supported by ESLint.',
-                        'Option "module-source-path" is not supported by ESLint.',
-                        'Option "named-imports-order" is not supported by ESLint.',
+                        "Option 'groups' is too bespoke to be converted to ESLint plugin 'eslint-plugin-import'",
+                    ],
+                    ruleArguments: [
+                        {
+                            "newlines-between": "ignore",
+                            alphabetize: {
+                                caseInsensitive: true,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: false,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("fails with option named-imports-order", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [
+                {
+                    "named-imports-order": "any",
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    notices: [
+                        "Option 'named-imports-order' is not supported by ESLint plugin 'eslint-plugin-import'",
+                    ],
+                    ruleArguments: [
+                        {
+                            "newlines-between": "ignore",
+                            alphabetize: {
+                                caseInsensitive: true,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: false,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
+                    ],
+                    ruleName: "import/order",
+                },
+            ],
+        });
+    });
+
+    test("fails with option module-source-path as 'basename'", () => {
+        const result = convertOrderedImports({
+            ruleArguments: [
+                {
+                    "module-source-path": "basename",
+                },
+            ],
+        });
+
+        expect(result).toEqual({
+            plugins: ["eslint-plugin-import"],
+            rules: [
+                {
+                    notices: [
+                        "Option 'module-source-path' with a value of 'basename' is not supported by ESLint plugin 'eslint-plugin-import'. The behavior will fallback to 'full'",
+                    ],
+                    ruleArguments: [
+                        {
+                            "newlines-between": "ignore",
+                            alphabetize: {
+                                caseInsensitive: true,
+                                order: "asc",
+                            },
+                            groups: [
+                                ["builtin", "external", "internal", "unknown", "object", "type"],
+                                "parent",
+                                ["sibling", "index"],
+                            ],
+                            pathGroupsExcludedImportTypes: [],
+                            pathGroupsNaturalNewlines: false,
+                            pathGroups: [
+                                {
+                                    pattern: "./",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: ".",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "sibling",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "..",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                                {
+                                    pattern: "../",
+                                    patternOptions: {
+                                        nocomment: true,
+                                        dot: true,
+                                    },
+                                    group: "parent",
+                                    position: "before",
+                                },
+                            ],
+                        },
                     ],
                     ruleName: "import/order",
                 },

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ordered-imports.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ordered-imports.test.ts
@@ -25,7 +25,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: false,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -99,7 +99,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: false,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -173,7 +173,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: false,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -243,7 +243,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: false,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -339,7 +339,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: false,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -408,7 +408,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: false,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -482,7 +482,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: true,
+                            distinctGroup: true,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -557,7 +557,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: true,
+                            distinctGroup: true,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -632,7 +632,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: true,
+                            distinctGroup: true,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -733,7 +733,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: true,
+                            distinctGroup: true,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -807,7 +807,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: true,
+                            distinctGroup: true,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -880,7 +880,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: true,
+                            distinctGroup: true,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -956,7 +956,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: false,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -1032,7 +1032,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: false,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -1108,7 +1108,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            pathGroupsNaturalNewlines: false,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/ordered-imports.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/ordered-imports.test.ts
@@ -482,7 +482,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            distinctGroup: true,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -557,7 +557,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            distinctGroup: true,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -632,7 +632,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            distinctGroup: true,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -733,7 +733,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            distinctGroup: true,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -807,7 +807,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            distinctGroup: true,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",
@@ -880,7 +880,7 @@ describe("convertOrderedImports", () => {
                                 ["sibling", "index"],
                             ],
                             pathGroupsExcludedImportTypes: [],
-                            distinctGroup: true,
+                            distinctGroup: false,
                             pathGroups: [
                                 {
                                     pattern: "./",


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: Fixes #647
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Simply adds support for the `ordered-imports` option. This is a draft PR because the correct functionality depends on a [PR within `eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import/pull/2395)
