### PR TITLE
Improve JSON parse test assertion to work on recent Node versions

### DIFF
--- a/src/input/findReportedConfiguration.test.ts
+++ b/src/input/findReportedConfiguration.test.ts
@@ -37,10 +37,9 @@ describe("findReportedConfiguration", () => {
         const result = await findReportedConfiguration(exec, "command", "sample.json");
 
         // Assert
-        expect(result).toEqual(
-            new Error(
-                "Error parsing configuration: SyntaxError: Unexpected token i in JSON at position 0",
-            ),
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toMatch(
+            /Error parsing configuration: SyntaxError: Unexpected token '?i/,
         );
     });
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## Overview

I'm on Node `v19.0.0`, and it seems the JSON parser has been improved to be more descriptive. However, this causes a test to fail, since the `.message` property of the `SyntaxError` is slightly different. 

![image](https://user-images.githubusercontent.com/24364012/205217579-2e62208b-0114-4ef1-8f7f-891ae503f783.png)

This PR fixes that by matching `.message` with a Regex directly. I tried to use `[...].toContainEqual(result)`, but that didn't seem to work, so this fix seemed to be the next best alternative.


