### PR TITLE
chore: Fix `@typescript-eslint/sort-type-constituents` errors

### DIFF
--- a/src/adapters/globAsync.ts
+++ b/src/adapters/globAsync.ts
@@ -1,7 +1,7 @@
 import glob from "glob";
 
 export const globAsync = async (pattern: string) => {
-    return new Promise<string[] | Error>((resolve) => {
+    return new Promise<Error | string[]>((resolve) => {
         glob(pattern, (error, matches) => {
             resolve(error ?? matches);
         });

--- a/src/comments/collectCommentFileNames.ts
+++ b/src/comments/collectCommentFileNames.ts
@@ -16,7 +16,7 @@ export type CommentFileNames = {
 
 export const collectCommentFileNames = async (
     dependencies: CollectCommentFileNamesDependencies,
-    filePathGlobs: true | string | string[],
+    filePathGlobs: string[] | string | true,
     typescriptConfiguration?: TypeScriptConfiguration,
 ): Promise<CommentFileNames | Error> => {
     if (filePathGlobs === true) {

--- a/src/converters/comments/convertFileComments.test.ts
+++ b/src/converters/comments/convertFileComments.test.ts
@@ -6,7 +6,7 @@ import { createStubConverter } from "../lintConfigs/rules/ruleConverter.stubs";
 import { convertFileComments, ConvertFileCommentsDependencies } from "./convertFileComments";
 
 const createStubDependencies = (
-    readFileResult: string | Error,
+    readFileResult: Error | string,
 ): ConvertFileCommentsDependencies => ({
     converters: new Map([
         ["ts-a", createStubConverter(["es-a"])],

--- a/src/converters/comments/parseFileComments.ts
+++ b/src/converters/comments/parseFileComments.ts
@@ -9,7 +9,7 @@ export type FileComment = {
     ruleNames: string[];
 };
 
-export type TSLintDirective = "tslint:disable" | "tslint:disable-next-line" | "tslint:enable";
+export type TSLintDirective = "tslint:disable-next-line" | "tslint:disable" | "tslint:enable";
 
 /**
  * @see https://github.com/Microsoft/TypeScript/issues/21049

--- a/src/converters/editorConfigs/converters/convertVSCodeConfig.ts
+++ b/src/converters/editorConfigs/converters/convertVSCodeConfig.ts
@@ -13,7 +13,7 @@ const knownMissingSettings = [
 ];
 
 export const convertVSCodeConfig: EditorConfigConverter = (rawEditorSettings, settings) => {
-    const editorSettings: Record<string, string | number | symbol> = parseJson(rawEditorSettings);
+    const editorSettings: Record<string, number | string | symbol> = parseJson(rawEditorSettings);
     const missing = knownMissingSettings.filter((setting) => editorSettings[setting]);
 
     const autoFixOnSave =

--- a/src/converters/lintConfigs/formatConvertedRules.ts
+++ b/src/converters/lintConfigs/formatConvertedRules.ts
@@ -7,7 +7,7 @@ export const formatConvertedRules = (
     conversionResults: RuleConversionResults,
     tslintConfiguration: TSLintConfiguration,
 ) => {
-    const output: Record<string, string | any[]> = {};
+    const output: Record<string, any[] | string> = {};
     const sortedRuleEntries = Array.from(conversionResults.converted).sort(
         ([ruleNameA], [ruleNameB]) => ruleNameA.localeCompare(ruleNameB),
     );

--- a/src/converters/lintConfigs/rules/ruleConverters/import-blacklist.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/import-blacklist.ts
@@ -8,10 +8,10 @@ type ESLintOptionPath = {
 };
 type ESLintSimpleOption = string[];
 type ESLintComplexOption = RequireAtLeastOne<{
-    paths: (string | ESLintOptionPath)[];
+    paths: (ESLintOptionPath | string)[];
     patterns: string[];
 }>;
-type ESLintOptions = ESLintSimpleOption | ESLintComplexOption;
+type ESLintOptions = ESLintComplexOption | ESLintSimpleOption;
 
 const NOTICE_MATCH_PATTERNS =
     "ESLint and TSLint use different strategies to match patterns. TSLint uses standard regular expressions, but ESLint .gitignore spec.";

--- a/src/converters/lintConfigs/rules/ruleConverters/trailing-comma.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/trailing-comma.ts
@@ -151,7 +151,7 @@ type TSLintArg = {
     esSpecCompliant?: boolean;
 };
 
-type TSLintArgValue = TSLintStringValue | TSLintObject;
+type TSLintArgValue = TSLintObject | TSLintStringValue;
 type TSLintObjectKey = keyof TSLintObject;
 
 type TSLintObject = {
@@ -166,8 +166,8 @@ type TSLintStringValue = "always" | "never";
 type TSLintStringValueForObject = TSLintStringValue | "ignore";
 
 // ESLint
-type ESLintArgValue = ESLintStringValue | ESLintObject;
-type ESLintStringValue = "never" | "always" | "always-multiline" | "only-multiline" | "ignore";
+type ESLintArgValue = ESLintObject | ESLintStringValue;
+type ESLintStringValue = "always-multiline" | "always" | "ignore" | "never" | "only-multiline";
 type ESLintObject = {
     arrays?: ESLintStringValue;
     objects?: ESLintStringValue;

--- a/src/converters/lintConfigs/rules/types.ts
+++ b/src/converters/lintConfigs/rules/types.ts
@@ -3,7 +3,7 @@
  *
  * @see https://palantir.github.io/tslint/usage/configuration
  */
-export type TSLintRuleSeverity = "warning" | "error" | "off";
+export type TSLintRuleSeverity = "error" | "off" | "warning";
 
 /**
  * Rich descriptor and options for an individual TSLint rule.
@@ -19,7 +19,7 @@ export type TSLintRuleOptions = {
  *
  * @see https://eslint.org/docs/user-guide/configuring#configuring-rules
  */
-export type ESLintRuleSeverity = "warn" | "error" | "off";
+export type ESLintRuleSeverity = "error" | "off" | "warn";
 
 /**
  * Permitted severities for an ESLint rule's configuration.

--- a/src/converters/lintConfigs/summarization/resolveExtensionNames.ts
+++ b/src/converters/lintConfigs/summarization/resolveExtensionNames.ts
@@ -1,4 +1,4 @@
-export const resolveExtensionNames = (rawExtensionNames: string | string[]) => {
+export const resolveExtensionNames = (rawExtensionNames: string[] | string) => {
     if (typeof rawExtensionNames === "string") {
         rawExtensionNames = [rawExtensionNames];
     }

--- a/src/converters/lintConfigs/summarization/retrieveExtendsValues.ts
+++ b/src/converters/lintConfigs/summarization/retrieveExtendsValues.ts
@@ -40,7 +40,7 @@ const pluginExtensions = new Map([
  */
 export const retrieveExtendsValues = async (
     dependencies: RetrieveExtendsValuesDependencies,
-    rawExtensionNames: string | string[],
+    rawExtensionNames: string[] | string,
 ): Promise<RetrievedExtensionValues> => {
     const importedExtensions: Partial<ESLintConfiguration>[] = [];
     const configurationErrors: ConfigurationError[] = [];

--- a/src/input/findESLintConfiguration.ts
+++ b/src/input/findESLintConfiguration.ts
@@ -10,7 +10,7 @@ import { importer } from "./importer";
 
 export type ESLintConfiguration = {
     env?: Record<string, boolean | undefined>;
-    extends?: string | string[];
+    extends?: string[] | string;
     globals?: Record<string, boolean | undefined>;
     rules?: ESLintConfigurationRules;
 };
@@ -35,7 +35,7 @@ export type FindESLintConfigurationDependencies = {
 export const findESLintConfiguration = async (
     dependencies: FindESLintConfigurationDependencies,
     config: Pick<ConfigurationLocations, "config" | "eslint">,
-): Promise<OriginalConfigurations<ESLintConfiguration> | Error> => {
+): Promise<Error | OriginalConfigurations<ESLintConfiguration>> => {
     const filePath = config.eslint ?? config.config;
     const [rawConfiguration, reportedConfiguration] = await Promise.all([
         findRawConfiguration<ESLintConfiguration>(dependencies.importer, filePath, {

--- a/src/input/findOriginalConfigurations.test.ts
+++ b/src/input/findOriginalConfigurations.test.ts
@@ -42,7 +42,7 @@ const createStubDependencies = (
         },
     }),
     mergeLintConfigurations: (
-        _: OriginalConfigurations<ESLintConfiguration> | Error,
+        _: Error | OriginalConfigurations<ESLintConfiguration>,
         tslint: OriginalConfigurations<TSLintConfiguration>,
     ) => tslint,
     ...overrides,

--- a/src/input/findPackagesConfiguration.ts
+++ b/src/input/findPackagesConfiguration.ts
@@ -11,7 +11,7 @@ export type PackagesConfiguration = {
 export const findPackagesConfiguration = async (
     dependencies: FindReportedConfigurationDependencies,
     config: string | undefined,
-): Promise<PackagesConfiguration | Error> => {
+): Promise<Error | PackagesConfiguration> => {
     const rawConfiguration = await findReportedConfiguration<PackagesConfiguration>(
         dependencies.exec,
         dependencies.platform === "win32" ? "type" : "cat",

--- a/src/input/findReportedConfiguration.ts
+++ b/src/input/findReportedConfiguration.ts
@@ -29,7 +29,7 @@ export const findReportedConfiguration = async <Configuration>(
     }
 };
 
-const execAndCatch = async (exec: Exec, fullCommand: string): Promise<string | Error> => {
+const execAndCatch = async (exec: Exec, fullCommand: string): Promise<Error | string> => {
     try {
         const { stderr, stdout } = await exec(fullCommand);
 

--- a/src/input/findTypeScriptConfiguration.ts
+++ b/src/input/findTypeScriptConfiguration.ts
@@ -22,7 +22,7 @@ const defaultTypeScriptConfiguration = {
 export const findTypeScriptConfiguration = async (
     dependencies: FindReportedConfigurationDependencies,
     config: string | undefined,
-): Promise<TypeScriptConfiguration | Error> => {
+): Promise<Error | TypeScriptConfiguration> => {
     const rawConfiguration = await findReportedConfiguration<TypeScriptConfiguration>(
         dependencies.exec,
         "tsc --showConfig -p",

--- a/src/input/importer.test.ts
+++ b/src/input/importer.test.ts
@@ -6,7 +6,7 @@ import { importer } from "./importer";
 const stubCwd = "/path/to/cwd";
 
 type StubImporterSettings = {
-    files?: Record<string, string | Error>;
+    files?: Record<string, Error | string>;
     modules?: Record<string, unknown>;
 };
 

--- a/src/input/mergeLintConfigurations.ts
+++ b/src/input/mergeLintConfigurations.ts
@@ -3,7 +3,7 @@ import { OriginalConfigurations } from "./findOriginalConfigurations";
 import { TSLintConfiguration } from "./findTSLintConfiguration";
 
 export const mergeLintConfigurations = (
-    eslint: OriginalConfigurations<ESLintConfiguration> | Error,
+    eslint: Error | OriginalConfigurations<ESLintConfiguration>,
     tslint: OriginalConfigurations<TSLintConfiguration>,
 ): OriginalConfigurations<TSLintConfiguration> => {
     if (eslint instanceof Error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type ConfigurationLocations = {
     /*
      * Original Editor configuration file path(s), such as `.vscode/settings.json`.
      */
-    editor?: string | string[];
+    editor?: string[] | string;
 
     /**
      * Original ESLint configuration file path, such as `.eslintrc.js`.
@@ -50,7 +50,7 @@ export type TSLintToESLintSettings = LintConfigConversionSettings & {
     /**
      * File globs to convert `tslint:disable` comments within to `eslint-disable`.
      */
-    comments?: true | string | string[];
+    comments?: string[] | string | true;
 
     /**
      * Original Editor configuration file path, such as `.vscode/settings.json`.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,9 +8,9 @@ export const asError = (error: unknown) => (error instanceof Error ? error : new
 
 export const isDefined = <Item>(item: Item | undefined): item is Item => item !== undefined;
 
-export const isError = <Item>(item: Item | Error): item is Error => item instanceof Error;
+export const isError = <Item>(item: Error | Item): item is Error => item instanceof Error;
 
-export const isTruthy = <Item>(item: Item | false | undefined | null | 0): item is Item => !!item;
+export const isTruthy = <Item>(item: Item | 0 | false | null | undefined): item is Item => !!item;
 
 export const removeEmptyMembers = <T extends Record<string, unknown>>(items: T): T => {
     const result = {} as T;
@@ -42,10 +42,10 @@ export const separateErrors = <Item>(mixed: (Error | Item)[]): [Error[], Item[]]
     return [errors, items];
 };
 
-export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
-    {
-        [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
-    }[Keys];
+export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = {
+    [K in Keys]-?: Partial<Pick<T, Exclude<Keys, K>>> & Required<Pick<T, K>>;
+}[Keys] &
+    Pick<T, Exclude<keyof T, Keys>>;
 
 export const uniqueFromSources = <T>(...sources: (T | T[] | undefined)[]) => {
     const items: T[] = [];


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [ ] Addresses an existing issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

When working on #1717 and #1716, I noticed that ESLint snagged on some unrelated code in CI (but not locally). This fixes the errors that show up in CI.

The environment difference seems to be related to the difference in package resolution. Locally, `rm -rf node_modules && pnpm i && pnpm run eslint` does not show the ESLint errors. However, `rm -rf node_modules && npm ci && pnpm run eslint` _does_.