### PR TITLE
feat: add converter for tslint-misc-rules/class-method-newlines → lines-between-class-members

### DIFF
--- a/src/rules/converters/tslint-misc-rules/class-method-newlines.test.ts
+++ b/src/rules/converters/tslint-misc-rules/class-method-newlines.test.ts
@@ -1,0 +1,29 @@
+import { convertClassMethodNewlines } from "./class-method-newlines";
+
+describe(convertClassMethodNewlines, () => {
+    test("conversion without arguments", () => {
+        const result = convertClassMethodNewlines({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "lines-between-class-members",
+                    ruleArguments: [
+                        "error",
+                        {
+                            enforce: [
+                                {
+                                    blankLine: "always",
+                                    prev: "method",
+                                    next: "method",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/src/rules/converters/tslint-misc-rules/class-method-newlines.ts
+++ b/src/rules/converters/tslint-misc-rules/class-method-newlines.ts
@@ -1,0 +1,23 @@
+import { RuleConverter } from "../../converter";
+
+export const convertClassMethodNewlines: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "lines-between-class-members",
+                ruleArguments: [
+                    "error",
+                    {
+                        enforce: [
+                            {
+                                blankLine: "always",
+                                prev: "method",
+                                next: "method",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+};


### PR DESCRIPTION
## Summary

This PR adds a missing converter for `class-method-newlines` from [`tslint-misc-rules`](https://github.com/jwbay/tslint-misc-rules), mapping it to ESLint's built-in `lines-between-class-members` rule.

**Fixes:** #1983
**Related to:** #1357

---

## Changes

- ✅ Added `src/rules/converters/tslint-misc-rules/class-method-newlines.ts` — converter logic
- ✅ Added `src/rules/converters/tslint-misc-rules/class-method-newlines.test.ts` — unit test

## Rule Mapping

| TSLint (`tslint-misc-rules`) | ESLint (built-in) |
|---|---|
| `"class-method-newlines": true` | `"lines-between-class-members": ["error", { "enforce": [{ "blankLine": "always", "prev": "method", "next": "method" }] }]` |

Both rules enforce that class methods are separated by blank lines, making this a near 1:1 behavioral mapping.

## Test

```ts
describe(convertClassMethodNewlines, () => {
    test("conversion without arguments", () => {
        // verifies the rule maps correctly to lines-between-class-members
    });
});
```

---

This is part of the larger effort in #1357 to add converters for all missing `tslint-misc-rules` rules. Happy to take on more rules from that list after this is reviewed! 🙌