### PR TITLE
fix: Do not show Errors from reading directories

### DIFF
--- a/src/adapters/fileSystem.stub.ts
+++ b/src/adapters/fileSystem.stub.ts
@@ -1,8 +1,9 @@
 import { FileSystem } from "../adapters/fileSystem";
 import { fn } from "../fn";
 
-export const createStubFileSystem = ({ data = {}, exists = true } = {}) => ({
+export const createStubFileSystem = ({ data = {}, exists = true, isDir = false } = {}) => ({
     fileExists: async () => exists,
+    directoryExists: async () => exists && isDir,
     readFile: async () => data,
     writeFile: fn<FileSystem["writeFile"]>(),
 });

--- a/src/adapters/fileSystem.ts
+++ b/src/adapters/fileSystem.ts
@@ -1,5 +1,6 @@
 export type FileSystem = {
     fileExists: (filePath: string) => Promise<boolean>;
-    readFile: (filePath: string) => Promise<Error | string>;
-    writeFile: (filePath: string, contents: string) => Promise<Error | undefined>;
+    directoryExists: (filePath: string) => Promise<boolean>;
+    readFile: (filePath: string) => Promise<NodeJS.ErrnoException | string>;
+    writeFile: (filePath: string, contents: string) => Promise<NodeJS.ErrnoException | undefined>;
 };

--- a/src/adapters/fsFileSystem.ts
+++ b/src/adapters/fsFileSystem.ts
@@ -11,6 +11,14 @@ export const fsFileSystem: FileSystem = {
             return false;
         }
     },
+    directoryExists: async (filePath: string) => {
+        try {
+            const stat = await fs.promises.stat(filePath);
+            return stat.isDirectory();
+        } catch (error) {
+            return false;
+        }
+    },
     readFile: async (filePath: string) => {
         try {
             return (await fs.promises.readFile(filePath)).toString();

--- a/src/api/dependencies.ts
+++ b/src/api/dependencies.ts
@@ -121,6 +121,7 @@ export const findOriginalConfigurationsDependencies: FindOriginalConfigurationsD
 
 export const collectCommentFileNamesDependencies: CollectCommentFileNamesDependencies = {
     findTypeScriptConfiguration: bind(findTypeScriptConfiguration, findConfigurationDependencies),
+    fileSystem: fsFileSystem,
 };
 
 export const extractGlobPathsDependencies: ExtractGlobPathsDependencies = {

--- a/src/comments/collectCommentFileNames.test.ts
+++ b/src/comments/collectCommentFileNames.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 
+import { createStubFileSystem } from "../adapters/fileSystem.stub";
+import { fsFileSystem as fileSystem } from "../adapters/fsFileSystem";
 import { collectCommentFileNames } from "./collectCommentFileNames";
 
 const stubFoundConfiguration = {
@@ -10,7 +12,10 @@ describe("collectCommentFileNames", () => {
     it("returns an error result when filePathGlobs is true and typescriptConfiguration is undefined", async () => {
         const findTypeScriptConfiguration = async () => stubFoundConfiguration;
 
-        const result = await collectCommentFileNames({ findTypeScriptConfiguration }, true);
+        const result = await collectCommentFileNames(
+            { findTypeScriptConfiguration, fileSystem },
+            true,
+        );
 
         expect(result).toEqual(expect.any(Error));
     });
@@ -22,7 +27,7 @@ describe("collectCommentFileNames", () => {
         };
 
         const result = await collectCommentFileNames(
-            { findTypeScriptConfiguration },
+            { findTypeScriptConfiguration, fileSystem },
             true,
             typescriptConfiguration,
         );
@@ -35,7 +40,7 @@ describe("collectCommentFileNames", () => {
         const filePathGlobs = ["a.ts"];
 
         const result = await collectCommentFileNames(
-            { findTypeScriptConfiguration },
+            { findTypeScriptConfiguration, fileSystem },
             filePathGlobs,
         );
 
@@ -51,7 +56,7 @@ describe("collectCommentFileNames", () => {
         const filePathGlobs = "a.ts";
 
         const result = await collectCommentFileNames(
-            { findTypeScriptConfiguration },
+            { findTypeScriptConfiguration, fileSystem },
             filePathGlobs,
         );
 
@@ -65,7 +70,7 @@ describe("collectCommentFileNames", () => {
         const findTypeScriptConfiguration = async () => error;
 
         const result = await collectCommentFileNames(
-            { findTypeScriptConfiguration },
+            { findTypeScriptConfiguration, fileSystem },
             "tsconfig.json",
         );
 
@@ -76,12 +81,30 @@ describe("collectCommentFileNames", () => {
         const findTypeScriptConfiguration = async () => stubFoundConfiguration;
 
         const result = await collectCommentFileNames(
-            { findTypeScriptConfiguration },
+            { findTypeScriptConfiguration, fileSystem },
             "tsconfig.json",
         );
 
         expect(result).toEqual({
             include: ["a.ts"],
+        });
+    });
+
+    it("returns only files when filePathGlobs includes directories", async () => {
+        const findTypeScriptConfiguration = async () => ({
+            include: ["directory"],
+        });
+
+        const result = await collectCommentFileNames(
+            {
+                findTypeScriptConfiguration,
+                fileSystem: createStubFileSystem({ isDir: true }),
+            },
+            "tsconfig.json",
+        );
+
+        expect(result).toEqual({
+            include: [],
         });
     });
 });

--- a/src/converters/comments/convertFileComments.test.ts
+++ b/src/converters/comments/convertFileComments.test.ts
@@ -6,7 +6,7 @@ import { createStubConverter } from "../lintConfigs/rules/ruleConverter.stubs";
 import { convertFileComments, ConvertFileCommentsDependencies } from "./convertFileComments";
 
 const createStubDependencies = (
-    readFileResult: Error | string,
+    readFileResult: NodeJS.ErrnoException | string,
 ): ConvertFileCommentsDependencies => ({
     converters: new Map([
         ["ts-a", createStubConverter(["es-a"])],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1720
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

If a `tsconfig.json` contains something like the following:

```ts
{
    "include": ["cool"]
}
```

Then, an error shows up, for example, when using `--comments`:

```text
✨ 143 rules replaced with their ESLint equivalents. ✨

⚡ 1 new package is required for this ESLint configuration. ⚡
  npm install eslint-config-prettier --save-dev
❌ 1 error running tslint-to-eslint: ❌
  Error: EISDIR: illegal operation on a directory, read
```

According to the [TypeScript docs](https://www.typescriptlang.org/tsconfig#include), a directory entry for `include` is valid:

> If the last path segment in a pattern does not contain a file extension or wildcard charater, then it is treated as a directory, and files with supported extensions inside that directory are included (e.g. .ts, .tsx, and .d.ts by default, with .js and .jsx if [allowJs](https://www.typescriptlang.org/tsconfig#allowJs) is set to true).

This fixes that case.