### PR TITLE
docs: Fix 'accepting prs' GitHub link

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -2,7 +2,7 @@
 
 Thanks for looking at tslint-to-eslint-config!
 
-Any issue marked as [accepting prs](https://github.com/typescript-eslint/tslint-to-eslint-config/issues?q=is%3Aissue+is%3Aopen+label%3A%22accepting+prs%22) on the issue tracker is fair game to take on.
+Any issue marked as [accepting prs](https://github.com/typescript-eslint/tslint-to-eslint-config/issues?q=is%3Aissue+is%3Aopen+label%3A%22status:+accepting+prs%22) on the issue tracker is fair game to take on.
 
 Please do file issues if you find bugs or lacking features!
 


### PR DESCRIPTION
## Overview

This fixes a typo in the docs - it appears the accepting prs label has been changed to `status: accepting prs`