### PR TITLE
fix(rule/variable-name): Use `ruleArguments` property

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/tests/variable-name.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/variable-name.test.ts
@@ -17,7 +17,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -49,7 +49,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -81,7 +81,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -113,7 +113,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE", "PascalCase"],
@@ -145,7 +145,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -177,7 +177,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE", "snake_case"],
@@ -209,7 +209,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -241,7 +241,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -273,7 +273,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -296,6 +296,49 @@ describe("convertVariableName", () => {
         });
     });
 
+    test("conversion with ban-keywords argument without check-format argument", () => {
+        const result = convertVariableName({
+            ruleArguments: ["ban-keywords"],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "@typescript-eslint/naming-convention",
+                    ruleArguments: [
+                        {
+                            selector: "variable",
+                            format: ["camelCase", "UPPER_CASE"],
+                            leadingUnderscore: "forbid",
+                            trailingUnderscore: "forbid",
+                        },
+                    ],
+                },
+                {
+                    ruleName: "no-underscore-dangle",
+                    notices: [ForbiddenLeadingTrailingIdentifierMsg],
+                },
+                {
+                    ruleName: "id-denylist",
+                    ruleArguments: [
+                        "any",
+                        "Number",
+                        "number",
+                        "String",
+                        "string",
+                        "Boolean",
+                        "boolean",
+                        "Undefined",
+                        "undefined",
+                    ],
+                },
+                {
+                    ruleName: "id-match",
+                },
+            ],
+        });
+    });
+
     test("conversion with require-const-for-all-caps argument and check-format argument", () => {
         const result = convertVariableName({
             ruleArguments: ["check-format", "require-const-for-all-caps"],
@@ -306,7 +349,7 @@ describe("convertVariableName", () => {
                 {
                     notices: [ConstRequiredForAllCapsMsg],
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -338,7 +381,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -371,7 +414,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -408,7 +451,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE"],
@@ -449,7 +492,7 @@ describe("convertVariableName", () => {
             rules: [
                 {
                     ruleName: "@typescript-eslint/naming-convention",
-                    rules: [
+                    ruleArguments: [
                         {
                             selector: "variable",
                             format: ["camelCase", "UPPER_CASE", "PascalCase", "snake_case"],

--- a/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/variable-name.ts
@@ -38,7 +38,6 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
         const camelCaseRules: Record<string, unknown>[] = [];
         const camelCaseOptionNotices: string[] = [];
         const formats = ["camelCase", "UPPER_CASE"];
-
         if (hasCheckFormat && allowPascalCase) {
             formats.push("PascalCase");
         }
@@ -68,7 +67,7 @@ export const convertVariableName: RuleConverter = (tslintRule) => {
 
         return {
             ...(camelCaseOptionNotices.length !== 0 && { notices: camelCaseOptionNotices }),
-            ...(camelCaseRules.length !== 0 && { rules: camelCaseRules }),
+            ...(camelCaseRules.length !== 0 && { ruleArguments: camelCaseRules }),
             ruleName: "@typescript-eslint/naming-convention",
         };
     };


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1225
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

Hello again! :smile: 

## Overview

As mentioned in the linked issue, one problem was that the arguments for `"@typescript-eslint/naming-convention"` weren't being passed to the ESLint rule properly, so it just said `"error"`. From my understanding, this caused problems since this would also include lint errors for function names, etc. too

It seems the fix was just a typo in the plugin. I also added a test specifically for `ban-keywords`, so it is a little more clear what is going on. This code generates the following ESLint file (for the same `tslint.json` file in the linked issue):

<details>
<summary>.eslintrc</summary>

```js
Hi! This file was autogenerated by tslint-to-eslint-config.
https://github.com/typescript-eslint/tslint-to-eslint-config

It represents the closest reasonable ESLint configuration to this
project's original TSLint configuration.

We recommend eventually switching this configuration to extend from
the recommended rulesets in typescript-eslint.
https://github.com/typescript-eslint/tslint-to-eslint-config/blob/master/docs/FAQs.md

Happy linting! M-pM-^_M-^RM-^V
*/
module.exports = {
    "env": {
        "browser": true,
        "es6": true
    },
    "extends": [
        "prettier"
    ],
    "parser": "@typescript-eslint/parser",
    "parserOptions": {
        "project": "tsconfig.json",
        "sourceType": "module"
    },
    "plugins": [
        "@typescript-eslint"
    ],
    "root": true,
    "rules": {
        "@typescript-eslint/naming-convention": [
            "error",
            {
                "selector": "variable",
                "format": [
                    "camelCase",
                    "UPPER_CASE"
                ],
                "leadingUnderscore": "forbid",
                "trailingUnderscore": "forbid"
            }
        ],
        "id-denylist": [
            "error",
            "any",
            "Number",
            "number",
            "String",
            "string",
            "Boolean",
            "boolean",
            "Undefined",
            "undefined"
        ],
        "id-match": "error",
        "no-underscore-dangle": "error"
    }
};
```

</details>

Also it was stated in the linked issue that the best thing would possibly be "only outputing the `id-denylist`" rule - this doesn't address that part specifically, but does fix the bug within the rule.


To make sure this issue doesn't exist for other plugins, maybe it might be a good idea to validate whatever a plugin returns against some schema, at least in testing? That way, a plugin won't accidentally set `rules` instead of `ruleArguments` without some alarms going off.

