### PR TITLE
Properly use `ruleSeverity` properties of rule converters during conversion

### DIFF
--- a/src/converters/lintConfigs/rules/convertRules.test.ts
+++ b/src/converters/lintConfigs/rules/convertRules.test.ts
@@ -4,7 +4,7 @@ import { ConversionError } from "../../../errors/conversionError";
 import { convertRules } from "./convertRules";
 import { ConversionResult, RuleConverter } from "./ruleConverter";
 import { RuleMerger } from "./ruleMerger";
-import { TSLintRuleOptions, TSLintRuleSeverity } from "./types";
+import { ESLintRuleSeverity, TSLintRuleOptions, TSLintRuleSeverity } from "./types";
 
 describe("convertRules", () => {
     it("doesn't crash when passed an undefined configuration", () => {
@@ -347,6 +347,45 @@ describe("convertRules", () => {
                         ruleName: "eslint-rule-a",
                         ruleSeverity: "error",
                         notices: [],
+                    },
+                ],
+            ]),
+        ]).toContainEqual(converted);
+    });
+
+    it("merges when a rule's ruleSeverity explicitly differs from its TSLint equivalent", () => {
+        // Arrange
+        const conversionResult: {
+            rules: { ruleName: string; ruleSeverity: ESLintRuleSeverity }[];
+        } = {
+            rules: [
+                {
+                    ruleName: "eslint-rule-a",
+                    ruleSeverity: "off",
+                },
+            ],
+        };
+        const { tslintRule, converters, mergers } = setupConversionEnvironment({
+            ruleSeverity: "error",
+            conversionResult,
+            ruleToMerge: conversionResult.rules[0].ruleName,
+        });
+
+        // Act
+        const { converted } = convertRules(
+            { ruleConverters: converters, ruleMergers: mergers },
+            { [tslintRule.ruleName]: tslintRule },
+            new Map<string, string[]>(),
+        );
+
+        // Assert
+        expect([
+            new Map([
+                [
+                    "eslint-rule-a",
+                    {
+                        ruleName: "eslint-rule-a",
+                        ruleSeverity: "off",
                     },
                 ],
             ]),

--- a/src/converters/lintConfigs/rules/convertRules.test.ts
+++ b/src/converters/lintConfigs/rules/convertRules.test.ts
@@ -353,7 +353,7 @@ describe("convertRules", () => {
         ]).toContainEqual(converted);
     });
 
-    it("merges when a rule's ruleSeverity explicitly differs from its TSLint equivalent", () => {
+    it("merges when a rule severity differs from its TSLint equivalent", () => {
         // Arrange
         const rules: ConvertedRuleChanges[] = [
             {
@@ -382,6 +382,51 @@ describe("convertRules", () => {
                     {
                         ruleName: "eslint-rule-a",
                         ruleSeverity: "off",
+                    },
+                ],
+            ]),
+        ]).toContainEqual(converted);
+    });
+
+    it("merges when rule severities inconsistently differ from their TSLint equivalent", () => {
+        // Arrange
+        const rules: ConvertedRuleChanges[] = [
+            {
+                ruleName: "eslint-rule-a",
+                ruleSeverity: "off",
+            },
+            {
+                ruleName: "eslint-rule-b",
+            },
+        ];
+        const { tslintRule, converters, mergers } = setupConversionEnvironment({
+            ruleSeverity: "error",
+            conversionResult: { rules },
+            ruleToMerge: rules[0].ruleName,
+        });
+
+        // Act
+        const { converted } = convertRules(
+            { ruleConverters: converters, ruleMergers: mergers },
+            { [tslintRule.ruleName]: tslintRule },
+            new Map(),
+        );
+
+        // Assert
+        expect([
+            new Map([
+                [
+                    "eslint-rule-a",
+                    {
+                        ruleName: "eslint-rule-a",
+                        ruleSeverity: "off",
+                    },
+                ],
+                [
+                    "eslint-rule-b",
+                    {
+                        ruleName: "eslint-rule-b",
+                        ruleSeverity: "error",
                     },
                 ],
             ]),

--- a/src/converters/lintConfigs/rules/convertRules.test.ts
+++ b/src/converters/lintConfigs/rules/convertRules.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, test } from "@jest/globals";
 
 import { ConversionError } from "../../../errors/conversionError";
 import { convertRules } from "./convertRules";
-import { ConversionResult, RuleConverter } from "./ruleConverter";
+import { ConversionResult, ConvertedRuleChanges, RuleConverter } from "./ruleConverter";
 import { RuleMerger } from "./ruleMerger";
-import { ESLintRuleSeverity, TSLintRuleOptions, TSLintRuleSeverity } from "./types";
+import { TSLintRuleOptions, TSLintRuleSeverity } from "./types";
 
 describe("convertRules", () => {
     it("doesn't crash when passed an undefined configuration", () => {
@@ -355,27 +355,23 @@ describe("convertRules", () => {
 
     it("merges when a rule's ruleSeverity explicitly differs from its TSLint equivalent", () => {
         // Arrange
-        const conversionResult: {
-            rules: { ruleName: string; ruleSeverity: ESLintRuleSeverity }[];
-        } = {
-            rules: [
-                {
-                    ruleName: "eslint-rule-a",
-                    ruleSeverity: "off",
-                },
-            ],
-        };
+        const rules: ConvertedRuleChanges[] = [
+            {
+                ruleName: "eslint-rule-a",
+                ruleSeverity: "off",
+            },
+        ];
         const { tslintRule, converters, mergers } = setupConversionEnvironment({
             ruleSeverity: "error",
-            conversionResult,
-            ruleToMerge: conversionResult.rules[0].ruleName,
+            conversionResult: { rules },
+            ruleToMerge: rules[0].ruleName,
         });
 
         // Act
         const { converted } = convertRules(
             { ruleConverters: converters, ruleMergers: mergers },
             { [tslintRule.ruleName]: tslintRule },
-            new Map<string, string[]>(),
+            new Map(),
         );
 
         // Assert

--- a/src/converters/lintConfigs/rules/convertRules.ts
+++ b/src/converters/lintConfigs/rules/convertRules.ts
@@ -80,7 +80,8 @@ export const convertRules = (
                 const existingConversion = converted.get(changes.ruleName);
                 const newConversion = {
                     ...changes,
-                    ruleSeverity: convertTSLintRuleSeverity(tslintRule.ruleSeverity),
+                    ruleSeverity:
+                        changes.ruleSeverity || convertTSLintRuleSeverity(tslintRule.ruleSeverity),
                 };
 
                 // 4c. If this is the first time the output ESLint rule is seen, it's directly marked as converted.

--- a/src/converters/lintConfigs/rules/convertRules.ts
+++ b/src/converters/lintConfigs/rules/convertRules.ts
@@ -81,7 +81,7 @@ export const convertRules = (
                 const newConversion = {
                     ...changes,
                     ruleSeverity:
-                        changes.ruleSeverity || convertTSLintRuleSeverity(tslintRule.ruleSeverity),
+                        changes.ruleSeverity ?? convertTSLintRuleSeverity(tslintRule.ruleSeverity),
                 };
 
                 // 4c. If this is the first time the output ESLint rule is seen, it's directly marked as converted.


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1207
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

It seems that if `ruleSeverity` is specified within a rule of a converter, it is not properly applied when converting to the ESLint rules. The linked page mentions it specifically for `semicolon`, but it seems to be more general
 
For example, the following TSLint rules will both have a `ruleSeverity` of `error` since `true` is the first array element

```json
{
    "rules": {
        "semicolon": [true, "always"],
        "no-variable-usage-before-declaration": [true]
    }
}
```

This translates directly to the following ESLint, even though we do `{ ruleName: "semi", ruleSeverity: "off" }`, etc. in the converters

```json
{
    "rules": {
        "no-use-before-define": "error",
        "semi": "error"
    }
}
```

The patches fix this by setting the converted `ruleSeverity` with the explicitly specified `rule.ruleSeverity` if it is truthy

The following show the full resulting ESLint configs before and after the code changes (using the aforementioned TSLint config)

**Before:**

<details>
<summary>.eslintrc.json</summary>

```json
{
    "env": {
        "browser": true,
        "es6": true
    },
    "extends": [
        "prettier"
    ],
    "parser": "@typescript-eslint/parser",
    "parserOptions": {
        "project": "tsconfig.json",
        "sourceType": "module"
    },
    "plugins": [
        "@typescript-eslint"
    ],
    "root": true,
    "rules": {
        "@typescript-eslint/member-delimiter-style": [
            "error",
            {
                "multiline": {
                    "delimiter": "semi",
                    "requireLast": true
                },
                "singleline": {
                    "delimiter": "semi",
                    "requireLast": false
                }
            }
        ],
        "@typescript-eslint/no-use-before-define": [
            "error",
            {
                "variables": true
            }
        ],
        "@typescript-eslint/semi": [
            "error",
            "always"
        ],
        "no-use-before-define": "error",
        "semi": "error"
    }
}
```



</details>

**After:**

<details>
<summary>.eslintrc.json</summary>

```json
{
    "env": {
        "browser": true,
        "es6": true
    },
    "extends": [
        "prettier"
    ],
    "parser": "@typescript-eslint/parser",
    "parserOptions": {
        "project": "tsconfig.json",
        "sourceType": "module"
    },
    "plugins": [
        "@typescript-eslint"
    ],
    "root": true,
    "rules": {
        "@typescript-eslint/member-delimiter-style": [
            "error",
            {
                "multiline": {
                    "delimiter": "semi",
                    "requireLast": true
                },
                "singleline": {
                    "delimiter": "semi",
                    "requireLast": false
                }
            }
        ],
        "@typescript-eslint/no-use-before-define": [
            "error",
            {
                "variables": true
            }
        ],
        "@typescript-eslint/semi": [
            "error",
            "always"
        ],
        "no-use-before-define": "off",
        "semi": "off"
    }
}
```


</details>