### PR TITLE
fix: Do not default-import 'glob' package

### DIFF
--- a/src/adapters/globAsync.ts
+++ b/src/adapters/globAsync.ts
@@ -1,4 +1,4 @@
-import glob from "glob";
+import { glob } from "glob";
 
 export const globAsync = async (pattern: string) => {
     return new Promise<Error | string[]>((resolve) => {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing issue: fixes #1817
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

Fixes the import. Closes #1817

As noted in the linked issue, this was caused by commit c2572c173d13c850fd35e761bb7ecdc239f4a913. Maybe a rennovate config of something like:

```json
{
  "packageRules": [
    {
      "matchUpdateTypes": ["major"],
      "enabled": false
    }
  ]
}
```

would have prevented this sort of error? I'm not as familiar with rennovate, but I noticed that [create-typescript-app's renovate.json](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/renovate.json) didn't have this configuration. I think this repository's config still has to be updated, to match that from create-typescript-app, so perhaps this question is moot.