### PR TITLE
fix: Set `root: true` by default

### DIFF
--- a/src/converters/lintConfigs/joinConfigConversionResults.test.ts
+++ b/src/converters/lintConfigs/joinConfigConversionResults.test.ts
@@ -42,6 +42,7 @@ describe("writeConversionResults", () => {
                 sourceType: "module",
             },
             plugins: ["@typescript-eslint"],
+            root: true,
         });
     });
 
@@ -77,6 +78,7 @@ describe("writeConversionResults", () => {
                 sourceType: "module",
             },
             plugins: ["eslint-plugin-example", "@typescript-eslint", "@typescript-eslint/tslint"],
+            root: true,
             rules: {
                 "@typescript-eslint/tslint/config": [
                     "error",
@@ -124,6 +126,7 @@ describe("writeConversionResults", () => {
                 sourceType: "module",
             },
             plugins: ["@typescript-eslint"],
+            root: true,
         });
     });
 
@@ -155,6 +158,7 @@ describe("writeConversionResults", () => {
                 sourceType: "module",
             },
             plugins: ["@typescript-eslint"],
+            root: true,
         });
     });
 
@@ -196,6 +200,7 @@ describe("writeConversionResults", () => {
                 sourceType: "module",
             },
             plugins: ["@typescript-eslint"],
+            root: true,
         });
     });
 });

--- a/src/converters/lintConfigs/joinConfigConversionResults.ts
+++ b/src/converters/lintConfigs/joinConfigConversionResults.ts
@@ -29,6 +29,7 @@ export const joinConfigConversionResults = (
             sourceType: "module",
         },
         plugins: Array.from(plugins),
+        root: true,
         rules: formatConvertedRules(summarizedResults, tslint.full),
     });
 };


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1465
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Simply sets the `root` to `true` by default. Alphabetization of keys is preserved