### PR TITLE
Remove node: imports

### DIFF
--- a/src/cli/runCli.test.ts
+++ b/src/cli/runCli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, jest } from "@jest/globals";
-import path from "node:path";
 import { EOL } from "os";
+import path from "path";
 import { fileURLToPath } from "url";
 
 import { createStubLogger, expectEqualWrites } from "../adapters/logger.stubs";

--- a/src/cli/runCli.ts
+++ b/src/cli/runCli.ts
@@ -1,8 +1,8 @@
 import chalk from "chalk";
 import { Command } from "commander";
 import { promises as fs } from "fs";
-import { EOL } from "node:os";
-import path from "node:path";
+import { EOL } from "os";
+import path from "path";
 
 import { Logger } from "../adapters/logger";
 import { SansDependencies } from "../binding";


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1404
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Replaces `node:*` with `*` imports. They're not supported in Node <16.
