### PR TITLE
fix: corrected tslint: one-line -> eslint: brace-style 

### DIFF
--- a/src/converters/lintConfigs/rules/ruleConverters/one-line.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/one-line.ts
@@ -8,7 +8,7 @@ export const convertOneLine: RuleConverter = (tslintRule) => {
         rules: [
             {
                 notices: ruleLen > 0 && ruleLen < 5 ? [CheckAllTokensMsg] : undefined,
-                ruleArguments: [ruleLen > 0 ? "1tbs" : "off"],
+                ruleArguments: ruleLen > 0 ? ["1tbs", { allowSingleLine: true }] : ["off"],
                 ruleName: "brace-style",
             },
         ],

--- a/src/converters/lintConfigs/rules/ruleConverters/tests/one-line.test.ts
+++ b/src/converters/lintConfigs/rules/ruleConverters/tests/one-line.test.ts
@@ -27,7 +27,7 @@ describe("convertOneLine", () => {
             rules: [
                 {
                     notices: [CheckAllTokensMsg],
-                    ruleArguments: ["1tbs"],
+                    ruleArguments: ["1tbs", { allowSingleLine: true }],
                     ruleName: "brace-style",
                 },
             ],
@@ -48,7 +48,7 @@ describe("convertOneLine", () => {
         expect(result).toEqual({
             rules: [
                 {
-                    ruleArguments: ["1tbs"],
+                    ruleArguments: ["1tbs", { allowSingleLine: true }],
                     ruleName: "brace-style",
                 },
             ],


### PR DESCRIPTION


<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #1226 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->

### Summary
sets `allowSingleLine: true` for the **one-line → brace-style** rule conversion.

### Details
ESLint’s `brace-style` is stricter than TSLint’s `one-line`, which doesn’t flag single-line blocks.  
This change aligns behavior by generating:

```json
"brace-style": ["error", "1tbs", { "allowSingleLine": true }]
```
 Changes
-  Updated conversion logic to include { allowSingleLine: true }

-  Modified corresponding test file (one-line.test.ts) to reflect the new output