### PR TITLE
fix(prefer-arrow-functions): Allow `allowStandaloneDeclarations` by default

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/only-arrow-functions.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/only-arrow-functions.ts
@@ -3,13 +3,9 @@ import { RuleConverter } from "../ruleConverter";
 export const convertOnlyArrowFunctions: RuleConverter = (tslintRule) => {
     const notices: string[] = [];
 
-    if (tslintRule.ruleArguments.includes("allow-declarations")) {
-        notices.push("ESLint does not support allowing standalone function declarations.");
-    }
-
     if (tslintRule.ruleArguments.includes("allow-named-functions")) {
         notices.push(
-            "ESLint does not support allowing named functions defined with the function keyword.",
+            "ESLint (eslint-plugin-prefer-arrow plugin) does not support allowing named functions defined with the function keyword.",
         );
     }
 
@@ -17,6 +13,13 @@ export const convertOnlyArrowFunctions: RuleConverter = (tslintRule) => {
         rules: [
             {
                 ...(notices.length !== 0 && { notices }),
+                ruleArguments: [
+                    {
+                        ...(tslintRule.ruleArguments.includes("allow-declarations") && {
+                            allowStandaloneDeclarations: true,
+                        }),
+                    },
+                ],
                 ruleName: "prefer-arrow/prefer-arrow-functions",
             },
         ],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/only-arrow-functions.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/only-arrow-functions.test.ts
@@ -12,6 +12,7 @@ describe("convertOnlyArrowFunctions", () => {
             plugins: ["eslint-plugin-prefer-arrow"],
             rules: [
                 {
+                    ruleArguments: [{}],
                     ruleName: "prefer-arrow/prefer-arrow-functions",
                 },
             ],
@@ -27,7 +28,11 @@ describe("convertOnlyArrowFunctions", () => {
             plugins: ["eslint-plugin-prefer-arrow"],
             rules: [
                 {
-                    notices: ["ESLint does not support allowing standalone function declarations."],
+                    ruleArguments: [
+                        {
+                            allowStandaloneDeclarations: true,
+                        },
+                    ],
                     ruleName: "prefer-arrow/prefer-arrow-functions",
                 },
             ],
@@ -44,8 +49,9 @@ describe("convertOnlyArrowFunctions", () => {
             rules: [
                 {
                     notices: [
-                        "ESLint does not support allowing named functions defined with the function keyword.",
+                        "ESLint (eslint-plugin-prefer-arrow plugin) does not support allowing named functions defined with the function keyword.",
                     ],
+                    ruleArguments: [{}],
                     ruleName: "prefer-arrow/prefer-arrow-functions",
                 },
             ],
@@ -62,8 +68,12 @@ describe("convertOnlyArrowFunctions", () => {
             rules: [
                 {
                     notices: [
-                        "ESLint does not support allowing standalone function declarations.",
-                        "ESLint does not support allowing named functions defined with the function keyword.",
+                        "ESLint (eslint-plugin-prefer-arrow plugin) does not support allowing named functions defined with the function keyword.",
+                    ],
+                    ruleArguments: [
+                        {
+                            allowStandaloneDeclarations: true,
+                        },
                     ],
                     ruleName: "prefer-arrow/prefer-arrow-functions",
                 },


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #838
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Change the default of `prefer-arrow/prefer-arrow-functions` so `allowStandaloneDeclarations` is enabled.