### PR TITLE
fix: update converter to return PascalCase and snake_case format values for variable names

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/tests/variable-name.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/variable-name.test.ts
@@ -104,6 +104,38 @@ describe("convertVariableName", () => {
         });
     });
 
+    test("conversion with allow-pascal-case argument with check-format", () => {
+        const result = convertVariableName({
+            ruleArguments: ["allow-pascal-case", "check-format"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE", "PascalCase"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
+                },
+                {
+                    notices: [ForbiddenLeadingTrailingIdentifierMsg],
+                    ruleName: "no-underscore-dangle",
+                },
+                {
+                    ruleName: "id-denylist",
+                },
+                {
+                    ruleName: "id-match",
+                },
+            ],
+        });
+    });
+
     test("conversion with allow-snake-case argument without check-format argument", () => {
         const result = convertVariableName({
             ruleArguments: ["allow-snake-case"],
@@ -117,6 +149,38 @@ describe("convertVariableName", () => {
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
+                },
+                {
+                    notices: [ForbiddenLeadingTrailingIdentifierMsg],
+                    ruleName: "no-underscore-dangle",
+                },
+                {
+                    ruleName: "id-denylist",
+                },
+                {
+                    ruleName: "id-match",
+                },
+            ],
+        });
+    });
+
+    test("conversion with allow-snake-case argument with check-format", () => {
+        const result = convertVariableName({
+            ruleArguments: ["allow-snake-case", "check-format"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/naming-convention",
+                    rules: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE", "snake_case"],
                             leadingUnderscore: "forbid",
                             trailingUnderscore: "forbid",
                         },
@@ -388,7 +452,7 @@ describe("convertVariableName", () => {
                     rules: [
                         {
                             selector: "variable",
-                            format: ["camelCase", "UPPER_CASE"],
+                            format: ["camelCase", "UPPER_CASE", "PascalCase", "snake_case"],
                             leadingUnderscore: "allow",
                             trailingUnderscore: "allow",
                         },

--- a/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
@@ -49,14 +49,14 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
         if (!hasCheckFormat) {
             camelCaseRules.push({
                 selector: "variable",
-                format: ["camelCase", "UPPER_CASE"],
+                format: formats,
                 leadingUnderscore: "forbid",
                 trailingUnderscore: "forbid",
             });
         } else {
             camelCaseRules.push({
                 selector: "variable",
-                format: ["camelCase", "UPPER_CASE"],
+                format: formats,
                 leadingUnderscore: allowedLeadingUnderscore ? "allow" : "forbid",
                 trailingUnderscore: allowedTrailingUnderscore ? "allow" : "forbid",
             });


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes https://github.com/typescript-eslint/tslint-to-eslint-config/issues/1442
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

Updates the `variable-name` rule converter to return `PascalCase` and `snake_case` as formats if those are present in the rules to be converted. 
